### PR TITLE
Fix Monokai yellow

### DIFF
--- a/base16-monokai.dark.sh
+++ b/base16-monokai.dark.sh
@@ -10,7 +10,7 @@ fi
 color00="27/28/22" # Base 00 - Black
 color01="f9/26/72" # Base 08 - Red
 color02="a6/e2/2e" # Base 0B - Green
-color03="f4/bf/75" # Base 0A - Yellow
+color03="ff/e7/92" # Base 0A - Yellow
 color04="66/d9/ef" # Base 0D - Blue
 color05="ae/81/ff" # Base 0E - Magenta
 color06="a1/ef/e4" # Base 0C - Cyan

--- a/base16-monokai.light.sh
+++ b/base16-monokai.light.sh
@@ -10,7 +10,7 @@ fi
 color00="27/28/22" # Base 00 - Black
 color01="f9/26/72" # Base 08 - Red
 color02="a6/e2/2e" # Base 0B - Green
-color03="f4/bf/75" # Base 0A - Yellow
+color03="ff/e7/92" # Base 0A - Yellow
 color04="66/d9/ef" # Base 0D - Blue
 color05="ae/81/ff" # Base 0E - Magenta
 color06="a1/ef/e4" # Base 0C - Cyan


### PR DESCRIPTION
The yellow color was pretty far off from what I found in the actual
Monokai colorscheme. It was set to f4/bf/75, which is identical to
base16-default's yellow. I'm betting that this color was accidentally
missed when the Monokai version was created. In this commit I am
changing it to the yellow that I found in the Monokai colorscheme that
ships with Sublime Text 2.