### PR TITLE
Enabled reverse video on cursor colour

### DIFF
--- a/base16-3024.dark.sh
+++ b/base16-3024.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-3024.light.sh
+++ b/base16-3024.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-apathy.dark.sh
+++ b/base16-apathy.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-apathy.light.sh
+++ b/base16-apathy.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-ashes.dark.sh
+++ b/base16-ashes.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-ashes.light.sh
+++ b/base16-ashes.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-atelierdune.dark.sh
+++ b/base16-atelierdune.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-atelierdune.light.sh
+++ b/base16-atelierdune.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-atelierforest.dark.sh
+++ b/base16-atelierforest.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-atelierforest.light.sh
+++ b/base16-atelierforest.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-atelierheath.dark.sh
+++ b/base16-atelierheath.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-atelierheath.light.sh
+++ b/base16-atelierheath.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-atelierlakeside.dark.sh
+++ b/base16-atelierlakeside.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-atelierlakeside.light.sh
+++ b/base16-atelierlakeside.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-atelierseaside.dark.sh
+++ b/base16-atelierseaside.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-atelierseaside.light.sh
+++ b/base16-atelierseaside.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-bespin.dark.sh
+++ b/base16-bespin.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-bespin.light.sh
+++ b/base16-bespin.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-brewer.dark.sh
+++ b/base16-brewer.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-brewer.light.sh
+++ b/base16-brewer.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-bright.dark.sh
+++ b/base16-bright.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-bright.light.sh
+++ b/base16-bright.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-chalk.dark.sh
+++ b/base16-chalk.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-chalk.light.sh
+++ b/base16-chalk.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-codeschool.dark.sh
+++ b/base16-codeschool.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-codeschool.light.sh
+++ b/base16-codeschool.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-colors.dark.sh
+++ b/base16-colors.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-colors.light.sh
+++ b/base16-colors.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-default.dark.sh
+++ b/base16-default.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-default.light.sh
+++ b/base16-default.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-eighties.dark.sh
+++ b/base16-eighties.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-eighties.light.sh
+++ b/base16-eighties.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-embers.dark.sh
+++ b/base16-embers.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-embers.light.sh
+++ b/base16-embers.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-flat.dark.sh
+++ b/base16-flat.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-flat.light.sh
+++ b/base16-flat.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-google.dark.sh
+++ b/base16-google.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-google.light.sh
+++ b/base16-google.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-grayscale.dark.sh
+++ b/base16-grayscale.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-grayscale.light.sh
+++ b/base16-grayscale.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-greenscreen.dark.sh
+++ b/base16-greenscreen.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-greenscreen.light.sh
+++ b/base16-greenscreen.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-harmonic16.dark.sh
+++ b/base16-harmonic16.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-harmonic16.light.sh
+++ b/base16-harmonic16.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-isotope.dark.sh
+++ b/base16-isotope.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-isotope.light.sh
+++ b/base16-isotope.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-londontube.dark.sh
+++ b/base16-londontube.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-londontube.light.sh
+++ b/base16-londontube.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-marrakesh.dark.sh
+++ b/base16-marrakesh.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-marrakesh.light.sh
+++ b/base16-marrakesh.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-mocha.dark.sh
+++ b/base16-mocha.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-mocha.light.sh
+++ b/base16-mocha.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-monokai.dark.sh
+++ b/base16-monokai.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-monokai.light.sh
+++ b/base16-monokai.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-ocean.dark.sh
+++ b/base16-ocean.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-ocean.light.sh
+++ b/base16-ocean.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-paraiso.dark.sh
+++ b/base16-paraiso.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-paraiso.light.sh
+++ b/base16-paraiso.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-railscasts.dark.sh
+++ b/base16-railscasts.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-railscasts.light.sh
+++ b/base16-railscasts.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-shapeshifter.dark.sh
+++ b/base16-shapeshifter.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-shapeshifter.light.sh
+++ b/base16-shapeshifter.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-solarized.dark.sh
+++ b/base16-solarized.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-solarized.light.sh
+++ b/base16-solarized.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-summerfruit.dark.sh
+++ b/base16-summerfruit.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-summerfruit.light.sh
+++ b/base16-summerfruit.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-tomorrow.dark.sh
+++ b/base16-tomorrow.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-tomorrow.light.sh
+++ b/base16-tomorrow.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-twilight.dark.sh
+++ b/base16-twilight.dark.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up

--- a/base16-twilight.light.sh
+++ b/base16-twilight.light.sh
@@ -89,7 +89,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # text cursor color (reverse video)
 fi
 
 # clean up


### PR DESCRIPTION
Due to cursor colour and foreground colour being the same, the text would normally be obscured by the cursor. This should ensure it doesn't happen.

This has already been enabled in [base16-builder](https://github.com/chriskempson/base16-builder) through [this](https://github.com/chriskempson/base16-builder/pull/218) pull request but hasn't propagated to this repository.