### PR TITLE
README: Load base16 only on interactive fish sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ In `~/.bashrc` or `~/.zshrc` place the following lines:
 In `config.fish` place the following lines:
 
     # Base16 Shell
-    eval sh $HOME/.config/base16-shell/base16-default.dark.sh
+    if status --is-interactive
+        eval sh $HOME/.config/base16-shell/base16-default.dark.sh
+    end
 
 ## Troubleshooting
 Run the included **colortest** script and check that your colour assignments appear correct. If your teminal does not support the setting of colours in within the 256 colorspace (e.g. Apple Terminal), colours 17 to 21 will appear blue.


### PR DESCRIPTION
Currently, the `config.fish` example in `README` makes base16-shell load even on non-interactive session. That's not desirable as it will cause corruption of `stdout` when `fish` is spawned by eg. some script. Therefore, I've added a conditional which checks if fish is spawned as an interactive shell.