### PR TITLE
Allow colortest to be called from outside the base16 directory

### DIFF
--- a/colortest
+++ b/colortest
@@ -1,5 +1,5 @@
 #!/bin/bash
-theme=${1:-base16-default.dark.sh}
+theme=$(dirname $0)/${1:-base16-default.dark.sh}
 if [ -f $theme ]; then
   # get the color declarations in said theme, assumes there is a block of text that starts with color00= and ends with new line
   eval $(awk '/^color00=/,/^$/ {print}' $theme | sed 's/#.*//')


### PR DESCRIPTION
I've created a wrapper `colortest` command that is in my `$PATH` that calls this `colortest` file. This change allows that to happens whilst still allowing the file to be executed via `./colortest`