### PR TITLE
Do not include bell when passing escape sequences through to terminal

### DIFF
--- a/base16-3024.dark.sh
+++ b/base16-3024.dark.sh
@@ -36,14 +36,14 @@ color_cursor="a5/a2/a2" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-3024.light.sh
+++ b/base16-3024.light.sh
@@ -36,14 +36,14 @@ color_cursor="4a/45/43" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-apathy.dark.sh
+++ b/base16-apathy.dark.sh
@@ -36,14 +36,14 @@ color_cursor="81/B5/AC" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-apathy.light.sh
+++ b/base16-apathy.light.sh
@@ -36,14 +36,14 @@ color_cursor="18/4E/45" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-ashes.dark.sh
+++ b/base16-ashes.dark.sh
@@ -36,14 +36,14 @@ color_cursor="C7/CC/D1" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-ashes.light.sh
+++ b/base16-ashes.light.sh
@@ -36,14 +36,14 @@ color_cursor="56/5E/65" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-atelierdune.dark.sh
+++ b/base16-atelierdune.dark.sh
@@ -36,14 +36,14 @@ color_cursor="a6/a2/8c" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-atelierdune.light.sh
+++ b/base16-atelierdune.light.sh
@@ -36,14 +36,14 @@ color_cursor="6e/6b/5e" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-atelierforest.dark.sh
+++ b/base16-atelierforest.dark.sh
@@ -36,14 +36,14 @@ color_cursor="a8/a1/9f" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-atelierforest.light.sh
+++ b/base16-atelierforest.light.sh
@@ -36,14 +36,14 @@ color_cursor="68/61/5e" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-atelierheath.dark.sh
+++ b/base16-atelierheath.dark.sh
@@ -36,14 +36,14 @@ color_cursor="ab/9b/ab" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-atelierheath.light.sh
+++ b/base16-atelierheath.light.sh
@@ -36,14 +36,14 @@ color_cursor="69/5d/69" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-atelierlakeside.dark.sh
+++ b/base16-atelierlakeside.dark.sh
@@ -36,14 +36,14 @@ color_cursor="7e/a2/b4" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-atelierlakeside.light.sh
+++ b/base16-atelierlakeside.light.sh
@@ -36,14 +36,14 @@ color_cursor="51/6d/7b" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-atelierseaside.dark.sh
+++ b/base16-atelierseaside.dark.sh
@@ -36,14 +36,14 @@ color_cursor="8c/a6/8c" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-atelierseaside.light.sh
+++ b/base16-atelierseaside.light.sh
@@ -36,14 +36,14 @@ color_cursor="5e/6e/5e" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-bespin.dark.sh
+++ b/base16-bespin.dark.sh
@@ -36,14 +36,14 @@ color_cursor="8a/89/86" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-bespin.light.sh
+++ b/base16-bespin.light.sh
@@ -36,14 +36,14 @@ color_cursor="5e/5d/5c" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-brewer.dark.sh
+++ b/base16-brewer.dark.sh
@@ -36,14 +36,14 @@ color_cursor="b7/b8/b9" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-brewer.light.sh
+++ b/base16-brewer.light.sh
@@ -36,14 +36,14 @@ color_cursor="51/52/53" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-bright.dark.sh
+++ b/base16-bright.dark.sh
@@ -36,14 +36,14 @@ color_cursor="e0/e0/e0" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-bright.light.sh
+++ b/base16-bright.light.sh
@@ -36,14 +36,14 @@ color_cursor="50/50/50" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-chalk.dark.sh
+++ b/base16-chalk.dark.sh
@@ -36,14 +36,14 @@ color_cursor="d0/d0/d0" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-chalk.light.sh
+++ b/base16-chalk.light.sh
@@ -36,14 +36,14 @@ color_cursor="30/30/30" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-codeschool.dark.sh
+++ b/base16-codeschool.dark.sh
@@ -36,14 +36,14 @@ color_cursor="9e/a7/a6" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-codeschool.light.sh
+++ b/base16-codeschool.light.sh
@@ -36,14 +36,14 @@ color_cursor="2a/34/3a" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-colors.dark.sh
+++ b/base16-colors.dark.sh
@@ -36,14 +36,14 @@ color_cursor="bb/bb/bb" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-colors.light.sh
+++ b/base16-colors.light.sh
@@ -36,14 +36,14 @@ color_cursor="55/55/55" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-default.dark.sh
+++ b/base16-default.dark.sh
@@ -36,14 +36,14 @@ color_cursor="d8/d8/d8" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-default.light.sh
+++ b/base16-default.light.sh
@@ -36,14 +36,14 @@ color_cursor="38/38/38" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-eighties.dark.sh
+++ b/base16-eighties.dark.sh
@@ -36,14 +36,14 @@ color_cursor="d3/d0/c8" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-eighties.light.sh
+++ b/base16-eighties.light.sh
@@ -36,14 +36,14 @@ color_cursor="51/51/51" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-embers.dark.sh
+++ b/base16-embers.dark.sh
@@ -36,14 +36,14 @@ color_cursor="A3/9A/90" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-embers.light.sh
+++ b/base16-embers.light.sh
@@ -36,14 +36,14 @@ color_cursor="43/3B/32" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-flat.dark.sh
+++ b/base16-flat.dark.sh
@@ -36,14 +36,14 @@ color_cursor="e0/e0/e0" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-flat.light.sh
+++ b/base16-flat.light.sh
@@ -36,14 +36,14 @@ color_cursor="7F/8C/8D" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-google.dark.sh
+++ b/base16-google.dark.sh
@@ -36,14 +36,14 @@ color_cursor="c5/c8/c6" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-google.light.sh
+++ b/base16-google.light.sh
@@ -36,14 +36,14 @@ color_cursor="37/3b/41" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-grayscale.dark.sh
+++ b/base16-grayscale.dark.sh
@@ -36,14 +36,14 @@ color_cursor="b9/b9/b9" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-grayscale.light.sh
+++ b/base16-grayscale.light.sh
@@ -36,14 +36,14 @@ color_cursor="46/46/46" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-greenscreen.dark.sh
+++ b/base16-greenscreen.dark.sh
@@ -36,14 +36,14 @@ color_cursor="00/bb/00" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-greenscreen.light.sh
+++ b/base16-greenscreen.light.sh
@@ -36,14 +36,14 @@ color_cursor="00/55/00" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-harmonic16.dark.sh
+++ b/base16-harmonic16.dark.sh
@@ -36,14 +36,14 @@ color_cursor="cb/d6/e2" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-harmonic16.light.sh
+++ b/base16-harmonic16.light.sh
@@ -36,14 +36,14 @@ color_cursor="40/5c/79" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-isotope.dark.sh
+++ b/base16-isotope.dark.sh
@@ -36,14 +36,14 @@ color_cursor="d0/d0/d0" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-isotope.light.sh
+++ b/base16-isotope.light.sh
@@ -36,14 +36,14 @@ color_cursor="60/60/60" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-londontube.dark.sh
+++ b/base16-londontube.dark.sh
@@ -36,14 +36,14 @@ color_cursor="d9/d8/d8" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-londontube.light.sh
+++ b/base16-londontube.light.sh
@@ -36,14 +36,14 @@ color_cursor="5a/57/58" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-marrakesh.dark.sh
+++ b/base16-marrakesh.dark.sh
@@ -36,14 +36,14 @@ color_cursor="94/8e/48" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-marrakesh.light.sh
+++ b/base16-marrakesh.light.sh
@@ -36,14 +36,14 @@ color_cursor="5f/5b/17" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-mocha.dark.sh
+++ b/base16-mocha.dark.sh
@@ -36,14 +36,14 @@ color_cursor="d0/c8/c6" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-mocha.light.sh
+++ b/base16-mocha.light.sh
@@ -36,14 +36,14 @@ color_cursor="64/52/40" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-monokai.dark.sh
+++ b/base16-monokai.dark.sh
@@ -36,14 +36,14 @@ color_cursor="f8/f8/f2" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-monokai.light.sh
+++ b/base16-monokai.light.sh
@@ -36,14 +36,14 @@ color_cursor="49/48/3e" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-ocean.dark.sh
+++ b/base16-ocean.dark.sh
@@ -36,14 +36,14 @@ color_cursor="c0/c5/ce" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-ocean.light.sh
+++ b/base16-ocean.light.sh
@@ -36,14 +36,14 @@ color_cursor="4f/5b/66" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-paraiso.dark.sh
+++ b/base16-paraiso.dark.sh
@@ -36,14 +36,14 @@ color_cursor="a3/9e/9b" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-paraiso.light.sh
+++ b/base16-paraiso.light.sh
@@ -36,14 +36,14 @@ color_cursor="4f/42/4c" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-railscasts.dark.sh
+++ b/base16-railscasts.dark.sh
@@ -36,14 +36,14 @@ color_cursor="e6/e1/dc" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-railscasts.light.sh
+++ b/base16-railscasts.light.sh
@@ -36,14 +36,14 @@ color_cursor="3a/40/55" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-shapeshifter.dark.sh
+++ b/base16-shapeshifter.dark.sh
@@ -36,14 +36,14 @@ color_cursor="ab/ab/ab" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-shapeshifter.light.sh
+++ b/base16-shapeshifter.light.sh
@@ -36,14 +36,14 @@ color_cursor="10/20/15" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-solarized.dark.sh
+++ b/base16-solarized.dark.sh
@@ -36,14 +36,14 @@ color_cursor="93/a1/a1" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-solarized.light.sh
+++ b/base16-solarized.light.sh
@@ -36,14 +36,14 @@ color_cursor="58/6e/75" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-summerfruit.dark.sh
+++ b/base16-summerfruit.dark.sh
@@ -36,14 +36,14 @@ color_cursor="D0/D0/D0" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-summerfruit.light.sh
+++ b/base16-summerfruit.light.sh
@@ -36,14 +36,14 @@ color_cursor="30/30/30" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-tomorrow.dark.sh
+++ b/base16-tomorrow.dark.sh
@@ -36,14 +36,14 @@ color_cursor="c5/c8/c6" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-tomorrow.light.sh
+++ b/base16-tomorrow.light.sh
@@ -36,14 +36,14 @@ color_cursor="37/3b/41" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-twilight.dark.sh
+++ b/base16-twilight.dark.sh
@@ -36,14 +36,14 @@ color_cursor="a7/a7/a7" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"

--- a/base16-twilight.light.sh
+++ b/base16-twilight.light.sh
@@ -36,14 +36,14 @@ color_cursor="46/4b/50" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033Ptmux;\033\033]%s%s\033\\"
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
+  printf_template="\033P\033]4;%d;rgb:%s\033\\"
+  printf_template_var="\033P\033]%d;rgb:%s\033\\"
+  printf_template_custom="\033P\033]%s%s\033\\"
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"


### PR DESCRIPTION
Originally reported in #24 .  I know next to nothing about shell programming, but it seems like \007 is the ascii bell character and shouldn't be needed here.