### PR TITLE
Update to clobber .vimrc_background

### DIFF
--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -21,7 +21,7 @@ _base16()
   [ -f $script ] && . $script
   ln -fs $script ~/.base16_theme
   export BASE16_THEME=${theme}
-  echo "colorscheme base16-$theme" > ~/.vimrc_background
+  echo "colorscheme base16-$theme" >! ~/.vimrc_background
 }
 FUNC
 for script in $script_dir/scripts/base16*.sh; do


### PR DESCRIPTION
Currently outputs error when shell set to noclobber.