### PR TITLE
Only set colorscheme in .vimrc_background if necessary

### DIFF
--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -21,7 +21,7 @@ _base16()
   [ -f $script ] && . $script
   ln -fs $script ~/.base16_theme
   export BASE16_THEME=${theme}
-  echo "colorscheme base16-$theme" > ~/.vimrc_background
+  echo "if !exists('g:colors_name') || g:colors_name != 'base16-$theme'\n  colorscheme base16-$theme\nendif" > ~/.vimrc_background
 }
 FUNC
 for script in $script_dir/scripts/base16*.sh; do


### PR DESCRIPTION
I'm a sucker for automation, so I want to add a `source ~/.vimrc_background` to a FocusGained autocommand in vim. However setting the colorscheme unnecessarily causes vim to redraw, which is annoying. I've added a check to see that either a) there hasn't been a colorscheme loaded yet and b) the colorscheme is different that the current before calling `colorscheme`.