### PR TITLE
force clobbering when creating .vimrc_background

### DIFF
--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -21,7 +21,7 @@ _base16()
   [ -f $script ] && . $script
   ln -fs $script ~/.base16_theme
   export BASE16_THEME=${theme}
-  echo -e "if \0041exists('g:colors_name') || g:colors_name != 'base16-$theme'\n  colorscheme base16-$theme\nendif" > ~/.vimrc_background
+  echo -e "if \0041exists('g:colors_name') || g:colors_name != 'base16-$theme'\n  colorscheme base16-$theme\nendif" >| ~/.vimrc_background
 }
 FUNC
 for script in $script_dir/scripts/base16*.sh; do


### PR DESCRIPTION
Many popular zsh plugin management system set default to noclobber to prevent accidental file overwrites, but this cause problem when creating `.vimrc_background`

e.g.

```
% base16_tomorrow-night
_base16:7: file exists: /Users/gogao/.vimrc_background
```

This PR used force clobbering redirect operator `>|` to replace the normal `>`
`>|` is supported by both zsh and bash.
http://zsh.sourceforge.net/Doc/Release/Redirection.html
https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Redirections  (Section 3.6.2)
