### PR TITLE
Added option for ignoring background color

### DIFF
--- a/scripts/base16-3024.sh
+++ b/scripts/base16-3024.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 090300 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-apathy.sh
+++ b/scripts/base16-apathy.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 031A16 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-ashes.sh
+++ b/scripts/base16-ashes.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 1C2023 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-cave-light.sh
+++ b/scripts/base16-atelier-cave-light.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# Harmonic16 Light scheme by Jannik Siebert (https://github.com/janniks)
+# Atelier Cave scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="f7/f9/fb" # Base 00 - Black
-color01="bf/8b/56" # Base 08 - Red
-color02="56/bf/8b" # Base 0B - Green
-color03="8b/bf/56" # Base 0A - Yellow
-color04="8b/56/bf" # Base 0D - Blue
-color05="bf/56/8b" # Base 0E - Magenta
-color06="56/8b/bf" # Base 0C - Cyan
-color07="40/5c/79" # Base 05 - White
-color08="aa/bc/ce" # Base 03 - Bright Black
+color00="ef/ec/f4" # Base 00 - Black
+color01="be/46/78" # Base 08 - Red
+color02="2a/92/92" # Base 0B - Green
+color03="a0/6e/3b" # Base 0A - Yellow
+color04="57/6d/db" # Base 0D - Blue
+color05="95/5a/e7" # Base 0E - Magenta
+color06="39/8b/c6" # Base 0C - Cyan
+color07="58/52/60" # Base 05 - White
+color08="7e/78/87" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="0b/1c/2c" # Base 07 - Bright White
-color16="bf/bf/56" # Base 09
-color17="bf/56/56" # Base 0F
-color18="e5/eb/f1" # Base 01
-color19="cb/d6/e2" # Base 02
-color20="62/7e/99" # Base 04
-color21="22/3b/54" # Base 06
-color_foreground="40/5c/79" # Base 05
-color_background="f7/f9/fb" # Base 00
-color_cursor="40/5c/79" # Base 05
+color15="19/17/1c" # Base 07 - Bright White
+color16="aa/57/3c" # Base 09
+color17="bf/40/bf" # Base 0F
+color18="e2/df/e7" # Base 01
+color19="8b/87/92" # Base 02
+color20="65/5f/6d" # Base 04
+color21="26/23/2a" # Base 06
+color_foreground="58/52/60" # Base 05
+color_background="ef/ec/f4" # Base 00
+color_cursor="58/52/60" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,16 +80,18 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg 405c79 # forground
-  printf $printf_template_custom Ph f7f9fb # background
-  printf $printf_template_custom Pi 405c79 # bold color
-  printf $printf_template_custom Pj cbd6e2 # selection color
-  printf $printf_template_custom Pk 405c79 # selected text color
-  printf $printf_template_custom Pl 405c79 # cursor
-  printf $printf_template_custom Pm f7f9fb # cursor text
+  printf $printf_template_custom Pg 585260 # forground
+  printf $printf_template_custom Ph efecf4 # background
+  printf $printf_template_custom Pi 585260 # bold color
+  printf $printf_template_custom Pj 8b8792 # selection color
+  printf $printf_template_custom Pk 585260 # selected text color
+  printf $printf_template_custom Pl 585260 # cursor
+  printf $printf_template_custom Pm efecf4 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-cave.sh
+++ b/scripts/base16-atelier-cave.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 19171c # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-dune-light.sh
+++ b/scripts/base16-atelier-dune-light.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Atelier Dune scheme by Bram de Haan (http://atelierbramdehaan.nl)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="fe/fb/ec" # Base 00 - Black
+color01="d7/37/37" # Base 08 - Red
+color02="60/ac/39" # Base 0B - Green
+color03="ae/95/13" # Base 0A - Yellow
+color04="66/84/e1" # Base 0D - Blue
+color05="b8/54/d4" # Base 0E - Magenta
+color06="1f/ad/83" # Base 0C - Cyan
+color07="6e/6b/5e" # Base 05 - White
+color08="99/95/80" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="20/20/1d" # Base 07 - Bright White
+color16="b6/56/11" # Base 09
+color17="d4/35/52" # Base 0F
+color18="e8/e4/cf" # Base 01
+color19="a6/a2/8c" # Base 02
+color20="7d/7a/68" # Base 04
+color21="29/28/24" # Base 06
+color_foreground="6e/6b/5e" # Base 05
+color_background="fe/fb/ec" # Base 00
+color_cursor="6e/6b/5e" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg 6e6b5e # forground
+  printf $printf_template_custom Ph fefbec # background
+  printf $printf_template_custom Pi 6e6b5e # bold color
+  printf $printf_template_custom Pj a6a28c # selection color
+  printf $printf_template_custom Pk 6e6b5e # selected text color
+  printf $printf_template_custom Pl 6e6b5e # cursor
+  printf $printf_template_custom Pm fefbec # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-atelier-dune.sh
+++ b/scripts/base16-atelier-dune.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 20201d # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-estuary-light.sh
+++ b/scripts/base16-atelier-estuary-light.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# London Tube scheme by Jan T. Sott
+# Atelier Estuary scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="23/1f/20" # Base 00 - Black
-color01="ee/2e/24" # Base 08 - Red
-color02="00/85/3e" # Base 0B - Green
-color03="ff/d2/04" # Base 0A - Yellow
-color04="00/9d/dc" # Base 0D - Blue
-color05="98/00/5d" # Base 0E - Magenta
-color06="85/ce/bc" # Base 0C - Cyan
-color07="d9/d8/d8" # Base 05 - White
-color08="73/71/71" # Base 03 - Bright Black
+color00="f4/f3/ec" # Base 00 - Black
+color01="ba/62/36" # Base 08 - Red
+color02="7d/97/26" # Base 0B - Green
+color03="a5/98/0d" # Base 0A - Yellow
+color04="36/a1/66" # Base 0D - Blue
+color05="5f/91/82" # Base 0E - Magenta
+color06="5b/9d/48" # Base 0C - Cyan
+color07="5f/5e/4e" # Base 05 - White
+color08="87/85/73" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="f3/86/a1" # Base 09
-color17="b0/61/10" # Base 0F
-color18="1c/3f/95" # Base 01
-color19="5a/57/58" # Base 02
-color20="95/9c/a1" # Base 04
-color21="e7/e7/e8" # Base 06
-color_foreground="d9/d8/d8" # Base 05
-color_background="23/1f/20" # Base 00
-color_cursor="d9/d8/d8" # Base 05
+color15="22/22/1b" # Base 07 - Bright White
+color16="ae/73/13" # Base 09
+color17="9d/6c/7c" # Base 0F
+color18="e7/e6/df" # Base 01
+color19="92/91/81" # Base 02
+color20="6c/6b/5a" # Base 04
+color21="30/2f/27" # Base 06
+color_foreground="5f/5e/4e" # Base 05
+color_background="f4/f3/ec" # Base 00
+color_cursor="5f/5e/4e" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,16 +80,18 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg d9d8d8 # forground
-  printf $printf_template_custom Ph 231f20 # background
-  printf $printf_template_custom Pi d9d8d8 # bold color
-  printf $printf_template_custom Pj 5a5758 # selection color
-  printf $printf_template_custom Pk d9d8d8 # selected text color
-  printf $printf_template_custom Pl d9d8d8 # cursor
-  printf $printf_template_custom Pm 231f20 # cursor text
+  printf $printf_template_custom Pg 5f5e4e # forground
+  printf $printf_template_custom Ph f4f3ec # background
+  printf $printf_template_custom Pi 5f5e4e # bold color
+  printf $printf_template_custom Pj 929181 # selection color
+  printf $printf_template_custom Pk 5f5e4e # selected text color
+  printf $printf_template_custom Pl 5f5e4e # cursor
+  printf $printf_template_custom Pm f4f3ec # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-estuary.sh
+++ b/scripts/base16-atelier-estuary.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 22221b # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-forest-light.sh
+++ b/scripts/base16-atelier-forest-light.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# Harmonic16 Dark scheme by Jannik Siebert (https://github.com/janniks)
+# Atelier Forest scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="0b/1c/2c" # Base 00 - Black
-color01="bf/8b/56" # Base 08 - Red
-color02="56/bf/8b" # Base 0B - Green
-color03="8b/bf/56" # Base 0A - Yellow
-color04="8b/56/bf" # Base 0D - Blue
-color05="bf/56/8b" # Base 0E - Magenta
-color06="56/8b/bf" # Base 0C - Cyan
-color07="cb/d6/e2" # Base 05 - White
-color08="62/7e/99" # Base 03 - Bright Black
+color00="f1/ef/ee" # Base 00 - Black
+color01="f2/2c/40" # Base 08 - Red
+color02="7b/97/26" # Base 0B - Green
+color03="c3/84/18" # Base 0A - Yellow
+color04="40/7e/e7" # Base 0D - Blue
+color05="66/66/ea" # Base 0E - Magenta
+color06="3d/97/b8" # Base 0C - Cyan
+color07="68/61/5e" # Base 05 - White
+color08="9c/94/91" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f9/fb" # Base 07 - Bright White
-color16="bf/bf/56" # Base 09
-color17="bf/56/56" # Base 0F
-color18="22/3b/54" # Base 01
-color19="40/5c/79" # Base 02
-color20="aa/bc/ce" # Base 04
-color21="e5/eb/f1" # Base 06
-color_foreground="cb/d6/e2" # Base 05
-color_background="0b/1c/2c" # Base 00
-color_cursor="cb/d6/e2" # Base 05
+color15="1b/19/18" # Base 07 - Bright White
+color16="df/53/20" # Base 09
+color17="c3/3f/f3" # Base 0F
+color18="e6/e2/e0" # Base 01
+color19="a8/a1/9f" # Base 02
+color20="76/6e/6b" # Base 04
+color21="2c/24/21" # Base 06
+color_foreground="68/61/5e" # Base 05
+color_background="f1/ef/ee" # Base 00
+color_cursor="68/61/5e" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,16 +80,18 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg cbd6e2 # forground
-  printf $printf_template_custom Ph 0b1c2c # background
-  printf $printf_template_custom Pi cbd6e2 # bold color
-  printf $printf_template_custom Pj 405c79 # selection color
-  printf $printf_template_custom Pk cbd6e2 # selected text color
-  printf $printf_template_custom Pl cbd6e2 # cursor
-  printf $printf_template_custom Pm 0b1c2c # cursor text
+  printf $printf_template_custom Pg 68615e # forground
+  printf $printf_template_custom Ph f1efee # background
+  printf $printf_template_custom Pi 68615e # bold color
+  printf $printf_template_custom Pj a8a19f # selection color
+  printf $printf_template_custom Pk 68615e # selected text color
+  printf $printf_template_custom Pl 68615e # cursor
+  printf $printf_template_custom Pm f1efee # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-forest.sh
+++ b/scripts/base16-atelier-forest.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 1b1918 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-heath-light.sh
+++ b/scripts/base16-atelier-heath-light.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Atelier Heath scheme by Bram de Haan (http://atelierbramdehaan.nl)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="f7/f3/f7" # Base 00 - Black
+color01="ca/40/2b" # Base 08 - Red
+color02="91/8b/3b" # Base 0B - Green
+color03="bb/8a/35" # Base 0A - Yellow
+color04="51/6a/ec" # Base 0D - Blue
+color05="7b/59/c0" # Base 0E - Magenta
+color06="15/93/93" # Base 0C - Cyan
+color07="69/5d/69" # Base 05 - White
+color08="9e/8f/9e" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="1b/18/1b" # Base 07 - Bright White
+color16="a6/59/26" # Base 09
+color17="cc/33/cc" # Base 0F
+color18="d8/ca/d8" # Base 01
+color19="ab/9b/ab" # Base 02
+color20="77/69/77" # Base 04
+color21="29/23/29" # Base 06
+color_foreground="69/5d/69" # Base 05
+color_background="f7/f3/f7" # Base 00
+color_cursor="69/5d/69" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg 695d69 # forground
+  printf $printf_template_custom Ph f7f3f7 # background
+  printf $printf_template_custom Pi 695d69 # bold color
+  printf $printf_template_custom Pj ab9bab # selection color
+  printf $printf_template_custom Pk 695d69 # selected text color
+  printf $printf_template_custom Pl 695d69 # cursor
+  printf $printf_template_custom Pm f7f3f7 # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-atelier-heath.sh
+++ b/scripts/base16-atelier-heath.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 1b181b # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-lakeside-light.sh
+++ b/scripts/base16-atelier-lakeside-light.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Atelier Lakeside scheme by Bram de Haan (http://atelierbramdehaan.nl)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="eb/f8/ff" # Base 00 - Black
+color01="d2/2d/72" # Base 08 - Red
+color02="56/8c/3b" # Base 0B - Green
+color03="8a/8a/0f" # Base 0A - Yellow
+color04="25/7f/ad" # Base 0D - Blue
+color05="6b/6b/b8" # Base 0E - Magenta
+color06="2d/8f/6f" # Base 0C - Cyan
+color07="51/6d/7b" # Base 05 - White
+color08="71/95/a8" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="16/1b/1d" # Base 07 - Bright White
+color16="93/5c/25" # Base 09
+color17="b7/2d/d2" # Base 0F
+color18="c1/e4/f6" # Base 01
+color19="7e/a2/b4" # Base 02
+color20="5a/7b/8c" # Base 04
+color21="1f/29/2e" # Base 06
+color_foreground="51/6d/7b" # Base 05
+color_background="eb/f8/ff" # Base 00
+color_cursor="51/6d/7b" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg 516d7b # forground
+  printf $printf_template_custom Ph ebf8ff # background
+  printf $printf_template_custom Pi 516d7b # bold color
+  printf $printf_template_custom Pj 7ea2b4 # selection color
+  printf $printf_template_custom Pk 516d7b # selected text color
+  printf $printf_template_custom Pl 516d7b # cursor
+  printf $printf_template_custom Pm ebf8ff # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-atelier-lakeside.sh
+++ b/scripts/base16-atelier-lakeside.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 161b1d # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-plateau-light.sh
+++ b/scripts/base16-atelier-plateau-light.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Atelier Plateau scheme by Bram de Haan (http://atelierbramdehaan.nl)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="f4/ec/ec" # Base 00 - Black
+color01="ca/49/49" # Base 08 - Red
+color02="4b/8b/8b" # Base 0B - Green
+color03="a0/6e/3b" # Base 0A - Yellow
+color04="72/72/ca" # Base 0D - Blue
+color05="84/64/c4" # Base 0E - Magenta
+color06="54/85/b6" # Base 0C - Cyan
+color07="58/50/50" # Base 05 - White
+color08="7e/77/77" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="1b/18/18" # Base 07 - Bright White
+color16="b4/5a/3c" # Base 09
+color17="bd/51/87" # Base 0F
+color18="e7/df/df" # Base 01
+color19="8a/85/85" # Base 02
+color20="65/5d/5d" # Base 04
+color21="29/24/24" # Base 06
+color_foreground="58/50/50" # Base 05
+color_background="f4/ec/ec" # Base 00
+color_cursor="58/50/50" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg 585050 # forground
+  printf $printf_template_custom Ph f4ecec # background
+  printf $printf_template_custom Pi 585050 # bold color
+  printf $printf_template_custom Pj 8a8585 # selection color
+  printf $printf_template_custom Pk 585050 # selected text color
+  printf $printf_template_custom Pl 585050 # cursor
+  printf $printf_template_custom Pm f4ecec # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-atelier-plateau.sh
+++ b/scripts/base16-atelier-plateau.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 1b1818 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-savanna-light.sh
+++ b/scripts/base16-atelier-savanna-light.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Atelier Savanna scheme by Bram de Haan (http://atelierbramdehaan.nl)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="ec/f4/ee" # Base 00 - Black
+color01="b1/61/39" # Base 08 - Red
+color02="48/99/63" # Base 0B - Green
+color03="a0/7e/3b" # Base 0A - Yellow
+color04="47/8c/90" # Base 0D - Blue
+color05="55/85/9b" # Base 0E - Magenta
+color06="1c/9a/a0" # Base 0C - Cyan
+color07="52/60/57" # Base 05 - White
+color08="78/87/7d" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="17/1c/19" # Base 07 - Bright White
+color16="9f/71/3c" # Base 09
+color17="86/74/69" # Base 0F
+color18="df/e7/e2" # Base 01
+color19="87/92/8a" # Base 02
+color20="5f/6d/64" # Base 04
+color21="23/2a/25" # Base 06
+color_foreground="52/60/57" # Base 05
+color_background="ec/f4/ee" # Base 00
+color_cursor="52/60/57" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg 526057 # forground
+  printf $printf_template_custom Ph ecf4ee # background
+  printf $printf_template_custom Pi 526057 # bold color
+  printf $printf_template_custom Pj 87928a # selection color
+  printf $printf_template_custom Pk 526057 # selected text color
+  printf $printf_template_custom Pl 526057 # cursor
+  printf $printf_template_custom Pm ecf4ee # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-atelier-savanna.sh
+++ b/scripts/base16-atelier-savanna.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 171c19 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-seaside-light.sh
+++ b/scripts/base16-atelier-seaside-light.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# Solar Flare scheme by Chuck Harmston (https://chuck.harmston.ch)
+# Atelier Seaside scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="18/26/2F" # Base 00 - Black
-color01="EF/52/53" # Base 08 - Red
-color02="7C/C8/44" # Base 0B - Green
-color03="E4/B5/1C" # Base 0A - Yellow
-color04="33/B5/E1" # Base 0D - Blue
-color05="A3/63/D5" # Base 0E - Magenta
-color06="52/CB/B0" # Base 0C - Cyan
-color07="A6/AF/B8" # Base 05 - White
-color08="66/75/81" # Base 03 - Bright Black
+color00="f4/fb/f4" # Base 00 - Black
+color01="e6/19/3c" # Base 08 - Red
+color02="29/a3/29" # Base 0B - Green
+color03="98/98/1b" # Base 0A - Yellow
+color04="3d/62/f5" # Base 0D - Blue
+color05="ad/2b/ee" # Base 0E - Magenta
+color06="19/99/b3" # Base 0C - Cyan
+color07="5e/6e/5e" # Base 05 - White
+color08="80/99/80" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="F5/F7/FA" # Base 07 - Bright White
-color16="E6/6B/2B" # Base 09
-color17="D7/3C/9A" # Base 0F
-color18="22/2E/38" # Base 01
-color19="58/68/75" # Base 02
-color20="85/93/9E" # Base 04
-color21="E8/E9/ED" # Base 06
-color_foreground="A6/AF/B8" # Base 05
-color_background="18/26/2F" # Base 00
-color_cursor="A6/AF/B8" # Base 05
+color15="13/15/13" # Base 07 - Bright White
+color16="87/71/1d" # Base 09
+color17="e6/19/c3" # Base 0F
+color18="cf/e8/cf" # Base 01
+color19="8c/a6/8c" # Base 02
+color20="68/7d/68" # Base 04
+color21="24/29/24" # Base 06
+color_foreground="5e/6e/5e" # Base 05
+color_background="f4/fb/f4" # Base 00
+color_cursor="5e/6e/5e" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,16 +80,18 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg A6AFB8 # forground
-  printf $printf_template_custom Ph 18262F # background
-  printf $printf_template_custom Pi A6AFB8 # bold color
-  printf $printf_template_custom Pj 586875 # selection color
-  printf $printf_template_custom Pk A6AFB8 # selected text color
-  printf $printf_template_custom Pl A6AFB8 # cursor
-  printf $printf_template_custom Pm 18262F # cursor text
+  printf $printf_template_custom Pg 5e6e5e # forground
+  printf $printf_template_custom Ph f4fbf4 # background
+  printf $printf_template_custom Pi 5e6e5e # bold color
+  printf $printf_template_custom Pj 8ca68c # selection color
+  printf $printf_template_custom Pk 5e6e5e # selected text color
+  printf $printf_template_custom Pl 5e6e5e # cursor
+  printf $printf_template_custom Pm f4fbf4 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-seaside.sh
+++ b/scripts/base16-atelier-seaside.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 131513 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-atelier-sulphurpool-light.sh
+++ b/scripts/base16-atelier-sulphurpool-light.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Atelier Sulphurpool scheme by Bram de Haan (http://atelierbramdehaan.nl)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="f5/f7/ff" # Base 00 - Black
+color01="c9/49/22" # Base 08 - Red
+color02="ac/97/39" # Base 0B - Green
+color03="c0/8b/30" # Base 0A - Yellow
+color04="3d/8f/d1" # Base 0D - Blue
+color05="66/79/cc" # Base 0E - Magenta
+color06="22/a2/c9" # Base 0C - Cyan
+color07="5e/66/87" # Base 05 - White
+color08="89/8e/a4" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="20/27/46" # Base 07 - Bright White
+color16="c7/6b/29" # Base 09
+color17="9c/63/7a" # Base 0F
+color18="df/e2/f1" # Base 01
+color19="97/9d/b4" # Base 02
+color20="6b/73/94" # Base 04
+color21="29/32/56" # Base 06
+color_foreground="5e/66/87" # Base 05
+color_background="f5/f7/ff" # Base 00
+color_cursor="5e/66/87" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg 5e6687 # forground
+  printf $printf_template_custom Ph f5f7ff # background
+  printf $printf_template_custom Pi 5e6687 # bold color
+  printf $printf_template_custom Pj 979db4 # selection color
+  printf $printf_template_custom Pk 5e6687 # selected text color
+  printf $printf_template_custom Pl 5e6687 # cursor
+  printf $printf_template_custom Pm f5f7ff # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-atelier-sulphurpool.sh
+++ b/scripts/base16-atelier-sulphurpool.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 202746 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-bespin.sh
+++ b/scripts/base16-bespin.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 28211c # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-brewer.sh
+++ b/scripts/base16-brewer.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 0c0d0e # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-bright.sh
+++ b/scripts/base16-bright.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 000000 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-chalk.sh
+++ b/scripts/base16-chalk.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 151515 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-codeschool.sh
+++ b/scripts/base16-codeschool.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 232c31 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-cupcake.sh
+++ b/scripts/base16-cupcake.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm fbf1f2 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-darktooth.sh
+++ b/scripts/base16-darktooth.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 1D2021 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-default-dark.sh
+++ b/scripts/base16-default-dark.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 181818 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-default-light.sh
+++ b/scripts/base16-default-light.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm f8f8f8 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-dracula.sh
+++ b/scripts/base16-dracula.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 282936 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-eighties.sh
+++ b/scripts/base16-eighties.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 2d2d2d # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-embers.sh
+++ b/scripts/base16-embers.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 16130F # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-flat.sh
+++ b/scripts/base16-flat.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 2C3E50 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-github.sh
+++ b/scripts/base16-github.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm ffffff # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-google-dark.sh
+++ b/scripts/base16-google-dark.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 1d1f21 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-google-light.sh
+++ b/scripts/base16-google-light.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm ffffff # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-grayscale-dark.sh
+++ b/scripts/base16-grayscale-dark.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 101010 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-grayscale-light.sh
+++ b/scripts/base16-grayscale-light.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm f7f7f7 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-greenscreen.sh
+++ b/scripts/base16-greenscreen.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Green Screen scheme by Chris Kempson (http://chriskempson.com)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="00/11/00" # Base 00 - Black
+color01="00/77/00" # Base 08 - Red
+color02="00/bb/00" # Base 0B - Green
+color03="00/77/00" # Base 0A - Yellow
+color04="00/99/00" # Base 0D - Blue
+color05="00/bb/00" # Base 0E - Magenta
+color06="00/55/00" # Base 0C - Cyan
+color07="00/bb/00" # Base 05 - White
+color08="00/77/00" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="00/ff/00" # Base 07 - Bright White
+color16="00/99/00" # Base 09
+color17="00/55/00" # Base 0F
+color18="00/33/00" # Base 01
+color19="00/55/00" # Base 02
+color20="00/99/00" # Base 04
+color21="00/dd/00" # Base 06
+color_foreground="00/bb/00" # Base 05
+color_background="00/11/00" # Base 00
+color_cursor="00/bb/00" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg 00bb00 # forground
+  printf $printf_template_custom Ph 001100 # background
+  printf $printf_template_custom Pi 00bb00 # bold color
+  printf $printf_template_custom Pj 005500 # selection color
+  printf $printf_template_custom Pk 00bb00 # selected text color
+  printf $printf_template_custom Pl 00bb00 # cursor
+  printf $printf_template_custom Pm 001100 # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-gruvbox-dark-hard.sh
+++ b/scripts/base16-gruvbox-dark-hard.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Gruvbox dark, hard scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="1d/20/21" # Base 00 - Black
+color01="fb/49/34" # Base 08 - Red
+color02="b8/bb/26" # Base 0B - Green
+color03="fa/bd/2f" # Base 0A - Yellow
+color04="83/a5/98" # Base 0D - Blue
+color05="d3/86/9b" # Base 0E - Magenta
+color06="8e/c0/7c" # Base 0C - Cyan
+color07="d5/c4/a1" # Base 05 - White
+color08="66/5c/54" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="fb/f1/c7" # Base 07 - Bright White
+color16="fe/80/19" # Base 09
+color17="d6/5d/0e" # Base 0F
+color18="3c/38/36" # Base 01
+color19="50/49/45" # Base 02
+color20="bd/ae/93" # Base 04
+color21="eb/db/b2" # Base 06
+color_foreground="d5/c4/a1" # Base 05
+color_background="1d/20/21" # Base 00
+color_cursor="d5/c4/a1" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg d5c4a1 # forground
+  printf $printf_template_custom Ph 1d2021 # background
+  printf $printf_template_custom Pi d5c4a1 # bold color
+  printf $printf_template_custom Pj 504945 # selection color
+  printf $printf_template_custom Pk d5c4a1 # selected text color
+  printf $printf_template_custom Pl d5c4a1 # cursor
+  printf $printf_template_custom Pm 1d2021 # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-gruvbox-dark-medium.sh
+++ b/scripts/base16-gruvbox-dark-medium.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Gruvbox dark, medium scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="28/28/28" # Base 00 - Black
+color01="fb/49/34" # Base 08 - Red
+color02="b8/bb/26" # Base 0B - Green
+color03="fa/bd/2f" # Base 0A - Yellow
+color04="83/a5/98" # Base 0D - Blue
+color05="d3/86/9b" # Base 0E - Magenta
+color06="8e/c0/7c" # Base 0C - Cyan
+color07="d5/c4/a1" # Base 05 - White
+color08="66/5c/54" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="fb/f1/c7" # Base 07 - Bright White
+color16="fe/80/19" # Base 09
+color17="d6/5d/0e" # Base 0F
+color18="3c/38/36" # Base 01
+color19="50/49/45" # Base 02
+color20="bd/ae/93" # Base 04
+color21="eb/db/b2" # Base 06
+color_foreground="d5/c4/a1" # Base 05
+color_background="28/28/28" # Base 00
+color_cursor="d5/c4/a1" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg d5c4a1 # forground
+  printf $printf_template_custom Ph 282828 # background
+  printf $printf_template_custom Pi d5c4a1 # bold color
+  printf $printf_template_custom Pj 504945 # selection color
+  printf $printf_template_custom Pk d5c4a1 # selected text color
+  printf $printf_template_custom Pl d5c4a1 # cursor
+  printf $printf_template_custom Pm 282828 # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-gruvbox-dark-pale.sh
+++ b/scripts/base16-gruvbox-dark-pale.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Gruvbox dark, pale scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="26/26/26" # Base 00 - Black
+color01="d7/5f/5f" # Base 08 - Red
+color02="af/af/00" # Base 0B - Green
+color03="ff/af/00" # Base 0A - Yellow
+color04="83/ad/ad" # Base 0D - Blue
+color05="d4/85/ad" # Base 0E - Magenta
+color06="85/ad/85" # Base 0C - Cyan
+color07="da/b9/97" # Base 05 - White
+color08="8a/8a/8a" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="eb/db/b2" # Base 07 - Bright White
+color16="ff/87/00" # Base 09
+color17="d6/5d/0e" # Base 0F
+color18="3a/3a/3a" # Base 01
+color19="4e/4e/4e" # Base 02
+color20="94/94/94" # Base 04
+color21="d5/c4/a1" # Base 06
+color_foreground="da/b9/97" # Base 05
+color_background="26/26/26" # Base 00
+color_cursor="da/b9/97" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg dab997 # forground
+  printf $printf_template_custom Ph 262626 # background
+  printf $printf_template_custom Pi dab997 # bold color
+  printf $printf_template_custom Pj 4e4e4e # selection color
+  printf $printf_template_custom Pk dab997 # selected text color
+  printf $printf_template_custom Pl dab997 # cursor
+  printf $printf_template_custom Pm 262626 # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-gruvbox-dark-soft.sh
+++ b/scripts/base16-gruvbox-dark-soft.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# IR Black scheme by Timothée Poisot (http://timotheepoisot.fr)
+# Gruvbox dark, soft scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="00/00/00" # Base 00 - Black
-color01="ff/6c/60" # Base 08 - Red
-color02="a8/ff/60" # Base 0B - Green
-color03="ff/ff/b6" # Base 0A - Yellow
-color04="96/cb/fe" # Base 0D - Blue
-color05="ff/73/fd" # Base 0E - Magenta
-color06="c6/c5/fe" # Base 0C - Cyan
-color07="b5/b3/aa" # Base 05 - White
-color08="6c/6c/66" # Base 03 - Bright Black
+color00="32/30/2f" # Base 00 - Black
+color01="fb/49/34" # Base 08 - Red
+color02="b8/bb/26" # Base 0B - Green
+color03="fa/bd/2f" # Base 0A - Yellow
+color04="83/a5/98" # Base 0D - Blue
+color05="d3/86/9b" # Base 0E - Magenta
+color06="8e/c0/7c" # Base 0C - Cyan
+color07="d5/c4/a1" # Base 05 - White
+color08="66/5c/54" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="fd/fb/ee" # Base 07 - Bright White
-color16="e9/c0/62" # Base 09
-color17="b1/8a/3d" # Base 0F
-color18="24/24/22" # Base 01
-color19="48/48/44" # Base 02
-color20="91/8f/88" # Base 04
-color21="d9/d7/cc" # Base 06
-color_foreground="b5/b3/aa" # Base 05
-color_background="00/00/00" # Base 00
-color_cursor="b5/b3/aa" # Base 05
+color15="fb/f1/c7" # Base 07 - Bright White
+color16="fe/80/19" # Base 09
+color17="d6/5d/0e" # Base 0F
+color18="3c/38/36" # Base 01
+color19="50/49/45" # Base 02
+color20="bd/ae/93" # Base 04
+color21="eb/db/b2" # Base 06
+color_foreground="d5/c4/a1" # Base 05
+color_background="32/30/2f" # Base 00
+color_cursor="d5/c4/a1" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,16 +80,18 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg b5b3aa # forground
-  printf $printf_template_custom Ph 000000 # background
-  printf $printf_template_custom Pi b5b3aa # bold color
-  printf $printf_template_custom Pj 484844 # selection color
-  printf $printf_template_custom Pk b5b3aa # selected text color
-  printf $printf_template_custom Pl b5b3aa # cursor
-  printf $printf_template_custom Pm 000000 # cursor text
+  printf $printf_template_custom Pg d5c4a1 # forground
+  printf $printf_template_custom Ph 32302f # background
+  printf $printf_template_custom Pi d5c4a1 # bold color
+  printf $printf_template_custom Pj 504945 # selection color
+  printf $printf_template_custom Pk d5c4a1 # selected text color
+  printf $printf_template_custom Pl d5c4a1 # cursor
+  printf $printf_template_custom Pm 32302f # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-gruvbox-light-hard.sh
+++ b/scripts/base16-gruvbox-light-hard.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Gruvbox light, hard scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="f9/f5/d7" # Base 00 - Black
+color01="9d/00/06" # Base 08 - Red
+color02="79/74/0e" # Base 0B - Green
+color03="b5/76/14" # Base 0A - Yellow
+color04="07/66/78" # Base 0D - Blue
+color05="8f/3f/71" # Base 0E - Magenta
+color06="42/7b/58" # Base 0C - Cyan
+color07="50/49/45" # Base 05 - White
+color08="bd/ae/93" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="28/28/28" # Base 07 - Bright White
+color16="af/3a/03" # Base 09
+color17="d6/5d/0e" # Base 0F
+color18="eb/db/b2" # Base 01
+color19="d5/c4/a1" # Base 02
+color20="66/5c/54" # Base 04
+color21="3c/38/36" # Base 06
+color_foreground="50/49/45" # Base 05
+color_background="f9/f5/d7" # Base 00
+color_cursor="50/49/45" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg 504945 # forground
+  printf $printf_template_custom Ph f9f5d7 # background
+  printf $printf_template_custom Pi 504945 # bold color
+  printf $printf_template_custom Pj d5c4a1 # selection color
+  printf $printf_template_custom Pk 504945 # selected text color
+  printf $printf_template_custom Pl 504945 # cursor
+  printf $printf_template_custom Pm f9f5d7 # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-gruvbox-light-medium.sh
+++ b/scripts/base16-gruvbox-light-medium.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Gruvbox light, medium scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="fb/f1/c7" # Base 00 - Black
+color01="9d/00/06" # Base 08 - Red
+color02="79/74/0e" # Base 0B - Green
+color03="b5/76/14" # Base 0A - Yellow
+color04="07/66/78" # Base 0D - Blue
+color05="8f/3f/71" # Base 0E - Magenta
+color06="42/7b/58" # Base 0C - Cyan
+color07="50/49/45" # Base 05 - White
+color08="bd/ae/93" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="28/28/28" # Base 07 - Bright White
+color16="af/3a/03" # Base 09
+color17="d6/5d/0e" # Base 0F
+color18="eb/db/b2" # Base 01
+color19="d5/c4/a1" # Base 02
+color20="66/5c/54" # Base 04
+color21="3c/38/36" # Base 06
+color_foreground="50/49/45" # Base 05
+color_background="fb/f1/c7" # Base 00
+color_cursor="50/49/45" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg 504945 # forground
+  printf $printf_template_custom Ph fbf1c7 # background
+  printf $printf_template_custom Pi 504945 # bold color
+  printf $printf_template_custom Pj d5c4a1 # selection color
+  printf $printf_template_custom Pk 504945 # selected text color
+  printf $printf_template_custom Pl 504945 # cursor
+  printf $printf_template_custom Pm fbf1c7 # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-gruvbox-light-soft.sh
+++ b/scripts/base16-gruvbox-light-soft.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Gruvbox light, soft scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="f2/e5/bc" # Base 00 - Black
+color01="9d/00/06" # Base 08 - Red
+color02="79/74/0e" # Base 0B - Green
+color03="b5/76/14" # Base 0A - Yellow
+color04="07/66/78" # Base 0D - Blue
+color05="8f/3f/71" # Base 0E - Magenta
+color06="42/7b/58" # Base 0C - Cyan
+color07="50/49/45" # Base 05 - White
+color08="bd/ae/93" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="28/28/28" # Base 07 - Bright White
+color16="af/3a/03" # Base 09
+color17="d6/5d/0e" # Base 0F
+color18="eb/db/b2" # Base 01
+color19="d5/c4/a1" # Base 02
+color20="66/5c/54" # Base 04
+color21="3c/38/36" # Base 06
+color_foreground="50/49/45" # Base 05
+color_background="f2/e5/bc" # Base 00
+color_cursor="50/49/45" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg 504945 # forground
+  printf $printf_template_custom Ph f2e5bc # background
+  printf $printf_template_custom Pi 504945 # bold color
+  printf $printf_template_custom Pj d5c4a1 # selection color
+  printf $printf_template_custom Pk 504945 # selected text color
+  printf $printf_template_custom Pl 504945 # cursor
+  printf $printf_template_custom Pm f2e5bc # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-harmonic-dark.sh
+++ b/scripts/base16-harmonic-dark.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# Green Screen scheme by Chris Kempson (http://chriskempson.com)
+# Harmonic16 Dark scheme by Jannik Siebert (https://github.com/janniks)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="00/11/00" # Base 00 - Black
-color01="00/77/00" # Base 08 - Red
-color02="00/bb/00" # Base 0B - Green
-color03="00/77/00" # Base 0A - Yellow
-color04="00/99/00" # Base 0D - Blue
-color05="00/bb/00" # Base 0E - Magenta
-color06="00/55/00" # Base 0C - Cyan
-color07="00/bb/00" # Base 05 - White
-color08="00/77/00" # Base 03 - Bright Black
+color00="0b/1c/2c" # Base 00 - Black
+color01="bf/8b/56" # Base 08 - Red
+color02="56/bf/8b" # Base 0B - Green
+color03="8b/bf/56" # Base 0A - Yellow
+color04="8b/56/bf" # Base 0D - Blue
+color05="bf/56/8b" # Base 0E - Magenta
+color06="56/8b/bf" # Base 0C - Cyan
+color07="cb/d6/e2" # Base 05 - White
+color08="62/7e/99" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="00/ff/00" # Base 07 - Bright White
-color16="00/99/00" # Base 09
-color17="00/55/00" # Base 0F
-color18="00/33/00" # Base 01
-color19="00/55/00" # Base 02
-color20="00/99/00" # Base 04
-color21="00/dd/00" # Base 06
-color_foreground="00/bb/00" # Base 05
-color_background="00/11/00" # Base 00
-color_cursor="00/bb/00" # Base 05
+color15="f7/f9/fb" # Base 07 - Bright White
+color16="bf/bf/56" # Base 09
+color17="bf/56/56" # Base 0F
+color18="22/3b/54" # Base 01
+color19="40/5c/79" # Base 02
+color20="aa/bc/ce" # Base 04
+color21="e5/eb/f1" # Base 06
+color_foreground="cb/d6/e2" # Base 05
+color_background="0b/1c/2c" # Base 00
+color_cursor="cb/d6/e2" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,16 +80,18 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg 00bb00 # forground
-  printf $printf_template_custom Ph 001100 # background
-  printf $printf_template_custom Pi 00bb00 # bold color
-  printf $printf_template_custom Pj 005500 # selection color
-  printf $printf_template_custom Pk 00bb00 # selected text color
-  printf $printf_template_custom Pl 00bb00 # cursor
-  printf $printf_template_custom Pm 001100 # cursor text
+  printf $printf_template_custom Pg cbd6e2 # forground
+  printf $printf_template_custom Ph 0b1c2c # background
+  printf $printf_template_custom Pi cbd6e2 # bold color
+  printf $printf_template_custom Pj 405c79 # selection color
+  printf $printf_template_custom Pk cbd6e2 # selected text color
+  printf $printf_template_custom Pl cbd6e2 # cursor
+  printf $printf_template_custom Pm 0b1c2c # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-harmonic-light.sh
+++ b/scripts/base16-harmonic-light.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# Seti UI scheme by 
+# Harmonic16 Light scheme by Jannik Siebert (https://github.com/janniks)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="15/17/18" # Base 00 - Black
-color01="Cd/3f/45" # Base 08 - Red
-color02="9f/ca/56" # Base 0B - Green
-color03="e6/cd/69" # Base 0A - Yellow
-color04="55/b5/db" # Base 0D - Blue
-color05="a0/74/c4" # Base 0E - Magenta
-color06="55/db/be" # Base 0C - Cyan
-color07="d6/d6/d6" # Base 05 - White
-color08="41/53/5B" # Base 03 - Bright Black
+color00="f7/f9/fb" # Base 00 - Black
+color01="bf/8b/56" # Base 08 - Red
+color02="56/bf/8b" # Base 0B - Green
+color03="8b/bf/56" # Base 0A - Yellow
+color04="8b/56/bf" # Base 0D - Blue
+color05="bf/56/8b" # Base 0E - Magenta
+color06="56/8b/bf" # Base 0C - Cyan
+color07="40/5c/79" # Base 05 - White
+color08="aa/bc/ce" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="db/7b/55" # Base 09
-color17="8a/55/3f" # Base 0F
-color18="8e/c4/3d" # Base 01
-color19="3B/75/8C" # Base 02
-color20="43/a5/d5" # Base 04
-color21="ee/ee/ee" # Base 06
-color_foreground="d6/d6/d6" # Base 05
-color_background="15/17/18" # Base 00
-color_cursor="d6/d6/d6" # Base 05
+color15="0b/1c/2c" # Base 07 - Bright White
+color16="bf/bf/56" # Base 09
+color17="bf/56/56" # Base 0F
+color18="e5/eb/f1" # Base 01
+color19="cb/d6/e2" # Base 02
+color20="62/7e/99" # Base 04
+color21="22/3b/54" # Base 06
+color_foreground="40/5c/79" # Base 05
+color_background="f7/f9/fb" # Base 00
+color_cursor="40/5c/79" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,16 +80,18 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg d6d6d6 # forground
-  printf $printf_template_custom Ph 151718 # background
-  printf $printf_template_custom Pi d6d6d6 # bold color
-  printf $printf_template_custom Pj 3B758C # selection color
-  printf $printf_template_custom Pk d6d6d6 # selected text color
-  printf $printf_template_custom Pl d6d6d6 # cursor
-  printf $printf_template_custom Pm 151718 # cursor text
+  printf $printf_template_custom Pg 405c79 # forground
+  printf $printf_template_custom Ph f7f9fb # background
+  printf $printf_template_custom Pi 405c79 # bold color
+  printf $printf_template_custom Pj cbd6e2 # selection color
+  printf $printf_template_custom Pk 405c79 # selected text color
+  printf $printf_template_custom Pl 405c79 # cursor
+  printf $printf_template_custom Pm f7f9fb # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-hopscotch.sh
+++ b/scripts/base16-hopscotch.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 322931 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-irblack.sh
+++ b/scripts/base16-irblack.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# IR Black scheme by Timothée Poisot (http://timotheepoisot.fr)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="00/00/00" # Base 00 - Black
+color01="ff/6c/60" # Base 08 - Red
+color02="a8/ff/60" # Base 0B - Green
+color03="ff/ff/b6" # Base 0A - Yellow
+color04="96/cb/fe" # Base 0D - Blue
+color05="ff/73/fd" # Base 0E - Magenta
+color06="c6/c5/fe" # Base 0C - Cyan
+color07="b5/b3/aa" # Base 05 - White
+color08="6c/6c/66" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="fd/fb/ee" # Base 07 - Bright White
+color16="e9/c0/62" # Base 09
+color17="b1/8a/3d" # Base 0F
+color18="24/24/22" # Base 01
+color19="48/48/44" # Base 02
+color20="91/8f/88" # Base 04
+color21="d9/d7/cc" # Base 06
+color_foreground="b5/b3/aa" # Base 05
+color_background="00/00/00" # Base 00
+color_cursor="b5/b3/aa" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg b5b3aa # forground
+  printf $printf_template_custom Ph 000000 # background
+  printf $printf_template_custom Pi b5b3aa # bold color
+  printf $printf_template_custom Pj 484844 # selection color
+  printf $printf_template_custom Pk b5b3aa # selected text color
+  printf $printf_template_custom Pl b5b3aa # cursor
+  printf $printf_template_custom Pm 000000 # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-isotope.sh
+++ b/scripts/base16-isotope.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 000000 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-macintosh.sh
+++ b/scripts/base16-macintosh.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 000000 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-marrakesh.sh
+++ b/scripts/base16-marrakesh.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 201602 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-materia.sh
+++ b/scripts/base16-materia.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 263238 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-mexico-light.sh
+++ b/scripts/base16-mexico-light.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm f8f8f8 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-mocha.sh
+++ b/scripts/base16-mocha.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 3B3228 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-monokai.sh
+++ b/scripts/base16-monokai.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 272822 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-ocean.sh
+++ b/scripts/base16-ocean.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 2b303b # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-oceanicnext.sh
+++ b/scripts/base16-oceanicnext.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 1B2B34 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-onedark.sh
+++ b/scripts/base16-onedark.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 282c34 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-paraiso.sh
+++ b/scripts/base16-paraiso.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 2f1e2e # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-phd.sh
+++ b/scripts/base16-phd.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 061229 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-pico.sh
+++ b/scripts/base16-pico.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 000000 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-pop.sh
+++ b/scripts/base16-pop.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 000000 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-railscasts.sh
+++ b/scripts/base16-railscasts.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 2b2b2b # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-seti.sh
+++ b/scripts/base16-seti.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Seti UI scheme by 
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="15/17/18" # Base 00 - Black
+color01="Cd/3f/45" # Base 08 - Red
+color02="9f/ca/56" # Base 0B - Green
+color03="e6/cd/69" # Base 0A - Yellow
+color04="55/b5/db" # Base 0D - Blue
+color05="a0/74/c4" # Base 0E - Magenta
+color06="55/db/be" # Base 0C - Cyan
+color07="d6/d6/d6" # Base 05 - White
+color08="41/53/5B" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="ff/ff/ff" # Base 07 - Bright White
+color16="db/7b/55" # Base 09
+color17="8a/55/3f" # Base 0F
+color18="8e/c4/3d" # Base 01
+color19="3B/75/8C" # Base 02
+color20="43/a5/d5" # Base 04
+color21="ee/ee/ee" # Base 06
+color_foreground="d6/d6/d6" # Base 05
+color_background="15/17/18" # Base 00
+color_cursor="d6/d6/d6" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg d6d6d6 # forground
+  printf $printf_template_custom Ph 151718 # background
+  printf $printf_template_custom Pi d6d6d6 # bold color
+  printf $printf_template_custom Pj 3B758C # selection color
+  printf $printf_template_custom Pk d6d6d6 # selected text color
+  printf $printf_template_custom Pl d6d6d6 # cursor
+  printf $printf_template_custom Pm 151718 # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-shapeshifter.sh
+++ b/scripts/base16-shapeshifter.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm f9f9f9 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-solarflare.sh
+++ b/scripts/base16-solarflare.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Solar Flare scheme by Chuck Harmston (https://chuck.harmston.ch)
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="18/26/2F" # Base 00 - Black
+color01="EF/52/53" # Base 08 - Red
+color02="7C/C8/44" # Base 0B - Green
+color03="E4/B5/1C" # Base 0A - Yellow
+color04="33/B5/E1" # Base 0D - Blue
+color05="A3/63/D5" # Base 0E - Magenta
+color06="52/CB/B0" # Base 0C - Cyan
+color07="A6/AF/B8" # Base 05 - White
+color08="66/75/81" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="F5/F7/FA" # Base 07 - Bright White
+color16="E6/6B/2B" # Base 09
+color17="D7/3C/9A" # Base 0F
+color18="22/2E/38" # Base 01
+color19="58/68/75" # Base 02
+color20="85/93/9E" # Base 04
+color21="E8/E9/ED" # Base 06
+color_foreground="A6/AF/B8" # Base 05
+color_background="18/26/2F" # Base 00
+color_cursor="A6/AF/B8" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg A6AFB8 # forground
+  printf $printf_template_custom Ph 18262F # background
+  printf $printf_template_custom Pi A6AFB8 # bold color
+  printf $printf_template_custom Pj 586875 # selection color
+  printf $printf_template_custom Pk A6AFB8 # selected text color
+  printf $printf_template_custom Pl A6AFB8 # cursor
+  printf $printf_template_custom Pm 18262F # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-solarized-dark.sh
+++ b/scripts/base16-solarized-dark.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 002b36 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-solarized-light.sh
+++ b/scripts/base16-solarized-light.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm fdf6e3 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-spacemacs.sh
+++ b/scripts/base16-spacemacs.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 1f2022 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-summerfruit-dark.sh
+++ b/scripts/base16-summerfruit-dark.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 151515 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-summerfruit-light.sh
+++ b/scripts/base16-summerfruit-light.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm FFFFFF # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-tomorrow-night.sh
+++ b/scripts/base16-tomorrow-night.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 1d1f21 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-tomorrow.sh
+++ b/scripts/base16-tomorrow.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm ffffff # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-tube.sh
+++ b/scripts/base16-tube.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# London Tube scheme by Jan T. Sott
+
+# This script doesn't support linux console (use 'vconsole' template instead)
+if [ "${TERM%%-*}" = 'linux' ]; then
+    return 2>/dev/null || exit 0
+fi
+
+color00="23/1f/20" # Base 00 - Black
+color01="ee/2e/24" # Base 08 - Red
+color02="00/85/3e" # Base 0B - Green
+color03="ff/d2/04" # Base 0A - Yellow
+color04="00/9d/dc" # Base 0D - Blue
+color05="98/00/5d" # Base 0E - Magenta
+color06="85/ce/bc" # Base 0C - Cyan
+color07="d9/d8/d8" # Base 05 - White
+color08="73/71/71" # Base 03 - Bright Black
+color09=$color01 # Base 08 - Bright Red
+color10=$color02 # Base 0B - Bright Green
+color11=$color03 # Base 0A - Bright Yellow
+color12=$color04 # Base 0D - Bright Blue
+color13=$color05 # Base 0E - Bright Magenta
+color14=$color06 # Base 0C - Bright Cyan
+color15="ff/ff/ff" # Base 07 - Bright White
+color16="f3/86/a1" # Base 09
+color17="b0/61/10" # Base 0F
+color18="1c/3f/95" # Base 01
+color19="5a/57/58" # Base 02
+color20="95/9c/a1" # Base 04
+color21="e7/e7/e8" # Base 06
+color_foreground="d9/d8/d8" # Base 05
+color_background="23/1f/20" # Base 00
+color_cursor="d9/d8/d8" # Base 05
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\033\033\\\033\\'
+elif [ "${TERM%%-*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  printf_template='\033P\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033P\033]%s%s\033\\'
+else
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
+fi
+
+# 16 color space
+printf $printf_template 0  $color00
+printf $printf_template 1  $color01
+printf $printf_template 2  $color02
+printf $printf_template 3  $color03
+printf $printf_template 4  $color04
+printf $printf_template 5  $color05
+printf $printf_template 6  $color06
+printf $printf_template 7  $color07
+printf $printf_template 8  $color08
+printf $printf_template 9  $color09
+printf $printf_template 10 $color10
+printf $printf_template 11 $color11
+printf $printf_template 12 $color12
+printf $printf_template 13 $color13
+printf $printf_template 14 $color14
+printf $printf_template 15 $color15
+
+# 256 color space
+printf $printf_template 16 $color16
+printf $printf_template 17 $color17
+printf $printf_template 18 $color18
+printf $printf_template 19 $color19
+printf $printf_template 20 $color20
+printf $printf_template 21 $color21
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  printf $printf_template_custom Pg d9d8d8 # forground
+  printf $printf_template_custom Ph 231f20 # background
+  printf $printf_template_custom Pi d9d8d8 # bold color
+  printf $printf_template_custom Pj 5a5758 # selection color
+  printf $printf_template_custom Pk d9d8d8 # selected text color
+  printf $printf_template_custom Pl d9d8d8 # cursor
+  printf $printf_template_custom Pm 231f20 # cursor text
+else
+  printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
+  printf $printf_template_var 11 $color_background
+  fi
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset printf_template
+unset printf_template_var
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background
+unset color_cursor

--- a/scripts/base16-twilight.sh
+++ b/scripts/base16-twilight.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 1e1e1e # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-unikitty-dark.sh
+++ b/scripts/base16-unikitty-dark.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 2e2a31 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-unikitty-light.sh
+++ b/scripts/base16-unikitty-light.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm ffffff # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/scripts/base16-woodland.sh
+++ b/scripts/base16-woodland.sh
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm 231e18 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -89,7 +89,9 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   printf $printf_template_custom Pm {{base00-hex}} # cursor text
 else
   printf $printf_template_var 10 $color_foreground
+  if [ "$shell_no_background" != true ]; then
   printf $printf_template_var 11 $color_background
+  fi
   printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 


### PR DESCRIPTION
Fixes #94 
This commit adds the option to ignore background color setup. This lets us control the background color directly from the terminal's options (useful for setting up transparent backgrounds).

The option should be set before the profile helper:

```bash
...
# Base16 shell tab completion
shell_no_background=true                                                                                                                                                                                                                           
BASE16_SHELL=$HOME/.config/base16-shell/
[ -n "$PS1" ] && [ -s $BASE16_SHELL/profile_helper.sh ] && eval "$($BASE16_SHELL/profile_helper.sh)"
```

If the option is ignored, the behavior is just like before the commit.