### PR TITLE
Add zsh plugin loader file (for oh-my-zsh, zgen, antigen, etc.)

### DIFF
--- a/base16-shell.plugin.zsh
+++ b/base16-shell.plugin.zsh
@@ -1,0 +1,2 @@
+BASE16_SHELL=$(dirname ${(%):-%x})
+[ -n "$PS1" ] && [ -s $BASE16_SHELL/profile_helper.sh ] && eval "$($BASE16_SHELL/profile_helper.sh)"


### PR DESCRIPTION
The file is automatically picked up by various ZSH plugin loaders and executed as the README instructions suggest.

Currently, antigen/antibody pick up `profile_helper.sh` but source it directly, which doesn't work.