### PR TITLE
Rename some themes to match latest schemas

### DIFF
--- a/scripts/base16-greenscreen.sh
+++ b/scripts/base16-greenscreen.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# Harmonic16 Dark scheme by Jannik Siebert (https://github.com/janniks)
+# Greenscreen scheme by Chris Kempson (http://chriskempson.com)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="0b/1c/2c" # Base 00 - Black
-color01="bf/8b/56" # Base 08 - Red
-color02="56/bf/8b" # Base 0B - Green
-color03="8b/bf/56" # Base 0A - Yellow
-color04="8b/56/bf" # Base 0D - Blue
-color05="bf/56/8b" # Base 0E - Magenta
-color06="56/8b/bf" # Base 0C - Cyan
-color07="cb/d6/e2" # Base 05 - White
-color08="62/7e/99" # Base 03 - Bright Black
+color00="00/11/00" # Base 00 - Black
+color01="00/77/00" # Base 08 - Red
+color02="00/bb/00" # Base 0B - Green
+color03="00/77/00" # Base 0A - Yellow
+color04="00/99/00" # Base 0D - Blue
+color05="00/bb/00" # Base 0E - Magenta
+color06="00/55/00" # Base 0C - Cyan
+color07="00/bb/00" # Base 05 - White
+color08="00/77/00" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f9/fb" # Base 07 - Bright White
-color16="bf/bf/56" # Base 09
-color17="bf/56/56" # Base 0F
-color18="22/3b/54" # Base 01
-color19="40/5c/79" # Base 02
-color20="aa/bc/ce" # Base 04
-color21="e5/eb/f1" # Base 06
-color_foreground="cb/d6/e2" # Base 05
-color_background="0b/1c/2c" # Base 00
-color_cursor="cb/d6/e2" # Base 05
+color15="00/ff/00" # Base 07 - Bright White
+color16="00/99/00" # Base 09
+color17="00/55/00" # Base 0F
+color18="00/33/00" # Base 01
+color19="00/55/00" # Base 02
+color20="00/99/00" # Base 04
+color21="00/dd/00" # Base 06
+color_foreground="00/bb/00" # Base 05
+color_background="00/11/00" # Base 00
+color_cursor="00/bb/00" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,13 +80,13 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg cbd6e2 # forground
-  printf $printf_template_custom Ph 0b1c2c # background
-  printf $printf_template_custom Pi cbd6e2 # bold color
-  printf $printf_template_custom Pj 405c79 # selection color
-  printf $printf_template_custom Pk cbd6e2 # selected text color
-  printf $printf_template_custom Pl cbd6e2 # cursor
-  printf $printf_template_custom Pm 0b1c2c # cursor text
+  printf $printf_template_custom Pg 00bb00 # forground
+  printf $printf_template_custom Ph 001100 # background
+  printf $printf_template_custom Pi 00bb00 # bold color
+  printf $printf_template_custom Pj 005500 # selection color
+  printf $printf_template_custom Pk 00bb00 # selected text color
+  printf $printf_template_custom Pl 00bb00 # cursor
+  printf $printf_template_custom Pm 001100 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background

--- a/scripts/base16-harmonic-dark.sh
+++ b/scripts/base16-harmonic-dark.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# Seti UI scheme by 
+# Harmonic Dark scheme by Jannik Siebert (https://github.com/janniks)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="15/17/18" # Base 00 - Black
-color01="Cd/3f/45" # Base 08 - Red
-color02="9f/ca/56" # Base 0B - Green
-color03="e6/cd/69" # Base 0A - Yellow
-color04="55/b5/db" # Base 0D - Blue
-color05="a0/74/c4" # Base 0E - Magenta
-color06="55/db/be" # Base 0C - Cyan
-color07="d6/d6/d6" # Base 05 - White
-color08="41/53/5B" # Base 03 - Bright Black
+color00="0b/1c/2c" # Base 00 - Black
+color01="bf/8b/56" # Base 08 - Red
+color02="56/bf/8b" # Base 0B - Green
+color03="8b/bf/56" # Base 0A - Yellow
+color04="8b/56/bf" # Base 0D - Blue
+color05="bf/56/8b" # Base 0E - Magenta
+color06="56/8b/bf" # Base 0C - Cyan
+color07="cb/d6/e2" # Base 05 - White
+color08="62/7e/99" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="db/7b/55" # Base 09
-color17="8a/55/3f" # Base 0F
-color18="8e/c4/3d" # Base 01
-color19="3B/75/8C" # Base 02
-color20="43/a5/d5" # Base 04
-color21="ee/ee/ee" # Base 06
-color_foreground="d6/d6/d6" # Base 05
-color_background="15/17/18" # Base 00
-color_cursor="d6/d6/d6" # Base 05
+color15="f7/f9/fb" # Base 07 - Bright White
+color16="bf/bf/56" # Base 09
+color17="bf/56/56" # Base 0F
+color18="22/3b/54" # Base 01
+color19="40/5c/79" # Base 02
+color20="aa/bc/ce" # Base 04
+color21="e5/eb/f1" # Base 06
+color_foreground="cb/d6/e2" # Base 05
+color_background="0b/1c/2c" # Base 00
+color_cursor="cb/d6/e2" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,13 +80,13 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg d6d6d6 # forground
-  printf $printf_template_custom Ph 151718 # background
-  printf $printf_template_custom Pi d6d6d6 # bold color
-  printf $printf_template_custom Pj 3B758C # selection color
-  printf $printf_template_custom Pk d6d6d6 # selected text color
-  printf $printf_template_custom Pl d6d6d6 # cursor
-  printf $printf_template_custom Pm 151718 # cursor text
+  printf $printf_template_custom Pg cbd6e2 # forground
+  printf $printf_template_custom Ph 0b1c2c # background
+  printf $printf_template_custom Pi cbd6e2 # bold color
+  printf $printf_template_custom Pj 405c79 # selection color
+  printf $printf_template_custom Pk cbd6e2 # selected text color
+  printf $printf_template_custom Pl cbd6e2 # cursor
+  printf $printf_template_custom Pm 0b1c2c # cursor text
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background

--- a/scripts/base16-harmonic-light.sh
+++ b/scripts/base16-harmonic-light.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# Harmonic16 Light scheme by Jannik Siebert (https://github.com/janniks)
+# Harmonic Light scheme by Jannik Siebert (https://github.com/janniks)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then

--- a/scripts/base16-seti.sh
+++ b/scripts/base16-seti.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# Green Screen scheme by Chris Kempson (http://chriskempson.com)
+# Seti scheme by
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="00/11/00" # Base 00 - Black
-color01="00/77/00" # Base 08 - Red
-color02="00/bb/00" # Base 0B - Green
-color03="00/77/00" # Base 0A - Yellow
-color04="00/99/00" # Base 0D - Blue
-color05="00/bb/00" # Base 0E - Magenta
-color06="00/55/00" # Base 0C - Cyan
-color07="00/bb/00" # Base 05 - White
-color08="00/77/00" # Base 03 - Bright Black
+color00="15/17/18" # Base 00 - Black
+color01="Cd/3f/45" # Base 08 - Red
+color02="9f/ca/56" # Base 0B - Green
+color03="e6/cd/69" # Base 0A - Yellow
+color04="55/b5/db" # Base 0D - Blue
+color05="a0/74/c4" # Base 0E - Magenta
+color06="55/db/be" # Base 0C - Cyan
+color07="d6/d6/d6" # Base 05 - White
+color08="41/53/5B" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="00/ff/00" # Base 07 - Bright White
-color16="00/99/00" # Base 09
-color17="00/55/00" # Base 0F
-color18="00/33/00" # Base 01
-color19="00/55/00" # Base 02
-color20="00/99/00" # Base 04
-color21="00/dd/00" # Base 06
-color_foreground="00/bb/00" # Base 05
-color_background="00/11/00" # Base 00
-color_cursor="00/bb/00" # Base 05
+color15="ff/ff/ff" # Base 07 - Bright White
+color16="db/7b/55" # Base 09
+color17="8a/55/3f" # Base 0F
+color18="8e/c4/3d" # Base 01
+color19="3B/75/8C" # Base 02
+color20="43/a5/d5" # Base 04
+color21="ee/ee/ee" # Base 06
+color_foreground="d6/d6/d6" # Base 05
+color_background="15/17/18" # Base 00
+color_cursor="d6/d6/d6" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,13 +80,13 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg 00bb00 # forground
-  printf $printf_template_custom Ph 001100 # background
-  printf $printf_template_custom Pi 00bb00 # bold color
-  printf $printf_template_custom Pj 005500 # selection color
-  printf $printf_template_custom Pk 00bb00 # selected text color
-  printf $printf_template_custom Pl 00bb00 # cursor
-  printf $printf_template_custom Pm 001100 # cursor text
+  printf $printf_template_custom Pg d6d6d6 # forground
+  printf $printf_template_custom Ph 151718 # background
+  printf $printf_template_custom Pi d6d6d6 # bold color
+  printf $printf_template_custom Pj 3B758C # selection color
+  printf $printf_template_custom Pk d6d6d6 # selected text color
+  printf $printf_template_custom Pl d6d6d6 # cursor
+  printf $printf_template_custom Pm 151718 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background

--- a/scripts/base16-solarflare.sh
+++ b/scripts/base16-solarflare.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# London Tube scheme by Jan T. Sott
+# Solarflare scheme by Chuck Harmston (https://chuck.harmston.ch)
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="23/1f/20" # Base 00 - Black
-color01="ee/2e/24" # Base 08 - Red
-color02="00/85/3e" # Base 0B - Green
-color03="ff/d2/04" # Base 0A - Yellow
-color04="00/9d/dc" # Base 0D - Blue
-color05="98/00/5d" # Base 0E - Magenta
-color06="85/ce/bc" # Base 0C - Cyan
-color07="d9/d8/d8" # Base 05 - White
-color08="73/71/71" # Base 03 - Bright Black
+color00="18/26/2F" # Base 00 - Black
+color01="EF/52/53" # Base 08 - Red
+color02="7C/C8/44" # Base 0B - Green
+color03="E4/B5/1C" # Base 0A - Yellow
+color04="33/B5/E1" # Base 0D - Blue
+color05="A3/63/D5" # Base 0E - Magenta
+color06="52/CB/B0" # Base 0C - Cyan
+color07="A6/AF/B8" # Base 05 - White
+color08="66/75/81" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="f3/86/a1" # Base 09
-color17="b0/61/10" # Base 0F
-color18="1c/3f/95" # Base 01
-color19="5a/57/58" # Base 02
-color20="95/9c/a1" # Base 04
-color21="e7/e7/e8" # Base 06
-color_foreground="d9/d8/d8" # Base 05
-color_background="23/1f/20" # Base 00
-color_cursor="d9/d8/d8" # Base 05
+color15="F5/F7/FA" # Base 07 - Bright White
+color16="E6/6B/2B" # Base 09
+color17="D7/3C/9A" # Base 0F
+color18="22/2E/38" # Base 01
+color19="58/68/75" # Base 02
+color20="85/93/9E" # Base 04
+color21="E8/E9/ED" # Base 06
+color_foreground="A6/AF/B8" # Base 05
+color_background="18/26/2F" # Base 00
+color_cursor="A6/AF/B8" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,13 +80,13 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg d9d8d8 # forground
-  printf $printf_template_custom Ph 231f20 # background
-  printf $printf_template_custom Pi d9d8d8 # bold color
-  printf $printf_template_custom Pj 5a5758 # selection color
-  printf $printf_template_custom Pk d9d8d8 # selected text color
-  printf $printf_template_custom Pl d9d8d8 # cursor
-  printf $printf_template_custom Pm 231f20 # cursor text
+  printf $printf_template_custom Pg A6AFB8 # forground
+  printf $printf_template_custom Ph 18262F # background
+  printf $printf_template_custom Pi A6AFB8 # bold color
+  printf $printf_template_custom Pj 586875 # selection color
+  printf $printf_template_custom Pk A6AFB8 # selected text color
+  printf $printf_template_custom Pl A6AFB8 # cursor
+  printf $printf_template_custom Pm 18262F # cursor text
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background

--- a/scripts/base16-tube.sh
+++ b/scripts/base16-tube.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 # base16-shell (https://github.com/chriskempson/base16-shell)
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
-# Solar Flare scheme by Chuck Harmston (https://chuck.harmston.ch)
+# Tube scheme by Jan T. Sott
 
 # This script doesn't support linux console (use 'vconsole' template instead)
 if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="18/26/2F" # Base 00 - Black
-color01="EF/52/53" # Base 08 - Red
-color02="7C/C8/44" # Base 0B - Green
-color03="E4/B5/1C" # Base 0A - Yellow
-color04="33/B5/E1" # Base 0D - Blue
-color05="A3/63/D5" # Base 0E - Magenta
-color06="52/CB/B0" # Base 0C - Cyan
-color07="A6/AF/B8" # Base 05 - White
-color08="66/75/81" # Base 03 - Bright Black
+color00="23/1f/20" # Base 00 - Black
+color01="ee/2e/24" # Base 08 - Red
+color02="00/85/3e" # Base 0B - Green
+color03="ff/d2/04" # Base 0A - Yellow
+color04="00/9d/dc" # Base 0D - Blue
+color05="98/00/5d" # Base 0E - Magenta
+color06="85/ce/bc" # Base 0C - Cyan
+color07="d9/d8/d8" # Base 05 - White
+color08="73/71/71" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="F5/F7/FA" # Base 07 - Bright White
-color16="E6/6B/2B" # Base 09
-color17="D7/3C/9A" # Base 0F
-color18="22/2E/38" # Base 01
-color19="58/68/75" # Base 02
-color20="85/93/9E" # Base 04
-color21="E8/E9/ED" # Base 06
-color_foreground="A6/AF/B8" # Base 05
-color_background="18/26/2F" # Base 00
-color_cursor="A6/AF/B8" # Base 05
+color15="ff/ff/ff" # Base 07 - Bright White
+color16="f3/86/a1" # Base 09
+color17="b0/61/10" # Base 0F
+color18="1c/3f/95" # Base 01
+color19="5a/57/58" # Base 02
+color20="95/9c/a1" # Base 04
+color21="e7/e7/e8" # Base 06
+color_foreground="d9/d8/d8" # Base 05
+color_background="23/1f/20" # Base 00
+color_cursor="d9/d8/d8" # Base 05
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -80,13 +80,13 @@ printf $printf_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  printf $printf_template_custom Pg A6AFB8 # forground
-  printf $printf_template_custom Ph 18262F # background
-  printf $printf_template_custom Pi A6AFB8 # bold color
-  printf $printf_template_custom Pj 586875 # selection color
-  printf $printf_template_custom Pk A6AFB8 # selected text color
-  printf $printf_template_custom Pl A6AFB8 # cursor
-  printf $printf_template_custom Pm 18262F # cursor text
+  printf $printf_template_custom Pg d9d8d8 # forground
+  printf $printf_template_custom Ph 231f20 # background
+  printf $printf_template_custom Pi d9d8d8 # bold color
+  printf $printf_template_custom Pj 5a5758 # selection color
+  printf $printf_template_custom Pk d9d8d8 # selected text color
+  printf $printf_template_custom Pl d9d8d8 # cursor
+  printf $printf_template_custom Pm 231f20 # cursor text
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background


### PR DESCRIPTION
In
https://github.com/chriskempson/base16-vim/commit/a993579e#diff-e2ad1445e89d0943e05d06fda12f8d4b
these were changed, but the shell repo was not updated so these themes
ended up breaking. This commit corrects this for a few that I spotted.

There seem to be some more changes in the commit I linked above (e.g.
some new themes maybe), but this is probably a good start.