### PR TITLE
/bin/bash -> /usr/bin/env bash

### DIFF
--- a/colortest
+++ b/colortest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 theme=$(dirname $0)/scripts/${1:-base16-default-dark.sh}
 if [ -f $theme ]; then
   # get the color declarations in said theme, assumes there is a block of text that starts with color00= and ends with new line

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ -s $BASH ]; then
     file_name=${BASH_SOURCE[0]}
 elif [ -s $ZSH_NAME ]; then


### PR DESCRIPTION
Needed for OSs without `/bin/bash`, like NixOS. [More info.](https://news.ycombinator.com/item?id=9708908)