### PR TITLE
Fix solarized light

### DIFF
--- a/scripts/base16-solarized-light.sh
+++ b/scripts/base16-solarized-light.sh
@@ -8,31 +8,31 @@ if [ "${TERM%%-*}" = 'linux' ]; then
     return 2>/dev/null || exit 0
 fi
 
-color00="fd/f6/e3" # Base 00 - Black
+color00="00/2b/36" # Base 00 - Black
 color01="dc/32/2f" # Base 08 - Red
 color02="85/99/00" # Base 0B - Green
 color03="b5/89/00" # Base 0A - Yellow
 color04="26/8b/d2" # Base 0D - Blue
 color05="6c/71/c4" # Base 0E - Magenta
 color06="2a/a1/98" # Base 0C - Cyan
-color07="58/6e/75" # Base 05 - White
-color08="83/94/96" # Base 03 - Bright Black
+color07="93/a1/a1" # Base 05 - White
+color08="65/7b/83" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
 color10=$color02 # Base 0B - Bright Green
 color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="00/2b/36" # Base 07 - Bright White
+color15="fd/f6/e3" # Base 07 - Bright White
 color16="cb/4b/16" # Base 09
 color17="d3/36/82" # Base 0F
-color18="ee/e8/d5" # Base 01
-color19="93/a1/a1" # Base 02
-color20="65/7b/83" # Base 04
-color21="07/36/42" # Base 06
-color_foreground="58/6e/75" # Base 05
-color_background="fd/f6/e3" # Base 00
-color_cursor="58/6e/75" # Base 05
+color18="07/36/42" # Base 01
+color19="58/6e/75" # Base 02
+color20="83/94/96" # Base 04
+color21="ee/e8/d5" # Base 06
+color_foreground="58/6e/75" # Base 02
+color_background="fd/f6/e3" # Base 07
+color_cursor="58/6e/75" # Base 02
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through


### PR DESCRIPTION
In eeeff9d solarized.light was removed, and only solarized was present.
It was re-added in 128d28b, but with different color values than before
eeeff9d.

This makes it use the previous values again, which are the same as with
the dark variant, except for fg/bg (and cursor, but that is unused).

This is assumed to be like that with e.g. https://github.com/blueyed/vim-colors-solarized/commit/92f2f994 and having black as "light white" seems to be just wrong.

Before:
![2017-04-25-124558_952x294_scrot](https://cloud.githubusercontent.com/assets/9766/25381760/41da2a6a-29b5-11e7-8a02-55678465420a.png)

After:
![2017-04-25-124602_952x294_scrot](https://cloud.githubusercontent.com/assets/9766/25381766/48d6c832-29b5-11e7-9ef3-e6b6a38ed012.png)

Dark, for comparison:
![2017-04-25-124838_952x294_scrot](https://cloud.githubusercontent.com/assets/9766/25381835/8aac96ba-29b5-11e7-99bc-e9483ec9db37.png)
