### PR TITLE
escape paths properly in profile_helper.[sh|fish]

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -11,12 +11,11 @@
 # TODO: maybe port to $HOME/.config/fish/functions ?
 
 
-
 set SCRIPT_DIR (realpath (dirname (status -f)))
 
 # load currently active theme...
 if test -e ~/.base16_theme
-  eval sh (realpath ~/.base16_theme)
+  eval sh '"'(realpath ~/.base16_theme)'"'
 end
 
 
@@ -24,7 +23,7 @@ end
 for SCRIPT in $SCRIPT_DIR/scripts/*.sh
   set THEME (basename $SCRIPT .sh)
   function $THEME -V SCRIPT -V THEME
-    eval sh $SCRIPT
+    eval sh '"'$SCRIPT'"'
     ln -sf $SCRIPT ~/.base16_theme
     set -x BASE16_THEME $THEME
     echo -e "if !exists('g:colors_name') || g:colors_name != '$THEME'\n  colorscheme $THEME\nendif" >  ~/.vimrc_background

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -9,7 +9,7 @@ script_dir=$(cd $(dirname $file_name) && pwd)
 . $script_dir/realpath/realpath.sh
 
 if [ -f ~/.base16_theme ]; then
-  script_name=$(basename $(realpath ~/.base16_theme) .sh)
+  script_name=$(basename "$(realpath ~/.base16_theme)" .sh)
   echo "export BASE16_THEME=${script_name}"
   echo ". ~/.base16_theme"
 fi


### PR DESCRIPTION
Currently `profile_helper.[sh|fish]` doesn't work properly if placed in a path with special characters like space.
This commit fixes it.