### PR TITLE
[fish] strip "base16-" from env var `BASE16_THEME`

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -26,7 +26,7 @@ for SCRIPT in $SCRIPT_DIR/scripts/*.sh
   function $THEME -V SCRIPT -V THEME
     eval sh $SCRIPT
     ln -sf $SCRIPT ~/.base16_theme
-    set -x BASE16_THEME $THEME
+    set -x BASE16_THEME (string split -m 1 '-' $THEME)[2]
     echo -e "if !exists('g:colors_name') || g:colors_name != '$THEME'\n  colorscheme $THEME\nendif" >  ~/.vimrc_background
   end
 end for


### PR DESCRIPTION
`BASE16_THEME` was wrongly set to `base16-NAME` is my previous diff.
This diff corrects it to `NAME`.