### PR TITLE
Add hooks in profile_helper.sh

### DIFF
--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -22,6 +22,11 @@ _base16()
   ln -fs $script ~/.base16_theme
   export BASE16_THEME=${theme}
   echo -e "if \0041exists('g:colors_name') || g:colors_name != 'base16-$theme'\n  colorscheme base16-$theme\nendif" >| ~/.vimrc_background
+  if [ -n ${BASE16_SHELL_HOOKS:+s} ] && [ -d "${BASE16_SHELL_HOOKS}" ]; then
+    for hook in $BASE16_SHELL_HOOKS/*; do
+      [ -f "$hook" ] && [ -x "$hook" ] && "$hook"
+    done
+  fi
 }
 FUNC
 for script in $script_dir/scripts/base16*.sh; do


### PR DESCRIPTION
With this PR is now possible to add custom hooks in profile helper. Executable scripts placed in $BASE16_SHELL_HOOKS folder will be run when a base16_* theme is used.
This would be very useful if, for example, i want to update my i3wm config every time i change shell theme.

Someone can use this optional feature like this:
- Step  1
In .bashrc
```
...
BASE16_SHELL=$HOME/.config/base16-shell/
BASE16_SHELL_HOOKS=$HOME/.config/base16-shell-hooks/
[ -n "$PS1" ] && [ -s $BASE16_SHELL/profile_helper.sh ] && eval "$($BASE16_SHELL/profile_helper.sh)"
...
```
- Step 2
In ~/.config/base16-shell-hooks/  i can now place as many scripts as i want:
```
#!/bin/bash
##notification
notify-send "$BASE16_THEME" "new base16-shell theme!"
...
```
```
#!/bin/bash
##Update some file,,
echo "$BASE16_THEME" > ~/.my_settings.cfg
...
```
- Step 3
Use a theme:
` ~$ base16_materia`

IMO hooks are very nice. What do you think?