### PR TITLE
Fixes base16-shell to work from inside GNU screen, closing 141 and 142

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -34,11 +34,11 @@ if [ -n "$TMUX" ]; then
   put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
   put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
   put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
-elif [ "${TERM%%-*}" = "screen" ]; then
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  put_template() { printf '\033P\033]4;%d;rgb:%s\033\\' $@; }
-  put_template_var() { printf '\033P\033]%d;rgb:%s\033\\' $@; }
-  put_template_custom() { printf '\033P\033]%s%s\033\\' $@; }
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
 elif [ "${TERM%%-*}" = "linux" ]; then
   put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
   put_template_var() { true; }


### PR DESCRIPTION
Closes 141 and closes 142 by fixing the default.mustache template. 

To pass an escape sequence through GNU screen it requires ESC P ... ESC \ but Xterm requires ESC ] ... BEL so the correct passthrough is ESC P ESC ] ... BEL ESC \

See https://lists.gnu.org/archive/html/screen-users/2006-05/msg00018.html

Also fixed the detection of the new screen TERM values of type "screen.X" e.g. screen.xterm as well as retaining the older detection code.