### PR TITLE
Fix BASE16_THEME environment variable consistency

### DIFF
--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -10,7 +10,7 @@ script_dir=$(cd $(dirname $file_name) && pwd)
 
 if [ -f ~/.base16_theme ]; then
   script_name=$(basename "$(realpath ~/.base16_theme)" .sh)
-  echo "export BASE16_THEME=${script_name}"
+  echo "export BASE16_THEME=${script_name#*-}"
   echo ". ~/.base16_theme"
 fi
 cat <<'FUNC'


### PR DESCRIPTION


Everywhere else sets `BASE16_THEME` to the theme name without the `base16-` prefix.

Issue demonstrated by using `profile_helper.sh`. For example, upon initial load of the shell `BASE16_THEME=base16-gruvbox-dark-hard`. In the same session, setting the theme using the alias results in `BASE16_THEME=gruvbox-dark-hard`.