### PR TITLE
fix syntax errors for `profile_helper.fish`

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -15,7 +15,7 @@ set SCRIPT_DIR (realpath (dirname (status -f)))
 
 # load currently active theme...
 if test -e ~/.base16_theme
-  eval sh '"'(realpath ~/.base16_theme)'"'
+  sh (realpath ~/.base16_theme)
 end
 
 
@@ -23,9 +23,9 @@ end
 for SCRIPT in $SCRIPT_DIR/scripts/*.sh
   set THEME (basename $SCRIPT .sh)
   function $THEME -V SCRIPT -V THEME
-    eval sh '"'$SCRIPT'"'
+    sh $SCRIPT
     ln -sf $SCRIPT ~/.base16_theme
     set -x BASE16_THEME (string split -m 1 '-' $THEME)[2]
     echo -e "if !exists('g:colors_name') || g:colors_name != '$THEME'\n  colorscheme $THEME\nendif" >  ~/.vimrc_background
   end
-end for
+end


### PR DESCRIPTION
This should fix the known syntax errors in the `profile_helper.fish` file for people using the fish shell.