### PR TITLE
Fix iterm bold colors

### DIFF
--- a/scripts/base16-3024.sh
+++ b/scripts/base16-3024.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg a5a2a2 # foreground
   put_template_custom Ph 090300 # background
-  put_template_custom Pi a5a2a2 # bold color
+  put_template_custom Pi f7f7f7 # bold color
   put_template_custom Pj 4a4543 # selection color
   put_template_custom Pk a5a2a2 # selected text color
   put_template_custom Pl a5a2a2 # cursor

--- a/scripts/base16-apathy.sh
+++ b/scripts/base16-apathy.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 81B5AC # foreground
   put_template_custom Ph 031A16 # background
-  put_template_custom Pi 81B5AC # bold color
+  put_template_custom Pi D2E7E4 # bold color
   put_template_custom Pj 184E45 # selection color
   put_template_custom Pk 81B5AC # selected text color
   put_template_custom Pl 81B5AC # cursor

--- a/scripts/base16-ashes.sh
+++ b/scripts/base16-ashes.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg C7CCD1 # foreground
   put_template_custom Ph 1C2023 # background
-  put_template_custom Pi C7CCD1 # bold color
+  put_template_custom Pi F3F4F5 # bold color
   put_template_custom Pj 565E65 # selection color
   put_template_custom Pk C7CCD1 # selected text color
   put_template_custom Pl C7CCD1 # cursor

--- a/scripts/base16-atelier-cave-light.sh
+++ b/scripts/base16-atelier-cave-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 585260 # foreground
   put_template_custom Ph efecf4 # background
-  put_template_custom Pi 585260 # bold color
+  put_template_custom Pi 19171c # bold color
   put_template_custom Pj 8b8792 # selection color
   put_template_custom Pk 585260 # selected text color
   put_template_custom Pl 585260 # cursor

--- a/scripts/base16-atelier-cave.sh
+++ b/scripts/base16-atelier-cave.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 8b8792 # foreground
   put_template_custom Ph 19171c # background
-  put_template_custom Pi 8b8792 # bold color
+  put_template_custom Pi efecf4 # bold color
   put_template_custom Pj 585260 # selection color
   put_template_custom Pk 8b8792 # selected text color
   put_template_custom Pl 8b8792 # cursor

--- a/scripts/base16-atelier-dune-light.sh
+++ b/scripts/base16-atelier-dune-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 6e6b5e # foreground
   put_template_custom Ph fefbec # background
-  put_template_custom Pi 6e6b5e # bold color
+  put_template_custom Pi 20201d # bold color
   put_template_custom Pj a6a28c # selection color
   put_template_custom Pk 6e6b5e # selected text color
   put_template_custom Pl 6e6b5e # cursor

--- a/scripts/base16-atelier-dune.sh
+++ b/scripts/base16-atelier-dune.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg a6a28c # foreground
   put_template_custom Ph 20201d # background
-  put_template_custom Pi a6a28c # bold color
+  put_template_custom Pi fefbec # bold color
   put_template_custom Pj 6e6b5e # selection color
   put_template_custom Pk a6a28c # selected text color
   put_template_custom Pl a6a28c # cursor

--- a/scripts/base16-atelier-estuary-light.sh
+++ b/scripts/base16-atelier-estuary-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 5f5e4e # foreground
   put_template_custom Ph f4f3ec # background
-  put_template_custom Pi 5f5e4e # bold color
+  put_template_custom Pi 22221b # bold color
   put_template_custom Pj 929181 # selection color
   put_template_custom Pk 5f5e4e # selected text color
   put_template_custom Pl 5f5e4e # cursor

--- a/scripts/base16-atelier-estuary.sh
+++ b/scripts/base16-atelier-estuary.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 929181 # foreground
   put_template_custom Ph 22221b # background
-  put_template_custom Pi 929181 # bold color
+  put_template_custom Pi f4f3ec # bold color
   put_template_custom Pj 5f5e4e # selection color
   put_template_custom Pk 929181 # selected text color
   put_template_custom Pl 929181 # cursor

--- a/scripts/base16-atelier-forest-light.sh
+++ b/scripts/base16-atelier-forest-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 68615e # foreground
   put_template_custom Ph f1efee # background
-  put_template_custom Pi 68615e # bold color
+  put_template_custom Pi 1b1918 # bold color
   put_template_custom Pj a8a19f # selection color
   put_template_custom Pk 68615e # selected text color
   put_template_custom Pl 68615e # cursor

--- a/scripts/base16-atelier-forest.sh
+++ b/scripts/base16-atelier-forest.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg a8a19f # foreground
   put_template_custom Ph 1b1918 # background
-  put_template_custom Pi a8a19f # bold color
+  put_template_custom Pi f1efee # bold color
   put_template_custom Pj 68615e # selection color
   put_template_custom Pk a8a19f # selected text color
   put_template_custom Pl a8a19f # cursor

--- a/scripts/base16-atelier-heath-light.sh
+++ b/scripts/base16-atelier-heath-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 695d69 # foreground
   put_template_custom Ph f7f3f7 # background
-  put_template_custom Pi 695d69 # bold color
+  put_template_custom Pi 1b181b # bold color
   put_template_custom Pj ab9bab # selection color
   put_template_custom Pk 695d69 # selected text color
   put_template_custom Pl 695d69 # cursor

--- a/scripts/base16-atelier-heath.sh
+++ b/scripts/base16-atelier-heath.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg ab9bab # foreground
   put_template_custom Ph 1b181b # background
-  put_template_custom Pi ab9bab # bold color
+  put_template_custom Pi f7f3f7 # bold color
   put_template_custom Pj 695d69 # selection color
   put_template_custom Pk ab9bab # selected text color
   put_template_custom Pl ab9bab # cursor

--- a/scripts/base16-atelier-lakeside-light.sh
+++ b/scripts/base16-atelier-lakeside-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 516d7b # foreground
   put_template_custom Ph ebf8ff # background
-  put_template_custom Pi 516d7b # bold color
+  put_template_custom Pi 161b1d # bold color
   put_template_custom Pj 7ea2b4 # selection color
   put_template_custom Pk 516d7b # selected text color
   put_template_custom Pl 516d7b # cursor

--- a/scripts/base16-atelier-lakeside.sh
+++ b/scripts/base16-atelier-lakeside.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 7ea2b4 # foreground
   put_template_custom Ph 161b1d # background
-  put_template_custom Pi 7ea2b4 # bold color
+  put_template_custom Pi ebf8ff # bold color
   put_template_custom Pj 516d7b # selection color
   put_template_custom Pk 7ea2b4 # selected text color
   put_template_custom Pl 7ea2b4 # cursor

--- a/scripts/base16-atelier-plateau-light.sh
+++ b/scripts/base16-atelier-plateau-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 585050 # foreground
   put_template_custom Ph f4ecec # background
-  put_template_custom Pi 585050 # bold color
+  put_template_custom Pi 1b1818 # bold color
   put_template_custom Pj 8a8585 # selection color
   put_template_custom Pk 585050 # selected text color
   put_template_custom Pl 585050 # cursor

--- a/scripts/base16-atelier-plateau.sh
+++ b/scripts/base16-atelier-plateau.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 8a8585 # foreground
   put_template_custom Ph 1b1818 # background
-  put_template_custom Pi 8a8585 # bold color
+  put_template_custom Pi f4ecec # bold color
   put_template_custom Pj 585050 # selection color
   put_template_custom Pk 8a8585 # selected text color
   put_template_custom Pl 8a8585 # cursor

--- a/scripts/base16-atelier-savanna-light.sh
+++ b/scripts/base16-atelier-savanna-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 526057 # foreground
   put_template_custom Ph ecf4ee # background
-  put_template_custom Pi 526057 # bold color
+  put_template_custom Pi 171c19 # bold color
   put_template_custom Pj 87928a # selection color
   put_template_custom Pk 526057 # selected text color
   put_template_custom Pl 526057 # cursor

--- a/scripts/base16-atelier-savanna.sh
+++ b/scripts/base16-atelier-savanna.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 87928a # foreground
   put_template_custom Ph 171c19 # background
-  put_template_custom Pi 87928a # bold color
+  put_template_custom Pi ecf4ee # bold color
   put_template_custom Pj 526057 # selection color
   put_template_custom Pk 87928a # selected text color
   put_template_custom Pl 87928a # cursor

--- a/scripts/base16-atelier-seaside-light.sh
+++ b/scripts/base16-atelier-seaside-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 5e6e5e # foreground
   put_template_custom Ph f4fbf4 # background
-  put_template_custom Pi 5e6e5e # bold color
+  put_template_custom Pi 131513 # bold color
   put_template_custom Pj 8ca68c # selection color
   put_template_custom Pk 5e6e5e # selected text color
   put_template_custom Pl 5e6e5e # cursor

--- a/scripts/base16-atelier-seaside.sh
+++ b/scripts/base16-atelier-seaside.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 8ca68c # foreground
   put_template_custom Ph 131513 # background
-  put_template_custom Pi 8ca68c # bold color
+  put_template_custom Pi f4fbf4 # bold color
   put_template_custom Pj 5e6e5e # selection color
   put_template_custom Pk 8ca68c # selected text color
   put_template_custom Pl 8ca68c # cursor

--- a/scripts/base16-atelier-sulphurpool-light.sh
+++ b/scripts/base16-atelier-sulphurpool-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 5e6687 # foreground
   put_template_custom Ph f5f7ff # background
-  put_template_custom Pi 5e6687 # bold color
+  put_template_custom Pi 202746 # bold color
   put_template_custom Pj 979db4 # selection color
   put_template_custom Pk 5e6687 # selected text color
   put_template_custom Pl 5e6687 # cursor

--- a/scripts/base16-atelier-sulphurpool.sh
+++ b/scripts/base16-atelier-sulphurpool.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 979db4 # foreground
   put_template_custom Ph 202746 # background
-  put_template_custom Pi 979db4 # bold color
+  put_template_custom Pi f5f7ff # bold color
   put_template_custom Pj 5e6687 # selection color
   put_template_custom Pk 979db4 # selected text color
   put_template_custom Pl 979db4 # cursor

--- a/scripts/base16-bespin.sh
+++ b/scripts/base16-bespin.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 8a8986 # foreground
   put_template_custom Ph 28211c # background
-  put_template_custom Pi 8a8986 # bold color
+  put_template_custom Pi baae9e # bold color
   put_template_custom Pj 5e5d5c # selection color
   put_template_custom Pk 8a8986 # selected text color
   put_template_custom Pl 8a8986 # cursor

--- a/scripts/base16-brewer.sh
+++ b/scripts/base16-brewer.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg b7b8b9 # foreground
   put_template_custom Ph 0c0d0e # background
-  put_template_custom Pi b7b8b9 # bold color
+  put_template_custom Pi fcfdfe # bold color
   put_template_custom Pj 515253 # selection color
   put_template_custom Pk b7b8b9 # selected text color
   put_template_custom Pl b7b8b9 # cursor

--- a/scripts/base16-bright.sh
+++ b/scripts/base16-bright.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg e0e0e0 # foreground
   put_template_custom Ph 000000 # background
-  put_template_custom Pi e0e0e0 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 505050 # selection color
   put_template_custom Pk e0e0e0 # selected text color
   put_template_custom Pl e0e0e0 # cursor

--- a/scripts/base16-brogrammer.sh
+++ b/scripts/base16-brogrammer.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 4e5ab7 # foreground
   put_template_custom Ph 1f1f1f # background
-  put_template_custom Pi 4e5ab7 # bold color
+  put_template_custom Pi d6dbe5 # bold color
   put_template_custom Pj 2dc55e # selection color
   put_template_custom Pk 4e5ab7 # selected text color
   put_template_custom Pl 4e5ab7 # cursor

--- a/scripts/base16-brushtrees-dark.sh
+++ b/scripts/base16-brushtrees-dark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg B0C5C8 # foreground
   put_template_custom Ph 485867 # background
-  put_template_custom Pi B0C5C8 # bold color
+  put_template_custom Pi E3EFEF # bold color
   put_template_custom Pj 6D828E # selection color
   put_template_custom Pk B0C5C8 # selected text color
   put_template_custom Pl B0C5C8 # cursor

--- a/scripts/base16-brushtrees.sh
+++ b/scripts/base16-brushtrees.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 6D828E # foreground
   put_template_custom Ph E3EFEF # background
-  put_template_custom Pi 6D828E # bold color
+  put_template_custom Pi 485867 # bold color
   put_template_custom Pj B0C5C8 # selection color
   put_template_custom Pk 6D828E # selected text color
   put_template_custom Pl 6D828E # cursor

--- a/scripts/base16-chalk.sh
+++ b/scripts/base16-chalk.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d0d0d0 # foreground
   put_template_custom Ph 151515 # background
-  put_template_custom Pi d0d0d0 # bold color
+  put_template_custom Pi f5f5f5 # bold color
   put_template_custom Pj 303030 # selection color
   put_template_custom Pk d0d0d0 # selected text color
   put_template_custom Pl d0d0d0 # cursor

--- a/scripts/base16-circus.sh
+++ b/scripts/base16-circus.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg a7a7a7 # foreground
   put_template_custom Ph 191919 # background
-  put_template_custom Pi a7a7a7 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 303030 # selection color
   put_template_custom Pk a7a7a7 # selected text color
   put_template_custom Pl a7a7a7 # cursor

--- a/scripts/base16-classic-dark.sh
+++ b/scripts/base16-classic-dark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg D0D0D0 # foreground
   put_template_custom Ph 151515 # background
-  put_template_custom Pi D0D0D0 # bold color
+  put_template_custom Pi F5F5F5 # bold color
   put_template_custom Pj 303030 # selection color
   put_template_custom Pk D0D0D0 # selected text color
   put_template_custom Pl D0D0D0 # cursor

--- a/scripts/base16-classic-light.sh
+++ b/scripts/base16-classic-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 303030 # foreground
   put_template_custom Ph F5F5F5 # background
-  put_template_custom Pi 303030 # bold color
+  put_template_custom Pi 151515 # bold color
   put_template_custom Pj D0D0D0 # selection color
   put_template_custom Pk 303030 # selected text color
   put_template_custom Pl 303030 # cursor

--- a/scripts/base16-codeschool.sh
+++ b/scripts/base16-codeschool.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 9ea7a6 # foreground
   put_template_custom Ph 232c31 # background
-  put_template_custom Pi 9ea7a6 # bold color
+  put_template_custom Pi b5d8f6 # bold color
   put_template_custom Pj 2a343a # selection color
   put_template_custom Pk 9ea7a6 # selected text color
   put_template_custom Pl 9ea7a6 # cursor

--- a/scripts/base16-cupcake.sh
+++ b/scripts/base16-cupcake.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 8b8198 # foreground
   put_template_custom Ph fbf1f2 # background
-  put_template_custom Pi 8b8198 # bold color
+  put_template_custom Pi 585062 # bold color
   put_template_custom Pj d8d5dd # selection color
   put_template_custom Pk 8b8198 # selected text color
   put_template_custom Pl 8b8198 # cursor

--- a/scripts/base16-cupertino.sh
+++ b/scripts/base16-cupertino.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 404040 # foreground
   put_template_custom Ph ffffff # background
-  put_template_custom Pi 404040 # bold color
+  put_template_custom Pi 5e5e5e # bold color
   put_template_custom Pj c0c0c0 # selection color
   put_template_custom Pk 404040 # selected text color
   put_template_custom Pl 404040 # cursor

--- a/scripts/base16-darktooth.sh
+++ b/scripts/base16-darktooth.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg A89984 # foreground
   put_template_custom Ph 1D2021 # background
-  put_template_custom Pi A89984 # bold color
+  put_template_custom Pi FDF4C1 # bold color
   put_template_custom Pj 504945 # selection color
   put_template_custom Pk A89984 # selected text color
   put_template_custom Pl A89984 # cursor

--- a/scripts/base16-default-dark.sh
+++ b/scripts/base16-default-dark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d8d8d8 # foreground
   put_template_custom Ph 181818 # background
-  put_template_custom Pi d8d8d8 # bold color
+  put_template_custom Pi f8f8f8 # bold color
   put_template_custom Pj 383838 # selection color
   put_template_custom Pk d8d8d8 # selected text color
   put_template_custom Pl d8d8d8 # cursor

--- a/scripts/base16-default-light.sh
+++ b/scripts/base16-default-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 383838 # foreground
   put_template_custom Ph f8f8f8 # background
-  put_template_custom Pi 383838 # bold color
+  put_template_custom Pi 181818 # bold color
   put_template_custom Pj d8d8d8 # selection color
   put_template_custom Pk 383838 # selected text color
   put_template_custom Pl 383838 # cursor

--- a/scripts/base16-dracula.sh
+++ b/scripts/base16-dracula.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg e9e9f4 # foreground
   put_template_custom Ph 282936 # background
-  put_template_custom Pi e9e9f4 # bold color
+  put_template_custom Pi f7f7fb # bold color
   put_template_custom Pj 626483 # selection color
   put_template_custom Pk e9e9f4 # selected text color
   put_template_custom Pl e9e9f4 # cursor

--- a/scripts/base16-eighties.sh
+++ b/scripts/base16-eighties.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d3d0c8 # foreground
   put_template_custom Ph 2d2d2d # background
-  put_template_custom Pi d3d0c8 # bold color
+  put_template_custom Pi f2f0ec # bold color
   put_template_custom Pj 515151 # selection color
   put_template_custom Pk d3d0c8 # selected text color
   put_template_custom Pl d3d0c8 # cursor

--- a/scripts/base16-embers.sh
+++ b/scripts/base16-embers.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg A39A90 # foreground
   put_template_custom Ph 16130F # background
-  put_template_custom Pi A39A90 # bold color
+  put_template_custom Pi DBD6D1 # bold color
   put_template_custom Pj 433B32 # selection color
   put_template_custom Pk A39A90 # selected text color
   put_template_custom Pl A39A90 # cursor

--- a/scripts/base16-flat.sh
+++ b/scripts/base16-flat.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg e0e0e0 # foreground
   put_template_custom Ph 2C3E50 # background
-  put_template_custom Pi e0e0e0 # bold color
+  put_template_custom Pi ECF0F1 # bold color
   put_template_custom Pj 7F8C8D # selection color
   put_template_custom Pk e0e0e0 # selected text color
   put_template_custom Pl e0e0e0 # cursor

--- a/scripts/base16-github.sh
+++ b/scripts/base16-github.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 333333 # foreground
   put_template_custom Ph ffffff # background
-  put_template_custom Pi 333333 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj c8c8fa # selection color
   put_template_custom Pk 333333 # selected text color
   put_template_custom Pl 333333 # cursor

--- a/scripts/base16-google-dark.sh
+++ b/scripts/base16-google-dark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg c5c8c6 # foreground
   put_template_custom Ph 1d1f21 # background
-  put_template_custom Pi c5c8c6 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 373b41 # selection color
   put_template_custom Pk c5c8c6 # selected text color
   put_template_custom Pl c5c8c6 # cursor

--- a/scripts/base16-google-light.sh
+++ b/scripts/base16-google-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 373b41 # foreground
   put_template_custom Ph ffffff # background
-  put_template_custom Pi 373b41 # bold color
+  put_template_custom Pi 1d1f21 # bold color
   put_template_custom Pj c5c8c6 # selection color
   put_template_custom Pk 373b41 # selected text color
   put_template_custom Pl 373b41 # cursor

--- a/scripts/base16-grayscale-dark.sh
+++ b/scripts/base16-grayscale-dark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg b9b9b9 # foreground
   put_template_custom Ph 101010 # background
-  put_template_custom Pi b9b9b9 # bold color
+  put_template_custom Pi f7f7f7 # bold color
   put_template_custom Pj 464646 # selection color
   put_template_custom Pk b9b9b9 # selected text color
   put_template_custom Pl b9b9b9 # cursor

--- a/scripts/base16-grayscale-light.sh
+++ b/scripts/base16-grayscale-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 464646 # foreground
   put_template_custom Ph f7f7f7 # background
-  put_template_custom Pi 464646 # bold color
+  put_template_custom Pi 101010 # bold color
   put_template_custom Pj b9b9b9 # selection color
   put_template_custom Pk 464646 # selected text color
   put_template_custom Pl 464646 # cursor

--- a/scripts/base16-greenscreen.sh
+++ b/scripts/base16-greenscreen.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 00bb00 # foreground
   put_template_custom Ph 001100 # background
-  put_template_custom Pi 00bb00 # bold color
+  put_template_custom Pi 00ff00 # bold color
   put_template_custom Pj 005500 # selection color
   put_template_custom Pk 00bb00 # selected text color
   put_template_custom Pl 00bb00 # cursor

--- a/scripts/base16-gruvbox-dark-hard.sh
+++ b/scripts/base16-gruvbox-dark-hard.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d5c4a1 # foreground
   put_template_custom Ph 1d2021 # background
-  put_template_custom Pi d5c4a1 # bold color
+  put_template_custom Pi fbf1c7 # bold color
   put_template_custom Pj 504945 # selection color
   put_template_custom Pk d5c4a1 # selected text color
   put_template_custom Pl d5c4a1 # cursor

--- a/scripts/base16-gruvbox-dark-medium.sh
+++ b/scripts/base16-gruvbox-dark-medium.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d5c4a1 # foreground
   put_template_custom Ph 282828 # background
-  put_template_custom Pi d5c4a1 # bold color
+  put_template_custom Pi fbf1c7 # bold color
   put_template_custom Pj 504945 # selection color
   put_template_custom Pk d5c4a1 # selected text color
   put_template_custom Pl d5c4a1 # cursor

--- a/scripts/base16-gruvbox-dark-pale.sh
+++ b/scripts/base16-gruvbox-dark-pale.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg dab997 # foreground
   put_template_custom Ph 262626 # background
-  put_template_custom Pi dab997 # bold color
+  put_template_custom Pi ebdbb2 # bold color
   put_template_custom Pj 4e4e4e # selection color
   put_template_custom Pk dab997 # selected text color
   put_template_custom Pl dab997 # cursor

--- a/scripts/base16-gruvbox-dark-soft.sh
+++ b/scripts/base16-gruvbox-dark-soft.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d5c4a1 # foreground
   put_template_custom Ph 32302f # background
-  put_template_custom Pi d5c4a1 # bold color
+  put_template_custom Pi fbf1c7 # bold color
   put_template_custom Pj 504945 # selection color
   put_template_custom Pk d5c4a1 # selected text color
   put_template_custom Pl d5c4a1 # cursor

--- a/scripts/base16-gruvbox-light-hard.sh
+++ b/scripts/base16-gruvbox-light-hard.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 504945 # foreground
   put_template_custom Ph f9f5d7 # background
-  put_template_custom Pi 504945 # bold color
+  put_template_custom Pi 282828 # bold color
   put_template_custom Pj d5c4a1 # selection color
   put_template_custom Pk 504945 # selected text color
   put_template_custom Pl 504945 # cursor

--- a/scripts/base16-gruvbox-light-medium.sh
+++ b/scripts/base16-gruvbox-light-medium.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 504945 # foreground
   put_template_custom Ph fbf1c7 # background
-  put_template_custom Pi 504945 # bold color
+  put_template_custom Pi 282828 # bold color
   put_template_custom Pj d5c4a1 # selection color
   put_template_custom Pk 504945 # selected text color
   put_template_custom Pl 504945 # cursor

--- a/scripts/base16-gruvbox-light-soft.sh
+++ b/scripts/base16-gruvbox-light-soft.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 504945 # foreground
   put_template_custom Ph f2e5bc # background
-  put_template_custom Pi 504945 # bold color
+  put_template_custom Pi 282828 # bold color
   put_template_custom Pj d5c4a1 # selection color
   put_template_custom Pk 504945 # selected text color
   put_template_custom Pl 504945 # cursor

--- a/scripts/base16-harmonic-dark.sh
+++ b/scripts/base16-harmonic-dark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg cbd6e2 # foreground
   put_template_custom Ph 0b1c2c # background
-  put_template_custom Pi cbd6e2 # bold color
+  put_template_custom Pi f7f9fb # bold color
   put_template_custom Pj 405c79 # selection color
   put_template_custom Pk cbd6e2 # selected text color
   put_template_custom Pl cbd6e2 # cursor

--- a/scripts/base16-harmonic-light.sh
+++ b/scripts/base16-harmonic-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 405c79 # foreground
   put_template_custom Ph f7f9fb # background
-  put_template_custom Pi 405c79 # bold color
+  put_template_custom Pi 0b1c2c # bold color
   put_template_custom Pj cbd6e2 # selection color
   put_template_custom Pk 405c79 # selected text color
   put_template_custom Pl 405c79 # cursor

--- a/scripts/base16-hopscotch.sh
+++ b/scripts/base16-hopscotch.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg b9b5b8 # foreground
   put_template_custom Ph 322931 # background
-  put_template_custom Pi b9b5b8 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 5c545b # selection color
   put_template_custom Pk b9b5b8 # selected text color
   put_template_custom Pl b9b5b8 # cursor

--- a/scripts/base16-icy.sh
+++ b/scripts/base16-icy.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 095b67 # foreground
   put_template_custom Ph 021012 # background
-  put_template_custom Pi 095b67 # bold color
+  put_template_custom Pi 109cb0 # bold color
   put_template_custom Pj 041f23 # selection color
   put_template_custom Pk 095b67 # selected text color
   put_template_custom Pl 095b67 # cursor

--- a/scripts/base16-irblack.sh
+++ b/scripts/base16-irblack.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg b5b3aa # foreground
   put_template_custom Ph 000000 # background
-  put_template_custom Pi b5b3aa # bold color
+  put_template_custom Pi fdfbee # bold color
   put_template_custom Pj 484844 # selection color
   put_template_custom Pk b5b3aa # selected text color
   put_template_custom Pl b5b3aa # cursor

--- a/scripts/base16-isotope.sh
+++ b/scripts/base16-isotope.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d0d0d0 # foreground
   put_template_custom Ph 000000 # background
-  put_template_custom Pi d0d0d0 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 606060 # selection color
   put_template_custom Pk d0d0d0 # selected text color
   put_template_custom Pl d0d0d0 # cursor

--- a/scripts/base16-macintosh.sh
+++ b/scripts/base16-macintosh.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg c0c0c0 # foreground
   put_template_custom Ph 000000 # background
-  put_template_custom Pi c0c0c0 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 404040 # selection color
   put_template_custom Pk c0c0c0 # selected text color
   put_template_custom Pl c0c0c0 # cursor

--- a/scripts/base16-marrakesh.sh
+++ b/scripts/base16-marrakesh.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 948e48 # foreground
   put_template_custom Ph 201602 # background
-  put_template_custom Pi 948e48 # bold color
+  put_template_custom Pi faf0a5 # bold color
   put_template_custom Pj 5f5b17 # selection color
   put_template_custom Pk 948e48 # selected text color
   put_template_custom Pl 948e48 # cursor

--- a/scripts/base16-materia.sh
+++ b/scripts/base16-materia.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg CDD3DE # foreground
   put_template_custom Ph 263238 # background
-  put_template_custom Pi CDD3DE # bold color
+  put_template_custom Pi FFFFFF # bold color
   put_template_custom Pj 37474F # selection color
   put_template_custom Pk CDD3DE # selected text color
   put_template_custom Pl CDD3DE # cursor

--- a/scripts/base16-material-darker.sh
+++ b/scripts/base16-material-darker.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg EEFFFF # foreground
   put_template_custom Ph 212121 # background
-  put_template_custom Pi EEFFFF # bold color
+  put_template_custom Pi FFFFFF # bold color
   put_template_custom Pj 353535 # selection color
   put_template_custom Pk EEFFFF # selected text color
   put_template_custom Pl EEFFFF # cursor

--- a/scripts/base16-material-lighter.sh
+++ b/scripts/base16-material-lighter.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 80CBC4 # foreground
   put_template_custom Ph FAFAFA # background
-  put_template_custom Pi 80CBC4 # bold color
+  put_template_custom Pi FFFFFF # bold color
   put_template_custom Pj CCEAE7 # selection color
   put_template_custom Pk 80CBC4 # selected text color
   put_template_custom Pl 80CBC4 # cursor

--- a/scripts/base16-material-palenight.sh
+++ b/scripts/base16-material-palenight.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 959DCB # foreground
   put_template_custom Ph 292D3E # background
-  put_template_custom Pi 959DCB # bold color
+  put_template_custom Pi FFFFFF # bold color
   put_template_custom Pj 32374D # selection color
   put_template_custom Pk 959DCB # selected text color
   put_template_custom Pl 959DCB # cursor

--- a/scripts/base16-material-vivid.sh
+++ b/scripts/base16-material-vivid.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg B0BEC5 # foreground
   put_template_custom Ph 263238 # background
-  put_template_custom Pi B0BEC5 # bold color
+  put_template_custom Pi ECEFF1 # bold color
   put_template_custom Pj 455A64 # selection color
   put_template_custom Pk B0BEC5 # selected text color
   put_template_custom Pl B0BEC5 # cursor

--- a/scripts/base16-material.sh
+++ b/scripts/base16-material.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg EEFFFF # foreground
   put_template_custom Ph 263238 # background
-  put_template_custom Pi EEFFFF # bold color
+  put_template_custom Pi FFFFFF # bold color
   put_template_custom Pj 314549 # selection color
   put_template_custom Pk EEFFFF # selected text color
   put_template_custom Pl EEFFFF # cursor

--- a/scripts/base16-mellow-purple.sh
+++ b/scripts/base16-mellow-purple.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg ffeeff # foreground
   put_template_custom Ph 1e0528 # background
-  put_template_custom Pi ffeeff # bold color
+  put_template_custom Pi f8c0ff # bold color
   put_template_custom Pj 331354 # selection color
   put_template_custom Pk ffeeff # selected text color
   put_template_custom Pl ffeeff # cursor

--- a/scripts/base16-mexico-light.sh
+++ b/scripts/base16-mexico-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 383838 # foreground
   put_template_custom Ph f8f8f8 # background
-  put_template_custom Pi 383838 # bold color
+  put_template_custom Pi 181818 # bold color
   put_template_custom Pj d8d8d8 # selection color
   put_template_custom Pk 383838 # selected text color
   put_template_custom Pl 383838 # cursor

--- a/scripts/base16-mocha.sh
+++ b/scripts/base16-mocha.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d0c8c6 # foreground
   put_template_custom Ph 3B3228 # background
-  put_template_custom Pi d0c8c6 # bold color
+  put_template_custom Pi f5eeeb # bold color
   put_template_custom Pj 645240 # selection color
   put_template_custom Pk d0c8c6 # selected text color
   put_template_custom Pl d0c8c6 # cursor

--- a/scripts/base16-monokai.sh
+++ b/scripts/base16-monokai.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg f8f8f2 # foreground
   put_template_custom Ph 272822 # background
-  put_template_custom Pi f8f8f2 # bold color
+  put_template_custom Pi f9f8f5 # bold color
   put_template_custom Pj 49483e # selection color
   put_template_custom Pk f8f8f2 # selected text color
   put_template_custom Pl f8f8f2 # cursor

--- a/scripts/base16-nord.sh
+++ b/scripts/base16-nord.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg E5E9F0 # foreground
   put_template_custom Ph 2E3440 # background
-  put_template_custom Pi E5E9F0 # bold color
+  put_template_custom Pi 8FBCBB # bold color
   put_template_custom Pj 434C5E # selection color
   put_template_custom Pk E5E9F0 # selected text color
   put_template_custom Pl E5E9F0 # cursor

--- a/scripts/base16-ocean.sh
+++ b/scripts/base16-ocean.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg c0c5ce # foreground
   put_template_custom Ph 2b303b # background
-  put_template_custom Pi c0c5ce # bold color
+  put_template_custom Pi eff1f5 # bold color
   put_template_custom Pj 4f5b66 # selection color
   put_template_custom Pk c0c5ce # selected text color
   put_template_custom Pl c0c5ce # cursor

--- a/scripts/base16-oceanicnext.sh
+++ b/scripts/base16-oceanicnext.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg C0C5CE # foreground
   put_template_custom Ph 1B2B34 # background
-  put_template_custom Pi C0C5CE # bold color
+  put_template_custom Pi D8DEE9 # bold color
   put_template_custom Pj 4F5B66 # selection color
   put_template_custom Pk C0C5CE # selected text color
   put_template_custom Pl C0C5CE # cursor

--- a/scripts/base16-one-light.sh
+++ b/scripts/base16-one-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 383a42 # foreground
   put_template_custom Ph fafafa # background
-  put_template_custom Pi 383a42 # bold color
+  put_template_custom Pi 090a0b # bold color
   put_template_custom Pj e5e5e6 # selection color
   put_template_custom Pk 383a42 # selected text color
   put_template_custom Pl 383a42 # cursor

--- a/scripts/base16-onedark.sh
+++ b/scripts/base16-onedark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg abb2bf # foreground
   put_template_custom Ph 282c34 # background
-  put_template_custom Pi abb2bf # bold color
+  put_template_custom Pi c8ccd4 # bold color
   put_template_custom Pj 3e4451 # selection color
   put_template_custom Pk abb2bf # selected text color
   put_template_custom Pl abb2bf # cursor

--- a/scripts/base16-outrun-dark.sh
+++ b/scripts/base16-outrun-dark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg D0D0FA # foreground
   put_template_custom Ph 00002A # background
-  put_template_custom Pi D0D0FA # bold color
+  put_template_custom Pi F5F5FF # bold color
   put_template_custom Pj 30305A # selection color
   put_template_custom Pk D0D0FA # selected text color
   put_template_custom Pl D0D0FA # cursor

--- a/scripts/base16-paraiso.sh
+++ b/scripts/base16-paraiso.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg a39e9b # foreground
   put_template_custom Ph 2f1e2e # background
-  put_template_custom Pi a39e9b # bold color
+  put_template_custom Pi e7e9db # bold color
   put_template_custom Pj 4f424c # selection color
   put_template_custom Pk a39e9b # selected text color
   put_template_custom Pl a39e9b # cursor

--- a/scripts/base16-phd.sh
+++ b/scripts/base16-phd.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg b8bbc2 # foreground
   put_template_custom Ph 061229 # background
-  put_template_custom Pi b8bbc2 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 4d5666 # selection color
   put_template_custom Pk b8bbc2 # selected text color
   put_template_custom Pl b8bbc2 # cursor

--- a/scripts/base16-pico.sh
+++ b/scripts/base16-pico.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 5f574f # foreground
   put_template_custom Ph 000000 # background
-  put_template_custom Pi 5f574f # bold color
+  put_template_custom Pi fff1e8 # bold color
   put_template_custom Pj 7e2553 # selection color
   put_template_custom Pk 5f574f # selected text color
   put_template_custom Pl 5f574f # cursor

--- a/scripts/base16-pop.sh
+++ b/scripts/base16-pop.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d0d0d0 # foreground
   put_template_custom Ph 000000 # background
-  put_template_custom Pi d0d0d0 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 303030 # selection color
   put_template_custom Pk d0d0d0 # selected text color
   put_template_custom Pl d0d0d0 # cursor

--- a/scripts/base16-porple.sh
+++ b/scripts/base16-porple.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d8d8d8 # foreground
   put_template_custom Ph 292c36 # background
-  put_template_custom Pi d8d8d8 # bold color
+  put_template_custom Pi f8f8f8 # bold color
   put_template_custom Pj 474160 # selection color
   put_template_custom Pk d8d8d8 # selected text color
   put_template_custom Pl d8d8d8 # cursor

--- a/scripts/base16-railscasts.sh
+++ b/scripts/base16-railscasts.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg e6e1dc # foreground
   put_template_custom Ph 2b2b2b # background
-  put_template_custom Pi e6e1dc # bold color
+  put_template_custom Pi f9f7f3 # bold color
   put_template_custom Pj 3a4055 # selection color
   put_template_custom Pk e6e1dc # selected text color
   put_template_custom Pl e6e1dc # cursor

--- a/scripts/base16-rebecca.sh
+++ b/scripts/base16-rebecca.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg f1eff8 # foreground
   put_template_custom Ph 292a44 # background
-  put_template_custom Pi f1eff8 # bold color
+  put_template_custom Pi 53495d # bold color
   put_template_custom Pj 383a62 # selection color
   put_template_custom Pk f1eff8 # selected text color
   put_template_custom Pl f1eff8 # cursor

--- a/scripts/base16-seti.sh
+++ b/scripts/base16-seti.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d6d6d6 # foreground
   put_template_custom Ph 151718 # background
-  put_template_custom Pi d6d6d6 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 3B758C # selection color
   put_template_custom Pk d6d6d6 # selected text color
   put_template_custom Pl d6d6d6 # cursor

--- a/scripts/base16-shapeshifter.sh
+++ b/scripts/base16-shapeshifter.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 102015 # foreground
   put_template_custom Ph f9f9f9 # background
-  put_template_custom Pi 102015 # bold color
+  put_template_custom Pi 000000 # bold color
   put_template_custom Pj ababab # selection color
   put_template_custom Pk 102015 # selected text color
   put_template_custom Pl 102015 # cursor

--- a/scripts/base16-snazzy.sh
+++ b/scripts/base16-snazzy.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg eff0eb # foreground
   put_template_custom Ph 1e1f29 # background
-  put_template_custom Pi eff0eb # bold color
+  put_template_custom Pi f1f1f0 # bold color
   put_template_custom Pj 4a4b53 # selection color
   put_template_custom Pk eff0eb # selected text color
   put_template_custom Pl eff0eb # cursor

--- a/scripts/base16-solarflare.sh
+++ b/scripts/base16-solarflare.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg A6AFB8 # foreground
   put_template_custom Ph 18262F # background
-  put_template_custom Pi A6AFB8 # bold color
+  put_template_custom Pi F5F7FA # bold color
   put_template_custom Pj 586875 # selection color
   put_template_custom Pk A6AFB8 # selected text color
   put_template_custom Pl A6AFB8 # cursor

--- a/scripts/base16-solarized-dark.sh
+++ b/scripts/base16-solarized-dark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 93a1a1 # foreground
   put_template_custom Ph 002b36 # background
-  put_template_custom Pi 93a1a1 # bold color
+  put_template_custom Pi fdf6e3 # bold color
   put_template_custom Pj 586e75 # selection color
   put_template_custom Pk 93a1a1 # selected text color
   put_template_custom Pl 93a1a1 # cursor

--- a/scripts/base16-solarized-light.sh
+++ b/scripts/base16-solarized-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 586e75 # foreground
   put_template_custom Ph fdf6e3 # background
-  put_template_custom Pi 586e75 # bold color
+  put_template_custom Pi 002b36 # bold color
   put_template_custom Pj 93a1a1 # selection color
   put_template_custom Pk 586e75 # selected text color
   put_template_custom Pl 586e75 # cursor

--- a/scripts/base16-spacemacs.sh
+++ b/scripts/base16-spacemacs.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg a3a3a3 # foreground
   put_template_custom Ph 1f2022 # background
-  put_template_custom Pi a3a3a3 # bold color
+  put_template_custom Pi f8f8f8 # bold color
   put_template_custom Pj 444155 # selection color
   put_template_custom Pk a3a3a3 # selected text color
   put_template_custom Pl a3a3a3 # cursor

--- a/scripts/base16-summerfruit-dark.sh
+++ b/scripts/base16-summerfruit-dark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg D0D0D0 # foreground
   put_template_custom Ph 151515 # background
-  put_template_custom Pi D0D0D0 # bold color
+  put_template_custom Pi FFFFFF # bold color
   put_template_custom Pj 303030 # selection color
   put_template_custom Pk D0D0D0 # selected text color
   put_template_custom Pl D0D0D0 # cursor

--- a/scripts/base16-summerfruit-light.sh
+++ b/scripts/base16-summerfruit-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 101010 # foreground
   put_template_custom Ph FFFFFF # background
-  put_template_custom Pi 101010 # bold color
+  put_template_custom Pi 202020 # bold color
   put_template_custom Pj D0D0D0 # selection color
   put_template_custom Pk 101010 # selected text color
   put_template_custom Pl 101010 # cursor

--- a/scripts/base16-tomorrow-night.sh
+++ b/scripts/base16-tomorrow-night.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg c5c8c6 # foreground
   put_template_custom Ph 1d1f21 # background
-  put_template_custom Pi c5c8c6 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 373b41 # selection color
   put_template_custom Pk c5c8c6 # selected text color
   put_template_custom Pl c5c8c6 # cursor

--- a/scripts/base16-tomorrow.sh
+++ b/scripts/base16-tomorrow.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 4d4d4c # foreground
   put_template_custom Ph ffffff # background
-  put_template_custom Pi 4d4d4c # bold color
+  put_template_custom Pi 1d1f21 # bold color
   put_template_custom Pj d6d6d6 # selection color
   put_template_custom Pk 4d4d4c # selected text color
   put_template_custom Pl 4d4d4c # cursor

--- a/scripts/base16-tube.sh
+++ b/scripts/base16-tube.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg d9d8d8 # foreground
   put_template_custom Ph 231f20 # background
-  put_template_custom Pi d9d8d8 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 5a5758 # selection color
   put_template_custom Pk d9d8d8 # selected text color
   put_template_custom Pl d9d8d8 # cursor

--- a/scripts/base16-twilight.sh
+++ b/scripts/base16-twilight.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg a7a7a7 # foreground
   put_template_custom Ph 1e1e1e # background
-  put_template_custom Pi a7a7a7 # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 464b50 # selection color
   put_template_custom Pk a7a7a7 # selected text color
   put_template_custom Pl a7a7a7 # cursor

--- a/scripts/base16-unikitty-dark.sh
+++ b/scripts/base16-unikitty-dark.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg bcbabe # foreground
   put_template_custom Ph 2e2a31 # background
-  put_template_custom Pi bcbabe # bold color
+  put_template_custom Pi f5f4f7 # bold color
   put_template_custom Pj 666369 # selection color
   put_template_custom Pk bcbabe # selected text color
   put_template_custom Pl bcbabe # cursor

--- a/scripts/base16-unikitty-light.sh
+++ b/scripts/base16-unikitty-light.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 6c696e # foreground
   put_template_custom Ph ffffff # background
-  put_template_custom Pi 6c696e # bold color
+  put_template_custom Pi 322d34 # bold color
   put_template_custom Pj c4c3c5 # selection color
   put_template_custom Pk 6c696e # selected text color
   put_template_custom Pl 6c696e # cursor

--- a/scripts/base16-woodland.sh
+++ b/scripts/base16-woodland.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg cabcb1 # foreground
   put_template_custom Ph 231e18 # background
-  put_template_custom Pi cabcb1 # bold color
+  put_template_custom Pi e4d4c8 # bold color
   put_template_custom Pj 48413a # selection color
   put_template_custom Pk cabcb1 # selected text color
   put_template_custom Pl cabcb1 # cursor

--- a/scripts/base16-xcode-dusk.sh
+++ b/scripts/base16-xcode-dusk.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg 939599 # foreground
   put_template_custom Ph 282B35 # background
-  put_template_custom Pi 939599 # bold color
+  put_template_custom Pi BEBFC2 # bold color
   put_template_custom Pj 53555D # selection color
   put_template_custom Pk 939599 # selected text color
   put_template_custom Pl 939599 # cursor

--- a/scripts/base16-zenburn.sh
+++ b/scripts/base16-zenburn.sh
@@ -80,7 +80,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
   put_template_custom Pg dcdccc # foreground
   put_template_custom Ph 3f3f3f # background
-  put_template_custom Pi dcdccc # bold color
+  put_template_custom Pi ffffff # bold color
   put_template_custom Pj 606060 # selection color
   put_template_custom Pk dcdccc # selected text color
   put_template_custom Pl dcdccc # cursor


### PR DESCRIPTION
Fixes #29. Not sure why the 'default text' bold color was set to the foreground color as it's correctly set in the other color list