### PR TITLE
Source theme before displaying colours in colortest

### DIFF
--- a/colortest
+++ b/colortest
@@ -2,6 +2,7 @@
 theme=$(dirname $0)/scripts/${1:-base16-default-dark.sh}
 if [ -f $theme ]; then
   # get the color declarations in said theme, assumes there is a block of text that starts with color00= and ends with new line
+  source $theme
   eval $(awk '/^color00=/,/^$/ {print}' $theme | sed 's/#.*//')
 else
   printf "No theme file %s found\n" $theme
@@ -60,3 +61,6 @@ for padded_value in `seq -w 0 21`; do
   foreground=$(printf "\x1b[38;5;${non_padded_value}m$color_variable")
   printf "%s %s %s %-30s %s\x1b[0m\n" $foreground $base16_color_name $current_color_label ${ansi_label:-""} $block
 done;
+if [ $# -eq 1 ]; then
+    printf "To restore current theme, source ~/.base16_theme or reopen your terminal\n"
+fi


### PR DESCRIPTION
Resolves #153

It requires the user to reopen their terminal to restore the old theme (or source ~/.base16_theme) but if this was done automatically the theme would only be shown for a fraction of a second.