### PR TITLE
Fix loop function ending.

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -28,4 +28,4 @@ for SCRIPT in $SCRIPT_DIR/scripts/*.sh
     set -x BASE16_THEME (string split -m 1 '-' $THEME)[2]
     echo -e "if !exists('g:colors_name') || g:colors_name != '$THEME'\n  colorscheme $THEME\nendif" >  ~/.vimrc_background
   end
-end for
+end


### PR DESCRIPTION
There is an error on the shell initialization:

```sh
~/.config/base16-shell//profile_helper.fish (line 31): 'end' does not take arguments. Did you forget a ';'?
end for
    ^
from sourcing file ~/.config/base16-shell//profile_helper.fish
        called on line 4 of file ~/.config/fish/config.fish

from sourcing file ~/.config/fish/config.fish
        called during startup

source: Error while reading file '/Users/thomas/.config/base16-shell//profile_helper.fish'
```

This one liner fixes it.

Environment:
```sh
❯ fish -v
fish, version 3.0.0
```