### PR TITLE
fixed error when sourcing profile_helper.fish

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -28,4 +28,4 @@ for SCRIPT in $SCRIPT_DIR/scripts/*.sh
     set -x BASE16_THEME (string split -m 1 '-' $THEME)[2]
     echo -e "if !exists('g:colors_name') || g:colors_name != '$THEME'\n  colorscheme $THEME\nendif" >  ~/.vimrc_background
   end
-end for
+end


### PR DESCRIPTION
There was a mistake in `profile_helper.fish`. The correct syntax for ending a for loop is just `end` and not `end for`.

This might've been a recent change by the developers of fish.