### PR TITLE
Fix syntax for profile_helper.fish

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -5,7 +5,9 @@
 # [usage] can be added to ~/.config/fish/config.fish like so:
 #
 # if status --is-interactive
-#    source $HOME/.config/base16-shell/profile_helper.fish
+#   if test -d $HOME/.config/base16-shell
+#     source "$HOME/.config/base16-shell/profile_helper.fish"
+#   end
 # end
 #
 # TODO: maybe port to $HOME/.config/fish/functions ?
@@ -28,4 +30,4 @@ for SCRIPT in $SCRIPT_DIR/scripts/*.sh
     set -x BASE16_THEME (string split -m 1 '-' $THEME)[2]
     echo -e "if !exists('g:colors_name') || g:colors_name != '$THEME'\n  colorscheme $THEME\nendif" >  ~/.vimrc_background
   end
-end for
+end


### PR DESCRIPTION
Loops using `for` ends in an `end` instead of `end for`. (As can be seen in documentation https://fishshell.com/docs/current/tutorial.html#tut_loops). As of now, this is broken otherwise.

Also, update the usage instructions in config.fish to test for the directory before sourcing.