### PR TITLE
Update profile_helper.fish

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -28,4 +28,4 @@ for SCRIPT in $SCRIPT_DIR/scripts/*.sh
     set -x BASE16_THEME (string split -m 1 '-' $THEME)[2]
     echo -e "if !exists('g:colors_name') || g:colors_name != '$THEME'\n  colorscheme $THEME\nendif" >  ~/.vimrc_background
   end
-end for
+end


### PR DESCRIPTION
According to the [fish documentation](https://fishshell.com/docs/current/tutorial.html#tut_loops), no 'for' is needed to end a loop, just and 'end' statement.

I found out while installing on OS X and commenting out the 'for' fixed the issue.