### PR TITLE
Quote variables to prevent word splitting

### DIFF
--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-if [ -s $BASH ]; then
+if [ -s "$BASH" ]; then
     file_name=${BASH_SOURCE[0]}
-elif [ -s $ZSH_NAME ]; then
+elif [ -s "$ZSH_NAME" ]; then
     file_name=${(%):-%x}
 fi
-script_dir=$(cd $(dirname $file_name) && pwd)
+script_dir=$(cd "$(dirname "$file_name")" && pwd)
 
-. $script_dir/realpath/realpath.sh
+. "$script_dir/realpath/realpath.sh"
 
 if [ -f ~/.base16_theme ]; then
   script_name=$(basename "$(realpath ~/.base16_theme)" .sh)
@@ -29,7 +29,7 @@ _base16()
   fi
 }
 FUNC
-for script in $script_dir/scripts/base16*.sh; do
+for script in "$script_dir"/scripts/base16*.sh; do
   script_name=${script##*/}
   script_name=${script_name%.sh}
   theme=${script_name#*-}


### PR DESCRIPTION
Had some issues using this with a user name with spaces, so I ran the `profile_helper.sh` through [shellcheck](https://github.com/koalaman/shellcheck) and discovered that some of the variables need to be quoted.

I am using Cygwin in this case however, this problem can occur with any users that have a space in their user name.

# Environment 
OS: Windows
Shell: zsh
Terminal: cygwin