### PR TITLE
Fix Nord colorscheme to use colors as dictated by Nord project

### DIFF
--- a/scripts/base16-nord.sh
+++ b/scripts/base16-nord.sh
@@ -3,13 +3,13 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Nord scheme by arcticicestudio
 
-color00="2E/34/40" # Base 00 - Black
-color01="88/C0/D0" # Base 08 - Red
-color02="BF/61/6A" # Base 0B - Green
-color03="5E/81/AC" # Base 0A - Yellow
-color04="EB/CB/8B" # Base 0D - Blue
-color05="A3/BE/8C" # Base 0E - Magenta
-color06="D0/87/70" # Base 0C - Cyan
+color00="3B/42/52" # Base 00 - Black
+color01="BF/61/6A" # Base 08 - Red
+color02="A3/BE/8C" # Base 0B - Green
+color03="EB/CB/8B" # Base 0A - Yellow
+color04="81/A1/C1" # Base 0D - Blue
+color05="B4/8E/AD" # Base 0E - Magenta
+color06="88/C0/D0" # Base 0C - Cyan
 color07="E5/E9/F0" # Base 05 - White
 color08="4C/56/6A" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
@@ -18,14 +18,14 @@ color11=$color03 # Base 0A - Bright Yellow
 color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
-color15="8F/BC/BB" # Base 07 - Bright White
+color15="EC/EF/F4" # Base 07 - Bright White
 color16="81/A1/C1" # Base 09
 color17="B4/8E/AD" # Base 0F
 color18="3B/42/52" # Base 01
 color19="43/4C/5E" # Base 02
 color20="D8/DE/E9" # Base 04
 color21="EC/EF/F4" # Base 06
-color_foreground="E5/E9/F0" # Base 05
+color_foreground="D8/DE/E9" # Base 05
 color_background="2E/34/40" # Base 00
 
 if [ -n "$TMUX" ]; then


### PR DESCRIPTION
As previously noted in #172, the colors in the Base16 Nord colorscheme do not conform to the color definitions as laid out by the [Nord project](https://github.com/arcticicestudio/nord). The most egregious offense is that green is red and red is blue, rendering the output of e.g. `git diff` rather unintuitive.

This PR sets all colors to the correct values; easily testable by running `colortest base16-nord.sh`.