### PR TITLE
Correct base16-nord color mappings

### DIFF
--- a/scripts/base16-nord.sh
+++ b/scripts/base16-nord.sh
@@ -4,12 +4,12 @@
 # Nord scheme by arcticicestudio
 
 color00="2E/34/40" # Base 00 - Black
-color01="88/C0/D0" # Base 08 - Red
-color02="BF/61/6A" # Base 0B - Green
-color03="5E/81/AC" # Base 0A - Yellow
-color04="EB/CB/8B" # Base 0D - Blue
-color05="A3/BE/8C" # Base 0E - Magenta
-color06="D0/87/70" # Base 0C - Cyan
+color01="BF/61/6A" # Base 08 - Red
+color02="A3/BE/8C" # Base 0B - Green
+color03="EB/CB/8B" # Base 0A - Yellow
+color04="81/A1/C1" # Base 0D - Blue
+color05="B4/8E/AD" # Base 0E - Magenta
+color06="99/C0/D0" # Base 0C - Cyan
 color07="E5/E9/F0" # Base 05 - White
 color08="4C/56/6A" # Base 03 - Bright Black
 color09=$color01 # Base 08 - Bright Red
@@ -19,8 +19,8 @@ color12=$color04 # Base 0D - Bright Blue
 color13=$color05 # Base 0E - Bright Magenta
 color14=$color06 # Base 0C - Bright Cyan
 color15="8F/BC/BB" # Base 07 - Bright White
-color16="81/A1/C1" # Base 09
-color17="B4/8E/AD" # Base 0F
+color16="D0/87/70" # Base 09
+color17="5E/81/AC" # Base 0F
 color18="3B/42/52" # Base 01
 color19="43/4C/5E" # Base 02
 color20="D8/DE/E9" # Base 04


### PR DESCRIPTION
Corrects the base16-nord.sh script colors, so that green is green, red is red, etc. Based on a similar fix to [ada-lovecraft/base16-nord-scheme](https://github.com/ada-lovecraft/base16-nord-scheme/pull/2/files).

## BEFORE:
<img width="421" alt="base16-shell-nord-before" src="https://user-images.githubusercontent.com/2079548/68091318-0dcf7e00-fe33-11e9-988f-b5903f1997df.png">

## AFTER:
<img width="420" alt="base16-shell-nord-after" src="https://user-images.githubusercontent.com/2079548/68091315-09a36080-fe33-11e9-9b40-07d185e2ab98.png">

