### PR TITLE
Add a default variant in addition to the original 256 one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Base16 Shell
-See the [Base16 repository](https://github.com/chriskempson/base16) for more information.  
+See the [Base16 repository](https://github.com/chriskempson/base16) for more information.
 These scripts were built with [Base16 Builder PHP](https://github.com/chriskempson/base16-builder-php).
 
 A shell script to change your shell's default ANSI colors but most importantly, colors 17 to 21 of your shell's 256 colorspace (if supported by your terminal). This script makes it possible to honor the original bright colors of your shell (e.g. bright green is still green and so on) while providing additional base16 colors to applications such as Vim.
@@ -8,7 +8,7 @@ A shell script to change your shell's default ANSI colors but most importantly, 
 
 ## Use Cases
 
-* You want to use a `*.256.*` variant of a Terminal theme designed to honor the original bright colors.
+* You want to use a `*.256.*` variant of a Terminal theme designed to honor the original bright colors (default 16 colors also implemented).
 * You prefer to use a script instead of a terminal emulator theme to color your shell.
 * You use this script to have different colorschemes appear on different SSH sessions.
 
@@ -27,6 +27,8 @@ Add following lines to `~/.bashrc` or `~/.zshrc`:
 ```bash
 # Base16 Shell
 BASE16_SHELL="$HOME/.config/base16-shell/"
+# Uncomment the following line if you want the default 16 colors template
+#export BASE16_SHELL_DEFAULT_VARIANT="1"
 [ -n "$PS1" ] && \
     [ -s "$BASE16_SHELL/profile_helper.sh" ] && \
         eval "$("$BASE16_SHELL/profile_helper.sh")"
@@ -42,6 +44,8 @@ Add following lines to `~/.config/fish/config.fish`:
 # Base16 Shell
 if status --is-interactive
     set BASE16_SHELL "$HOME/.config/base16-shell/"
+    # Uncomment the following line if you want the default 16 colors template
+    #set -x BASE16_SHELL_DEFAULT_VARIANT "1"
     source "$BASE16_SHELL/profile_helper.fish"
 end
 ```
@@ -53,13 +57,14 @@ Open a new shell and type `base16` followed by a tab to perform tab completion.
 the profile_helper will update a ~/.vimrc_background file that will have your current the colorscheme, you just need to source this file in your vimrc: i.e. (remove the base16colorspace line if not needed)
 
     if filereadable(expand("~/.vimrc_background"))
+      " Comment the following line if you are using the default 16 colors template
       let base16colorspace=256
       source ~/.vimrc_background
     endif
 
 ## Troubleshooting
 
-Run the included **colortest** script and check that your colour assignments appear correct. If your teminal does not support the setting of colours in within the 256 colorspace (e.g. Apple Terminal), colours 17 to 21 will appear blue.
+Run the included **colortest** script and check that your colour assignments appear correct. If your teminal does not support the setting of colours in within the 256 colorspace (e.g. Apple Terminal), colours 17 to 21 will appear blue. In this situation, you can use the default 16 colors variant (see the [Configuration](#Configuration) section above).
 
 ![setting 256 colourspace not supported](https://raw.github.com/chriskempson/base16-shell/master/setting-256-colourspace-not-supported.png)
 

--- a/colortest
+++ b/colortest
@@ -3,7 +3,7 @@ theme=$(dirname $0)/scripts/${1:-base16-default-dark.sh}
 if [ -f $theme ]; then
   # get the color declarations in said theme, assumes there is a block of text that starts with color00= and ends with new line
   source $theme
-  eval $(awk '/^color00=/,/^$/ {print}' $theme | sed 's/#.*//')
+  eval $(awk "/^color00=/,/^$/ {print}" $theme | sed -E 's/#.*//;s/^(if.*|else|fi;)$/;\1/')
 else
   printf "No theme file %s found\n" $theme
 fi;
@@ -42,21 +42,25 @@ colors=(
   base0E
   base0C
   base07
-  base09
-  base0F
-  base01
-  base02
-  base04
-  base06
 )
-for padded_value in `seq -w 0 21`; do
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  colors+=(
+    base09
+    base0F
+    base01
+    base02
+    base04
+    base06
+  )
+fi
+for padded_value in `seq -w 0 $((${#colors[@]}-1))`; do
   color_variable="color${padded_value}"
   eval current_color=\$${color_variable}
   current_color=$(echo ${current_color//\//} | tr '[:lower:]' '[:upper:]') # get rid of slashes, and uppercase
   non_padded_value=$((10#$padded_value))
   base16_color_name=${colors[$non_padded_value]}
   current_color_label=${current_color:-unknown}
-  ansi_label=${ansi_mappings[$non_padded_value]} 
+  ansi_label=${ansi_mappings[$non_padded_value]}
   block=$(printf "\x1b[48;5;${non_padded_value}m___________________________")
   foreground=$(printf "\x1b[38;5;${non_padded_value}m$color_variable")
   printf "%s %s %s %-30s %s\x1b[0m\n" $foreground $base16_color_name $current_color_label ${ansi_label:-""} $block

--- a/scripts/base16-3024.sh
+++ b/scripts/base16-3024.sh
@@ -11,20 +11,31 @@ color04="01/a0/e4" # Base 0D - Blue
 color05="a1/6a/94" # Base 0E - Magenta
 color06="b5/e4/f4" # Base 0C - Cyan
 color07="a5/a2/a2" # Base 05 - White
-color08="5c/58/55" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f7/f7" # Base 07 - Bright White
-color16="e8/bb/d0" # Base 09
-color17="cd/ab/53" # Base 0F
-color18="3a/34/32" # Base 01
-color19="4a/45/43" # Base 02
-color20="80/7d/7c" # Base 04
-color21="d6/d5/d4" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="5c/58/55" # Base 03 - Bright Black
+  color09="e8/bb/d0" # Base 09
+  color10="3a/34/32" # Base 01
+  color11="4a/45/43" # Base 02
+  color12="80/7d/7c" # Base 04
+  color13="d6/d5/d4" # Base 06
+  color14="cd/ab/53" # Base 0F
+  color15="f7/f7/f7" # Base 07 - Bright White
+else
+  color08="5c/58/55" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f7/f7/f7" # Base 07 - Bright White
+  color16="e8/bb/d0" # Base 09
+  color17="cd/ab/53" # Base 0F
+  color18="3a/34/32" # Base 01
+  color19="4a/45/43" # Base 02
+  color20="80/7d/7c" # Base 04
+  color21="d6/d5/d4" # Base 06
+fi;
 color_foreground="a5/a2/a2" # Base 05
 color_background="09/03/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-apathy.sh
+++ b/scripts/base16-apathy.sh
@@ -11,20 +11,31 @@ color04="96/88/3E" # Base 0D - Blue
 color05="4C/96/3E" # Base 0E - Magenta
 color06="96/3E/4C" # Base 0C - Cyan
 color07="81/B5/AC" # Base 05 - White
-color08="2B/68/5E" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="D2/E7/E4" # Base 07 - Bright White
-color16="3E/79/96" # Base 09
-color17="3E/96/5B" # Base 0F
-color18="0B/34/2D" # Base 01
-color19="18/4E/45" # Base 02
-color20="5F/9C/92" # Base 04
-color21="A7/CE/C8" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="2B/68/5E" # Base 03 - Bright Black
+  color09="3E/79/96" # Base 09
+  color10="0B/34/2D" # Base 01
+  color11="18/4E/45" # Base 02
+  color12="5F/9C/92" # Base 04
+  color13="A7/CE/C8" # Base 06
+  color14="3E/96/5B" # Base 0F
+  color15="D2/E7/E4" # Base 07 - Bright White
+else
+  color08="2B/68/5E" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="D2/E7/E4" # Base 07 - Bright White
+  color16="3E/79/96" # Base 09
+  color17="3E/96/5B" # Base 0F
+  color18="0B/34/2D" # Base 01
+  color19="18/4E/45" # Base 02
+  color20="5F/9C/92" # Base 04
+  color21="A7/CE/C8" # Base 06
+fi;
 color_foreground="81/B5/AC" # Base 05
 color_background="03/1A/16" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-ashes.sh
+++ b/scripts/base16-ashes.sh
@@ -11,20 +11,31 @@ color04="AE/95/C7" # Base 0D - Blue
 color05="C7/95/AE" # Base 0E - Magenta
 color06="95/AE/C7" # Base 0C - Cyan
 color07="C7/CC/D1" # Base 05 - White
-color08="74/7C/84" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="F3/F4/F5" # Base 07 - Bright White
-color16="C7/C7/95" # Base 09
-color17="C7/95/95" # Base 0F
-color18="39/3F/45" # Base 01
-color19="56/5E/65" # Base 02
-color20="AD/B3/BA" # Base 04
-color21="DF/E2/E5" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="74/7C/84" # Base 03 - Bright Black
+  color09="C7/C7/95" # Base 09
+  color10="39/3F/45" # Base 01
+  color11="56/5E/65" # Base 02
+  color12="AD/B3/BA" # Base 04
+  color13="DF/E2/E5" # Base 06
+  color14="C7/95/95" # Base 0F
+  color15="F3/F4/F5" # Base 07 - Bright White
+else
+  color08="74/7C/84" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="F3/F4/F5" # Base 07 - Bright White
+  color16="C7/C7/95" # Base 09
+  color17="C7/95/95" # Base 0F
+  color18="39/3F/45" # Base 01
+  color19="56/5E/65" # Base 02
+  color20="AD/B3/BA" # Base 04
+  color21="DF/E2/E5" # Base 06
+fi;
 color_foreground="C7/CC/D1" # Base 05
 color_background="1C/20/23" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-cave-light.sh
+++ b/scripts/base16-atelier-cave-light.sh
@@ -11,20 +11,31 @@ color04="57/6d/db" # Base 0D - Blue
 color05="95/5a/e7" # Base 0E - Magenta
 color06="39/8b/c6" # Base 0C - Cyan
 color07="58/52/60" # Base 05 - White
-color08="7e/78/87" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="19/17/1c" # Base 07 - Bright White
-color16="aa/57/3c" # Base 09
-color17="bf/40/bf" # Base 0F
-color18="e2/df/e7" # Base 01
-color19="8b/87/92" # Base 02
-color20="65/5f/6d" # Base 04
-color21="26/23/2a" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="7e/78/87" # Base 03 - Bright Black
+  color09="aa/57/3c" # Base 09
+  color10="e2/df/e7" # Base 01
+  color11="8b/87/92" # Base 02
+  color12="65/5f/6d" # Base 04
+  color13="26/23/2a" # Base 06
+  color14="bf/40/bf" # Base 0F
+  color15="19/17/1c" # Base 07 - Bright White
+else
+  color08="7e/78/87" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="19/17/1c" # Base 07 - Bright White
+  color16="aa/57/3c" # Base 09
+  color17="bf/40/bf" # Base 0F
+  color18="e2/df/e7" # Base 01
+  color19="8b/87/92" # Base 02
+  color20="65/5f/6d" # Base 04
+  color21="26/23/2a" # Base 06
+fi;
 color_foreground="58/52/60" # Base 05
 color_background="ef/ec/f4" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-cave.sh
+++ b/scripts/base16-atelier-cave.sh
@@ -11,20 +11,31 @@ color04="57/6d/db" # Base 0D - Blue
 color05="95/5a/e7" # Base 0E - Magenta
 color06="39/8b/c6" # Base 0C - Cyan
 color07="8b/87/92" # Base 05 - White
-color08="65/5f/6d" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ef/ec/f4" # Base 07 - Bright White
-color16="aa/57/3c" # Base 09
-color17="bf/40/bf" # Base 0F
-color18="26/23/2a" # Base 01
-color19="58/52/60" # Base 02
-color20="7e/78/87" # Base 04
-color21="e2/df/e7" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="65/5f/6d" # Base 03 - Bright Black
+  color09="aa/57/3c" # Base 09
+  color10="26/23/2a" # Base 01
+  color11="58/52/60" # Base 02
+  color12="7e/78/87" # Base 04
+  color13="e2/df/e7" # Base 06
+  color14="bf/40/bf" # Base 0F
+  color15="ef/ec/f4" # Base 07 - Bright White
+else
+  color08="65/5f/6d" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ef/ec/f4" # Base 07 - Bright White
+  color16="aa/57/3c" # Base 09
+  color17="bf/40/bf" # Base 0F
+  color18="26/23/2a" # Base 01
+  color19="58/52/60" # Base 02
+  color20="7e/78/87" # Base 04
+  color21="e2/df/e7" # Base 06
+fi;
 color_foreground="8b/87/92" # Base 05
 color_background="19/17/1c" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-dune-light.sh
+++ b/scripts/base16-atelier-dune-light.sh
@@ -11,20 +11,31 @@ color04="66/84/e1" # Base 0D - Blue
 color05="b8/54/d4" # Base 0E - Magenta
 color06="1f/ad/83" # Base 0C - Cyan
 color07="6e/6b/5e" # Base 05 - White
-color08="99/95/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="20/20/1d" # Base 07 - Bright White
-color16="b6/56/11" # Base 09
-color17="d4/35/52" # Base 0F
-color18="e8/e4/cf" # Base 01
-color19="a6/a2/8c" # Base 02
-color20="7d/7a/68" # Base 04
-color21="29/28/24" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="99/95/80" # Base 03 - Bright Black
+  color09="b6/56/11" # Base 09
+  color10="e8/e4/cf" # Base 01
+  color11="a6/a2/8c" # Base 02
+  color12="7d/7a/68" # Base 04
+  color13="29/28/24" # Base 06
+  color14="d4/35/52" # Base 0F
+  color15="20/20/1d" # Base 07 - Bright White
+else
+  color08="99/95/80" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="20/20/1d" # Base 07 - Bright White
+  color16="b6/56/11" # Base 09
+  color17="d4/35/52" # Base 0F
+  color18="e8/e4/cf" # Base 01
+  color19="a6/a2/8c" # Base 02
+  color20="7d/7a/68" # Base 04
+  color21="29/28/24" # Base 06
+fi;
 color_foreground="6e/6b/5e" # Base 05
 color_background="fe/fb/ec" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-dune.sh
+++ b/scripts/base16-atelier-dune.sh
@@ -11,20 +11,31 @@ color04="66/84/e1" # Base 0D - Blue
 color05="b8/54/d4" # Base 0E - Magenta
 color06="1f/ad/83" # Base 0C - Cyan
 color07="a6/a2/8c" # Base 05 - White
-color08="7d/7a/68" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fe/fb/ec" # Base 07 - Bright White
-color16="b6/56/11" # Base 09
-color17="d4/35/52" # Base 0F
-color18="29/28/24" # Base 01
-color19="6e/6b/5e" # Base 02
-color20="99/95/80" # Base 04
-color21="e8/e4/cf" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="7d/7a/68" # Base 03 - Bright Black
+  color09="b6/56/11" # Base 09
+  color10="29/28/24" # Base 01
+  color11="6e/6b/5e" # Base 02
+  color12="99/95/80" # Base 04
+  color13="e8/e4/cf" # Base 06
+  color14="d4/35/52" # Base 0F
+  color15="fe/fb/ec" # Base 07 - Bright White
+else
+  color08="7d/7a/68" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="fe/fb/ec" # Base 07 - Bright White
+  color16="b6/56/11" # Base 09
+  color17="d4/35/52" # Base 0F
+  color18="29/28/24" # Base 01
+  color19="6e/6b/5e" # Base 02
+  color20="99/95/80" # Base 04
+  color21="e8/e4/cf" # Base 06
+fi;
 color_foreground="a6/a2/8c" # Base 05
 color_background="20/20/1d" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-estuary-light.sh
+++ b/scripts/base16-atelier-estuary-light.sh
@@ -11,20 +11,31 @@ color04="36/a1/66" # Base 0D - Blue
 color05="5f/91/82" # Base 0E - Magenta
 color06="5b/9d/48" # Base 0C - Cyan
 color07="5f/5e/4e" # Base 05 - White
-color08="87/85/73" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="22/22/1b" # Base 07 - Bright White
-color16="ae/73/13" # Base 09
-color17="9d/6c/7c" # Base 0F
-color18="e7/e6/df" # Base 01
-color19="92/91/81" # Base 02
-color20="6c/6b/5a" # Base 04
-color21="30/2f/27" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="87/85/73" # Base 03 - Bright Black
+  color09="ae/73/13" # Base 09
+  color10="e7/e6/df" # Base 01
+  color11="92/91/81" # Base 02
+  color12="6c/6b/5a" # Base 04
+  color13="30/2f/27" # Base 06
+  color14="9d/6c/7c" # Base 0F
+  color15="22/22/1b" # Base 07 - Bright White
+else
+  color08="87/85/73" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="22/22/1b" # Base 07 - Bright White
+  color16="ae/73/13" # Base 09
+  color17="9d/6c/7c" # Base 0F
+  color18="e7/e6/df" # Base 01
+  color19="92/91/81" # Base 02
+  color20="6c/6b/5a" # Base 04
+  color21="30/2f/27" # Base 06
+fi;
 color_foreground="5f/5e/4e" # Base 05
 color_background="f4/f3/ec" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-estuary.sh
+++ b/scripts/base16-atelier-estuary.sh
@@ -11,20 +11,31 @@ color04="36/a1/66" # Base 0D - Blue
 color05="5f/91/82" # Base 0E - Magenta
 color06="5b/9d/48" # Base 0C - Cyan
 color07="92/91/81" # Base 05 - White
-color08="6c/6b/5a" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f4/f3/ec" # Base 07 - Bright White
-color16="ae/73/13" # Base 09
-color17="9d/6c/7c" # Base 0F
-color18="30/2f/27" # Base 01
-color19="5f/5e/4e" # Base 02
-color20="87/85/73" # Base 04
-color21="e7/e6/df" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="6c/6b/5a" # Base 03 - Bright Black
+  color09="ae/73/13" # Base 09
+  color10="30/2f/27" # Base 01
+  color11="5f/5e/4e" # Base 02
+  color12="87/85/73" # Base 04
+  color13="e7/e6/df" # Base 06
+  color14="9d/6c/7c" # Base 0F
+  color15="f4/f3/ec" # Base 07 - Bright White
+else
+  color08="6c/6b/5a" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f4/f3/ec" # Base 07 - Bright White
+  color16="ae/73/13" # Base 09
+  color17="9d/6c/7c" # Base 0F
+  color18="30/2f/27" # Base 01
+  color19="5f/5e/4e" # Base 02
+  color20="87/85/73" # Base 04
+  color21="e7/e6/df" # Base 06
+fi;
 color_foreground="92/91/81" # Base 05
 color_background="22/22/1b" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-forest-light.sh
+++ b/scripts/base16-atelier-forest-light.sh
@@ -11,20 +11,31 @@ color04="40/7e/e7" # Base 0D - Blue
 color05="66/66/ea" # Base 0E - Magenta
 color06="3d/97/b8" # Base 0C - Cyan
 color07="68/61/5e" # Base 05 - White
-color08="9c/94/91" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="1b/19/18" # Base 07 - Bright White
-color16="df/53/20" # Base 09
-color17="c3/3f/f3" # Base 0F
-color18="e6/e2/e0" # Base 01
-color19="a8/a1/9f" # Base 02
-color20="76/6e/6b" # Base 04
-color21="2c/24/21" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="9c/94/91" # Base 03 - Bright Black
+  color09="df/53/20" # Base 09
+  color10="e6/e2/e0" # Base 01
+  color11="a8/a1/9f" # Base 02
+  color12="76/6e/6b" # Base 04
+  color13="2c/24/21" # Base 06
+  color14="c3/3f/f3" # Base 0F
+  color15="1b/19/18" # Base 07 - Bright White
+else
+  color08="9c/94/91" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="1b/19/18" # Base 07 - Bright White
+  color16="df/53/20" # Base 09
+  color17="c3/3f/f3" # Base 0F
+  color18="e6/e2/e0" # Base 01
+  color19="a8/a1/9f" # Base 02
+  color20="76/6e/6b" # Base 04
+  color21="2c/24/21" # Base 06
+fi;
 color_foreground="68/61/5e" # Base 05
 color_background="f1/ef/ee" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-forest.sh
+++ b/scripts/base16-atelier-forest.sh
@@ -11,20 +11,31 @@ color04="40/7e/e7" # Base 0D - Blue
 color05="66/66/ea" # Base 0E - Magenta
 color06="3d/97/b8" # Base 0C - Cyan
 color07="a8/a1/9f" # Base 05 - White
-color08="76/6e/6b" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f1/ef/ee" # Base 07 - Bright White
-color16="df/53/20" # Base 09
-color17="c3/3f/f3" # Base 0F
-color18="2c/24/21" # Base 01
-color19="68/61/5e" # Base 02
-color20="9c/94/91" # Base 04
-color21="e6/e2/e0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="76/6e/6b" # Base 03 - Bright Black
+  color09="df/53/20" # Base 09
+  color10="2c/24/21" # Base 01
+  color11="68/61/5e" # Base 02
+  color12="9c/94/91" # Base 04
+  color13="e6/e2/e0" # Base 06
+  color14="c3/3f/f3" # Base 0F
+  color15="f1/ef/ee" # Base 07 - Bright White
+else
+  color08="76/6e/6b" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f1/ef/ee" # Base 07 - Bright White
+  color16="df/53/20" # Base 09
+  color17="c3/3f/f3" # Base 0F
+  color18="2c/24/21" # Base 01
+  color19="68/61/5e" # Base 02
+  color20="9c/94/91" # Base 04
+  color21="e6/e2/e0" # Base 06
+fi;
 color_foreground="a8/a1/9f" # Base 05
 color_background="1b/19/18" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-heath-light.sh
+++ b/scripts/base16-atelier-heath-light.sh
@@ -11,20 +11,31 @@ color04="51/6a/ec" # Base 0D - Blue
 color05="7b/59/c0" # Base 0E - Magenta
 color06="15/93/93" # Base 0C - Cyan
 color07="69/5d/69" # Base 05 - White
-color08="9e/8f/9e" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="1b/18/1b" # Base 07 - Bright White
-color16="a6/59/26" # Base 09
-color17="cc/33/cc" # Base 0F
-color18="d8/ca/d8" # Base 01
-color19="ab/9b/ab" # Base 02
-color20="77/69/77" # Base 04
-color21="29/23/29" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="9e/8f/9e" # Base 03 - Bright Black
+  color09="a6/59/26" # Base 09
+  color10="d8/ca/d8" # Base 01
+  color11="ab/9b/ab" # Base 02
+  color12="77/69/77" # Base 04
+  color13="29/23/29" # Base 06
+  color14="cc/33/cc" # Base 0F
+  color15="1b/18/1b" # Base 07 - Bright White
+else
+  color08="9e/8f/9e" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="1b/18/1b" # Base 07 - Bright White
+  color16="a6/59/26" # Base 09
+  color17="cc/33/cc" # Base 0F
+  color18="d8/ca/d8" # Base 01
+  color19="ab/9b/ab" # Base 02
+  color20="77/69/77" # Base 04
+  color21="29/23/29" # Base 06
+fi;
 color_foreground="69/5d/69" # Base 05
 color_background="f7/f3/f7" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-heath.sh
+++ b/scripts/base16-atelier-heath.sh
@@ -11,20 +11,31 @@ color04="51/6a/ec" # Base 0D - Blue
 color05="7b/59/c0" # Base 0E - Magenta
 color06="15/93/93" # Base 0C - Cyan
 color07="ab/9b/ab" # Base 05 - White
-color08="77/69/77" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f3/f7" # Base 07 - Bright White
-color16="a6/59/26" # Base 09
-color17="cc/33/cc" # Base 0F
-color18="29/23/29" # Base 01
-color19="69/5d/69" # Base 02
-color20="9e/8f/9e" # Base 04
-color21="d8/ca/d8" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="77/69/77" # Base 03 - Bright Black
+  color09="a6/59/26" # Base 09
+  color10="29/23/29" # Base 01
+  color11="69/5d/69" # Base 02
+  color12="9e/8f/9e" # Base 04
+  color13="d8/ca/d8" # Base 06
+  color14="cc/33/cc" # Base 0F
+  color15="f7/f3/f7" # Base 07 - Bright White
+else
+  color08="77/69/77" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f7/f3/f7" # Base 07 - Bright White
+  color16="a6/59/26" # Base 09
+  color17="cc/33/cc" # Base 0F
+  color18="29/23/29" # Base 01
+  color19="69/5d/69" # Base 02
+  color20="9e/8f/9e" # Base 04
+  color21="d8/ca/d8" # Base 06
+fi;
 color_foreground="ab/9b/ab" # Base 05
 color_background="1b/18/1b" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-lakeside-light.sh
+++ b/scripts/base16-atelier-lakeside-light.sh
@@ -11,20 +11,31 @@ color04="25/7f/ad" # Base 0D - Blue
 color05="6b/6b/b8" # Base 0E - Magenta
 color06="2d/8f/6f" # Base 0C - Cyan
 color07="51/6d/7b" # Base 05 - White
-color08="71/95/a8" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="16/1b/1d" # Base 07 - Bright White
-color16="93/5c/25" # Base 09
-color17="b7/2d/d2" # Base 0F
-color18="c1/e4/f6" # Base 01
-color19="7e/a2/b4" # Base 02
-color20="5a/7b/8c" # Base 04
-color21="1f/29/2e" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="71/95/a8" # Base 03 - Bright Black
+  color09="93/5c/25" # Base 09
+  color10="c1/e4/f6" # Base 01
+  color11="7e/a2/b4" # Base 02
+  color12="5a/7b/8c" # Base 04
+  color13="1f/29/2e" # Base 06
+  color14="b7/2d/d2" # Base 0F
+  color15="16/1b/1d" # Base 07 - Bright White
+else
+  color08="71/95/a8" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="16/1b/1d" # Base 07 - Bright White
+  color16="93/5c/25" # Base 09
+  color17="b7/2d/d2" # Base 0F
+  color18="c1/e4/f6" # Base 01
+  color19="7e/a2/b4" # Base 02
+  color20="5a/7b/8c" # Base 04
+  color21="1f/29/2e" # Base 06
+fi;
 color_foreground="51/6d/7b" # Base 05
 color_background="eb/f8/ff" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-lakeside.sh
+++ b/scripts/base16-atelier-lakeside.sh
@@ -11,20 +11,31 @@ color04="25/7f/ad" # Base 0D - Blue
 color05="6b/6b/b8" # Base 0E - Magenta
 color06="2d/8f/6f" # Base 0C - Cyan
 color07="7e/a2/b4" # Base 05 - White
-color08="5a/7b/8c" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="eb/f8/ff" # Base 07 - Bright White
-color16="93/5c/25" # Base 09
-color17="b7/2d/d2" # Base 0F
-color18="1f/29/2e" # Base 01
-color19="51/6d/7b" # Base 02
-color20="71/95/a8" # Base 04
-color21="c1/e4/f6" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="5a/7b/8c" # Base 03 - Bright Black
+  color09="93/5c/25" # Base 09
+  color10="1f/29/2e" # Base 01
+  color11="51/6d/7b" # Base 02
+  color12="71/95/a8" # Base 04
+  color13="c1/e4/f6" # Base 06
+  color14="b7/2d/d2" # Base 0F
+  color15="eb/f8/ff" # Base 07 - Bright White
+else
+  color08="5a/7b/8c" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="eb/f8/ff" # Base 07 - Bright White
+  color16="93/5c/25" # Base 09
+  color17="b7/2d/d2" # Base 0F
+  color18="1f/29/2e" # Base 01
+  color19="51/6d/7b" # Base 02
+  color20="71/95/a8" # Base 04
+  color21="c1/e4/f6" # Base 06
+fi;
 color_foreground="7e/a2/b4" # Base 05
 color_background="16/1b/1d" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-plateau-light.sh
+++ b/scripts/base16-atelier-plateau-light.sh
@@ -11,20 +11,31 @@ color04="72/72/ca" # Base 0D - Blue
 color05="84/64/c4" # Base 0E - Magenta
 color06="54/85/b6" # Base 0C - Cyan
 color07="58/50/50" # Base 05 - White
-color08="7e/77/77" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="1b/18/18" # Base 07 - Bright White
-color16="b4/5a/3c" # Base 09
-color17="bd/51/87" # Base 0F
-color18="e7/df/df" # Base 01
-color19="8a/85/85" # Base 02
-color20="65/5d/5d" # Base 04
-color21="29/24/24" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="7e/77/77" # Base 03 - Bright Black
+  color09="b4/5a/3c" # Base 09
+  color10="e7/df/df" # Base 01
+  color11="8a/85/85" # Base 02
+  color12="65/5d/5d" # Base 04
+  color13="29/24/24" # Base 06
+  color14="bd/51/87" # Base 0F
+  color15="1b/18/18" # Base 07 - Bright White
+else
+  color08="7e/77/77" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="1b/18/18" # Base 07 - Bright White
+  color16="b4/5a/3c" # Base 09
+  color17="bd/51/87" # Base 0F
+  color18="e7/df/df" # Base 01
+  color19="8a/85/85" # Base 02
+  color20="65/5d/5d" # Base 04
+  color21="29/24/24" # Base 06
+fi;
 color_foreground="58/50/50" # Base 05
 color_background="f4/ec/ec" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-plateau.sh
+++ b/scripts/base16-atelier-plateau.sh
@@ -11,20 +11,31 @@ color04="72/72/ca" # Base 0D - Blue
 color05="84/64/c4" # Base 0E - Magenta
 color06="54/85/b6" # Base 0C - Cyan
 color07="8a/85/85" # Base 05 - White
-color08="65/5d/5d" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f4/ec/ec" # Base 07 - Bright White
-color16="b4/5a/3c" # Base 09
-color17="bd/51/87" # Base 0F
-color18="29/24/24" # Base 01
-color19="58/50/50" # Base 02
-color20="7e/77/77" # Base 04
-color21="e7/df/df" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="65/5d/5d" # Base 03 - Bright Black
+  color09="b4/5a/3c" # Base 09
+  color10="29/24/24" # Base 01
+  color11="58/50/50" # Base 02
+  color12="7e/77/77" # Base 04
+  color13="e7/df/df" # Base 06
+  color14="bd/51/87" # Base 0F
+  color15="f4/ec/ec" # Base 07 - Bright White
+else
+  color08="65/5d/5d" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f4/ec/ec" # Base 07 - Bright White
+  color16="b4/5a/3c" # Base 09
+  color17="bd/51/87" # Base 0F
+  color18="29/24/24" # Base 01
+  color19="58/50/50" # Base 02
+  color20="7e/77/77" # Base 04
+  color21="e7/df/df" # Base 06
+fi;
 color_foreground="8a/85/85" # Base 05
 color_background="1b/18/18" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-savanna-light.sh
+++ b/scripts/base16-atelier-savanna-light.sh
@@ -11,20 +11,31 @@ color04="47/8c/90" # Base 0D - Blue
 color05="55/85/9b" # Base 0E - Magenta
 color06="1c/9a/a0" # Base 0C - Cyan
 color07="52/60/57" # Base 05 - White
-color08="78/87/7d" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="17/1c/19" # Base 07 - Bright White
-color16="9f/71/3c" # Base 09
-color17="86/74/69" # Base 0F
-color18="df/e7/e2" # Base 01
-color19="87/92/8a" # Base 02
-color20="5f/6d/64" # Base 04
-color21="23/2a/25" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="78/87/7d" # Base 03 - Bright Black
+  color09="9f/71/3c" # Base 09
+  color10="df/e7/e2" # Base 01
+  color11="87/92/8a" # Base 02
+  color12="5f/6d/64" # Base 04
+  color13="23/2a/25" # Base 06
+  color14="86/74/69" # Base 0F
+  color15="17/1c/19" # Base 07 - Bright White
+else
+  color08="78/87/7d" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="17/1c/19" # Base 07 - Bright White
+  color16="9f/71/3c" # Base 09
+  color17="86/74/69" # Base 0F
+  color18="df/e7/e2" # Base 01
+  color19="87/92/8a" # Base 02
+  color20="5f/6d/64" # Base 04
+  color21="23/2a/25" # Base 06
+fi;
 color_foreground="52/60/57" # Base 05
 color_background="ec/f4/ee" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-savanna.sh
+++ b/scripts/base16-atelier-savanna.sh
@@ -11,20 +11,31 @@ color04="47/8c/90" # Base 0D - Blue
 color05="55/85/9b" # Base 0E - Magenta
 color06="1c/9a/a0" # Base 0C - Cyan
 color07="87/92/8a" # Base 05 - White
-color08="5f/6d/64" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ec/f4/ee" # Base 07 - Bright White
-color16="9f/71/3c" # Base 09
-color17="86/74/69" # Base 0F
-color18="23/2a/25" # Base 01
-color19="52/60/57" # Base 02
-color20="78/87/7d" # Base 04
-color21="df/e7/e2" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="5f/6d/64" # Base 03 - Bright Black
+  color09="9f/71/3c" # Base 09
+  color10="23/2a/25" # Base 01
+  color11="52/60/57" # Base 02
+  color12="78/87/7d" # Base 04
+  color13="df/e7/e2" # Base 06
+  color14="86/74/69" # Base 0F
+  color15="ec/f4/ee" # Base 07 - Bright White
+else
+  color08="5f/6d/64" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ec/f4/ee" # Base 07 - Bright White
+  color16="9f/71/3c" # Base 09
+  color17="86/74/69" # Base 0F
+  color18="23/2a/25" # Base 01
+  color19="52/60/57" # Base 02
+  color20="78/87/7d" # Base 04
+  color21="df/e7/e2" # Base 06
+fi;
 color_foreground="87/92/8a" # Base 05
 color_background="17/1c/19" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-seaside-light.sh
+++ b/scripts/base16-atelier-seaside-light.sh
@@ -11,20 +11,31 @@ color04="3d/62/f5" # Base 0D - Blue
 color05="ad/2b/ee" # Base 0E - Magenta
 color06="19/99/b3" # Base 0C - Cyan
 color07="5e/6e/5e" # Base 05 - White
-color08="80/99/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="13/15/13" # Base 07 - Bright White
-color16="87/71/1d" # Base 09
-color17="e6/19/c3" # Base 0F
-color18="cf/e8/cf" # Base 01
-color19="8c/a6/8c" # Base 02
-color20="68/7d/68" # Base 04
-color21="24/29/24" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="80/99/80" # Base 03 - Bright Black
+  color09="87/71/1d" # Base 09
+  color10="cf/e8/cf" # Base 01
+  color11="8c/a6/8c" # Base 02
+  color12="68/7d/68" # Base 04
+  color13="24/29/24" # Base 06
+  color14="e6/19/c3" # Base 0F
+  color15="13/15/13" # Base 07 - Bright White
+else
+  color08="80/99/80" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="13/15/13" # Base 07 - Bright White
+  color16="87/71/1d" # Base 09
+  color17="e6/19/c3" # Base 0F
+  color18="cf/e8/cf" # Base 01
+  color19="8c/a6/8c" # Base 02
+  color20="68/7d/68" # Base 04
+  color21="24/29/24" # Base 06
+fi;
 color_foreground="5e/6e/5e" # Base 05
 color_background="f4/fb/f4" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-seaside.sh
+++ b/scripts/base16-atelier-seaside.sh
@@ -11,20 +11,31 @@ color04="3d/62/f5" # Base 0D - Blue
 color05="ad/2b/ee" # Base 0E - Magenta
 color06="19/99/b3" # Base 0C - Cyan
 color07="8c/a6/8c" # Base 05 - White
-color08="68/7d/68" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f4/fb/f4" # Base 07 - Bright White
-color16="87/71/1d" # Base 09
-color17="e6/19/c3" # Base 0F
-color18="24/29/24" # Base 01
-color19="5e/6e/5e" # Base 02
-color20="80/99/80" # Base 04
-color21="cf/e8/cf" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="68/7d/68" # Base 03 - Bright Black
+  color09="87/71/1d" # Base 09
+  color10="24/29/24" # Base 01
+  color11="5e/6e/5e" # Base 02
+  color12="80/99/80" # Base 04
+  color13="cf/e8/cf" # Base 06
+  color14="e6/19/c3" # Base 0F
+  color15="f4/fb/f4" # Base 07 - Bright White
+else
+  color08="68/7d/68" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f4/fb/f4" # Base 07 - Bright White
+  color16="87/71/1d" # Base 09
+  color17="e6/19/c3" # Base 0F
+  color18="24/29/24" # Base 01
+  color19="5e/6e/5e" # Base 02
+  color20="80/99/80" # Base 04
+  color21="cf/e8/cf" # Base 06
+fi;
 color_foreground="8c/a6/8c" # Base 05
 color_background="13/15/13" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-sulphurpool-light.sh
+++ b/scripts/base16-atelier-sulphurpool-light.sh
@@ -11,20 +11,31 @@ color04="3d/8f/d1" # Base 0D - Blue
 color05="66/79/cc" # Base 0E - Magenta
 color06="22/a2/c9" # Base 0C - Cyan
 color07="5e/66/87" # Base 05 - White
-color08="89/8e/a4" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="20/27/46" # Base 07 - Bright White
-color16="c7/6b/29" # Base 09
-color17="9c/63/7a" # Base 0F
-color18="df/e2/f1" # Base 01
-color19="97/9d/b4" # Base 02
-color20="6b/73/94" # Base 04
-color21="29/32/56" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="89/8e/a4" # Base 03 - Bright Black
+  color09="c7/6b/29" # Base 09
+  color10="df/e2/f1" # Base 01
+  color11="97/9d/b4" # Base 02
+  color12="6b/73/94" # Base 04
+  color13="29/32/56" # Base 06
+  color14="9c/63/7a" # Base 0F
+  color15="20/27/46" # Base 07 - Bright White
+else
+  color08="89/8e/a4" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="20/27/46" # Base 07 - Bright White
+  color16="c7/6b/29" # Base 09
+  color17="9c/63/7a" # Base 0F
+  color18="df/e2/f1" # Base 01
+  color19="97/9d/b4" # Base 02
+  color20="6b/73/94" # Base 04
+  color21="29/32/56" # Base 06
+fi;
 color_foreground="5e/66/87" # Base 05
 color_background="f5/f7/ff" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atelier-sulphurpool.sh
+++ b/scripts/base16-atelier-sulphurpool.sh
@@ -11,20 +11,31 @@ color04="3d/8f/d1" # Base 0D - Blue
 color05="66/79/cc" # Base 0E - Magenta
 color06="22/a2/c9" # Base 0C - Cyan
 color07="97/9d/b4" # Base 05 - White
-color08="6b/73/94" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f5/f7/ff" # Base 07 - Bright White
-color16="c7/6b/29" # Base 09
-color17="9c/63/7a" # Base 0F
-color18="29/32/56" # Base 01
-color19="5e/66/87" # Base 02
-color20="89/8e/a4" # Base 04
-color21="df/e2/f1" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="6b/73/94" # Base 03 - Bright Black
+  color09="c7/6b/29" # Base 09
+  color10="29/32/56" # Base 01
+  color11="5e/66/87" # Base 02
+  color12="89/8e/a4" # Base 04
+  color13="df/e2/f1" # Base 06
+  color14="9c/63/7a" # Base 0F
+  color15="f5/f7/ff" # Base 07 - Bright White
+else
+  color08="6b/73/94" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f5/f7/ff" # Base 07 - Bright White
+  color16="c7/6b/29" # Base 09
+  color17="9c/63/7a" # Base 0F
+  color18="29/32/56" # Base 01
+  color19="5e/66/87" # Base 02
+  color20="89/8e/a4" # Base 04
+  color21="df/e2/f1" # Base 06
+fi;
 color_foreground="97/9d/b4" # Base 05
 color_background="20/27/46" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-atlas.sh
+++ b/scripts/base16-atlas.sh
@@ -11,20 +11,31 @@ color04="5d/d7/b9" # Base 0D - Blue
 color05="9a/70/a4" # Base 0E - Magenta
 color06="14/74/7e" # Base 0C - Cyan
 color07="a1/a1/9a" # Base 05 - White
-color08="6C/8B/91" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fa/fa/f8" # Base 07 - Bright White
-color16="f0/8e/48" # Base 09
-color17="c4/30/60" # Base 0F
-color18="00/38/4d" # Base 01
-color19="51/7F/8D" # Base 02
-color20="86/96/96" # Base 04
-color21="e6/e6/dc" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="6C/8B/91" # Base 03 - Bright Black
+  color09="f0/8e/48" # Base 09
+  color10="00/38/4d" # Base 01
+  color11="51/7F/8D" # Base 02
+  color12="86/96/96" # Base 04
+  color13="e6/e6/dc" # Base 06
+  color14="c4/30/60" # Base 0F
+  color15="fa/fa/f8" # Base 07 - Bright White
+else
+  color08="6C/8B/91" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="fa/fa/f8" # Base 07 - Bright White
+  color16="f0/8e/48" # Base 09
+  color17="c4/30/60" # Base 0F
+  color18="00/38/4d" # Base 01
+  color19="51/7F/8D" # Base 02
+  color20="86/96/96" # Base 04
+  color21="e6/e6/dc" # Base 06
+fi;
 color_foreground="a1/a1/9a" # Base 05
 color_background="00/26/35" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-bespin.sh
+++ b/scripts/base16-bespin.sh
@@ -11,20 +11,31 @@ color04="5e/a6/ea" # Base 0D - Blue
 color05="9b/85/9d" # Base 0E - Magenta
 color06="af/c4/db" # Base 0C - Cyan
 color07="8a/89/86" # Base 05 - White
-color08="66/66/66" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ba/ae/9e" # Base 07 - Bright White
-color16="cf/7d/34" # Base 09
-color17="93/71/21" # Base 0F
-color18="36/31/2e" # Base 01
-color19="5e/5d/5c" # Base 02
-color20="79/79/77" # Base 04
-color21="9d/9b/97" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="66/66/66" # Base 03 - Bright Black
+  color09="cf/7d/34" # Base 09
+  color10="36/31/2e" # Base 01
+  color11="5e/5d/5c" # Base 02
+  color12="79/79/77" # Base 04
+  color13="9d/9b/97" # Base 06
+  color14="93/71/21" # Base 0F
+  color15="ba/ae/9e" # Base 07 - Bright White
+else
+  color08="66/66/66" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ba/ae/9e" # Base 07 - Bright White
+  color16="cf/7d/34" # Base 09
+  color17="93/71/21" # Base 0F
+  color18="36/31/2e" # Base 01
+  color19="5e/5d/5c" # Base 02
+  color20="79/79/77" # Base 04
+  color21="9d/9b/97" # Base 06
+fi;
 color_foreground="8a/89/86" # Base 05
 color_background="28/21/1c" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal-bathory.sh
+++ b/scripts/base16-black-metal-bathory.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal-burzum.sh
+++ b/scripts/base16-black-metal-burzum.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal-dark-funeral.sh
+++ b/scripts/base16-black-metal-dark-funeral.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal-gorgoroth.sh
+++ b/scripts/base16-black-metal-gorgoroth.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal-immortal.sh
+++ b/scripts/base16-black-metal-immortal.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal-khold.sh
+++ b/scripts/base16-black-metal-khold.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal-marduk.sh
+++ b/scripts/base16-black-metal-marduk.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal-mayhem.sh
+++ b/scripts/base16-black-metal-mayhem.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal-nile.sh
+++ b/scripts/base16-black-metal-nile.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal-venom.sh
+++ b/scripts/base16-black-metal-venom.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-black-metal.sh
+++ b/scripts/base16-black-metal.sh
@@ -11,20 +11,31 @@ color04="88/88/88" # Base 0D - Blue
 color05="99/99/99" # Base 0E - Magenta
 color06="aa/aa/aa" # Base 0C - Cyan
 color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="33/33/33" # Base 03 - Bright Black
+  color09="aa/aa/aa" # Base 09
+  color10="12/12/12" # Base 01
+  color11="22/22/22" # Base 02
+  color12="99/99/99" # Base 04
+  color13="99/99/99" # Base 06
+  color14="44/44/44" # Base 0F
+  color15="c1/c1/c1" # Base 07 - Bright White
+else
+  color08="33/33/33" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c1/c1/c1" # Base 07 - Bright White
+  color16="aa/aa/aa" # Base 09
+  color17="44/44/44" # Base 0F
+  color18="12/12/12" # Base 01
+  color19="22/22/22" # Base 02
+  color20="99/99/99" # Base 04
+  color21="99/99/99" # Base 06
+fi;
 color_foreground="c1/c1/c1" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-brewer.sh
+++ b/scripts/base16-brewer.sh
@@ -11,20 +11,31 @@ color04="31/82/bd" # Base 0D - Blue
 color05="75/6b/b1" # Base 0E - Magenta
 color06="80/b1/d3" # Base 0C - Cyan
 color07="b7/b8/b9" # Base 05 - White
-color08="73/74/75" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fc/fd/fe" # Base 07 - Bright White
-color16="e6/55/0d" # Base 09
-color17="b1/59/28" # Base 0F
-color18="2e/2f/30" # Base 01
-color19="51/52/53" # Base 02
-color20="95/96/97" # Base 04
-color21="da/db/dc" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="73/74/75" # Base 03 - Bright Black
+  color09="e6/55/0d" # Base 09
+  color10="2e/2f/30" # Base 01
+  color11="51/52/53" # Base 02
+  color12="95/96/97" # Base 04
+  color13="da/db/dc" # Base 06
+  color14="b1/59/28" # Base 0F
+  color15="fc/fd/fe" # Base 07 - Bright White
+else
+  color08="73/74/75" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="fc/fd/fe" # Base 07 - Bright White
+  color16="e6/55/0d" # Base 09
+  color17="b1/59/28" # Base 0F
+  color18="2e/2f/30" # Base 01
+  color19="51/52/53" # Base 02
+  color20="95/96/97" # Base 04
+  color21="da/db/dc" # Base 06
+fi;
 color_foreground="b7/b8/b9" # Base 05
 color_background="0c/0d/0e" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-bright.sh
+++ b/scripts/base16-bright.sh
@@ -11,20 +11,31 @@ color04="6f/b3/d2" # Base 0D - Blue
 color05="d3/81/c3" # Base 0E - Magenta
 color06="76/c7/b7" # Base 0C - Cyan
 color07="e0/e0/e0" # Base 05 - White
-color08="b0/b0/b0" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="fc/6d/24" # Base 09
-color17="be/64/3c" # Base 0F
-color18="30/30/30" # Base 01
-color19="50/50/50" # Base 02
-color20="d0/d0/d0" # Base 04
-color21="f5/f5/f5" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="b0/b0/b0" # Base 03 - Bright Black
+  color09="fc/6d/24" # Base 09
+  color10="30/30/30" # Base 01
+  color11="50/50/50" # Base 02
+  color12="d0/d0/d0" # Base 04
+  color13="f5/f5/f5" # Base 06
+  color14="be/64/3c" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="b0/b0/b0" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="fc/6d/24" # Base 09
+  color17="be/64/3c" # Base 0F
+  color18="30/30/30" # Base 01
+  color19="50/50/50" # Base 02
+  color20="d0/d0/d0" # Base 04
+  color21="f5/f5/f5" # Base 06
+fi;
 color_foreground="e0/e0/e0" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-brogrammer.sh
+++ b/scripts/base16-brogrammer.sh
@@ -11,20 +11,31 @@ color04="53/50/b9" # Base 0D - Blue
 color05="0f/7d/db" # Base 0E - Magenta
 color06="10/81/d6" # Base 0C - Cyan
 color07="4e/5a/b7" # Base 05 - White
-color08="ec/ba/0f" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="d6/db/e5" # Base 07 - Bright White
-color16="de/35/2e" # Base 09
-color17="ff/ff/ff" # Base 0F
-color18="f8/11/18" # Base 01
-color19="2d/c5/5e" # Base 02
-color20="2a/84/d2" # Base 04
-color21="10/81/d6" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="ec/ba/0f" # Base 03 - Bright Black
+  color09="de/35/2e" # Base 09
+  color10="f8/11/18" # Base 01
+  color11="2d/c5/5e" # Base 02
+  color12="2a/84/d2" # Base 04
+  color13="10/81/d6" # Base 06
+  color14="ff/ff/ff" # Base 0F
+  color15="d6/db/e5" # Base 07 - Bright White
+else
+  color08="ec/ba/0f" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="d6/db/e5" # Base 07 - Bright White
+  color16="de/35/2e" # Base 09
+  color17="ff/ff/ff" # Base 0F
+  color18="f8/11/18" # Base 01
+  color19="2d/c5/5e" # Base 02
+  color20="2a/84/d2" # Base 04
+  color21="10/81/d6" # Base 06
+fi;
 color_foreground="4e/5a/b7" # Base 05
 color_background="1f/1f/1f" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-brushtrees-dark.sh
+++ b/scripts/base16-brushtrees-dark.sh
@@ -11,20 +11,31 @@ color04="86/8c/b3" # Base 0D - Blue
 color05="b3/86/b2" # Base 0E - Magenta
 color06="86/b3/b3" # Base 0C - Cyan
 color07="B0/C5/C8" # Base 05 - White
-color08="82/99/A1" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="E3/EF/EF" # Base 07 - Bright White
-color16="d8/bb/a2" # Base 09
-color17="b3/9f/9f" # Base 0F
-color18="5A/6D/7A" # Base 01
-color19="6D/82/8E" # Base 02
-color20="98/AF/B5" # Base 04
-color21="C9/DB/DC" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="82/99/A1" # Base 03 - Bright Black
+  color09="d8/bb/a2" # Base 09
+  color10="5A/6D/7A" # Base 01
+  color11="6D/82/8E" # Base 02
+  color12="98/AF/B5" # Base 04
+  color13="C9/DB/DC" # Base 06
+  color14="b3/9f/9f" # Base 0F
+  color15="E3/EF/EF" # Base 07 - Bright White
+else
+  color08="82/99/A1" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="E3/EF/EF" # Base 07 - Bright White
+  color16="d8/bb/a2" # Base 09
+  color17="b3/9f/9f" # Base 0F
+  color18="5A/6D/7A" # Base 01
+  color19="6D/82/8E" # Base 02
+  color20="98/AF/B5" # Base 04
+  color21="C9/DB/DC" # Base 06
+fi;
 color_foreground="B0/C5/C8" # Base 05
 color_background="48/58/67" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-brushtrees.sh
+++ b/scripts/base16-brushtrees.sh
@@ -11,20 +11,31 @@ color04="86/8c/b3" # Base 0D - Blue
 color05="b3/86/b2" # Base 0E - Magenta
 color06="86/b3/b3" # Base 0C - Cyan
 color07="6D/82/8E" # Base 05 - White
-color08="98/AF/B5" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="48/58/67" # Base 07 - Bright White
-color16="d8/bb/a2" # Base 09
-color17="b3/9f/9f" # Base 0F
-color18="C9/DB/DC" # Base 01
-color19="B0/C5/C8" # Base 02
-color20="82/99/A1" # Base 04
-color21="5A/6D/7A" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="98/AF/B5" # Base 03 - Bright Black
+  color09="d8/bb/a2" # Base 09
+  color10="C9/DB/DC" # Base 01
+  color11="B0/C5/C8" # Base 02
+  color12="82/99/A1" # Base 04
+  color13="5A/6D/7A" # Base 06
+  color14="b3/9f/9f" # Base 0F
+  color15="48/58/67" # Base 07 - Bright White
+else
+  color08="98/AF/B5" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="48/58/67" # Base 07 - Bright White
+  color16="d8/bb/a2" # Base 09
+  color17="b3/9f/9f" # Base 0F
+  color18="C9/DB/DC" # Base 01
+  color19="B0/C5/C8" # Base 02
+  color20="82/99/A1" # Base 04
+  color21="5A/6D/7A" # Base 06
+fi;
 color_foreground="6D/82/8E" # Base 05
 color_background="E3/EF/EF" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-chalk.sh
+++ b/scripts/base16-chalk.sh
@@ -11,20 +11,31 @@ color04="6f/c2/ef" # Base 0D - Blue
 color05="e1/a3/ee" # Base 0E - Magenta
 color06="12/cf/c0" # Base 0C - Cyan
 color07="d0/d0/d0" # Base 05 - White
-color08="50/50/50" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f5/f5/f5" # Base 07 - Bright White
-color16="ed/a9/87" # Base 09
-color17="de/af/8f" # Base 0F
-color18="20/20/20" # Base 01
-color19="30/30/30" # Base 02
-color20="b0/b0/b0" # Base 04
-color21="e0/e0/e0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="50/50/50" # Base 03 - Bright Black
+  color09="ed/a9/87" # Base 09
+  color10="20/20/20" # Base 01
+  color11="30/30/30" # Base 02
+  color12="b0/b0/b0" # Base 04
+  color13="e0/e0/e0" # Base 06
+  color14="de/af/8f" # Base 0F
+  color15="f5/f5/f5" # Base 07 - Bright White
+else
+  color08="50/50/50" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f5/f5/f5" # Base 07 - Bright White
+  color16="ed/a9/87" # Base 09
+  color17="de/af/8f" # Base 0F
+  color18="20/20/20" # Base 01
+  color19="30/30/30" # Base 02
+  color20="b0/b0/b0" # Base 04
+  color21="e0/e0/e0" # Base 06
+fi;
 color_foreground="d0/d0/d0" # Base 05
 color_background="15/15/15" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-circus.sh
+++ b/scripts/base16-circus.sh
@@ -11,20 +11,31 @@ color04="63/9e/e4" # Base 0D - Blue
 color05="b8/88/e2" # Base 0E - Magenta
 color06="4b/b1/a7" # Base 0C - Cyan
 color07="a7/a7/a7" # Base 05 - White
-color08="5f/5a/60" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="4b/b1/a7" # Base 09
-color17="b8/88/e2" # Base 0F
-color18="20/20/20" # Base 01
-color19="30/30/30" # Base 02
-color20="50/50/50" # Base 04
-color21="80/80/80" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="5f/5a/60" # Base 03 - Bright Black
+  color09="4b/b1/a7" # Base 09
+  color10="20/20/20" # Base 01
+  color11="30/30/30" # Base 02
+  color12="50/50/50" # Base 04
+  color13="80/80/80" # Base 06
+  color14="b8/88/e2" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="5f/5a/60" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="4b/b1/a7" # Base 09
+  color17="b8/88/e2" # Base 0F
+  color18="20/20/20" # Base 01
+  color19="30/30/30" # Base 02
+  color20="50/50/50" # Base 04
+  color21="80/80/80" # Base 06
+fi;
 color_foreground="a7/a7/a7" # Base 05
 color_background="19/19/19" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-classic-dark.sh
+++ b/scripts/base16-classic-dark.sh
@@ -11,20 +11,31 @@ color04="6A/9F/B5" # Base 0D - Blue
 color05="AA/75/9F" # Base 0E - Magenta
 color06="75/B5/AA" # Base 0C - Cyan
 color07="D0/D0/D0" # Base 05 - White
-color08="50/50/50" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="F5/F5/F5" # Base 07 - Bright White
-color16="D2/84/45" # Base 09
-color17="8F/55/36" # Base 0F
-color18="20/20/20" # Base 01
-color19="30/30/30" # Base 02
-color20="B0/B0/B0" # Base 04
-color21="E0/E0/E0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="50/50/50" # Base 03 - Bright Black
+  color09="D2/84/45" # Base 09
+  color10="20/20/20" # Base 01
+  color11="30/30/30" # Base 02
+  color12="B0/B0/B0" # Base 04
+  color13="E0/E0/E0" # Base 06
+  color14="8F/55/36" # Base 0F
+  color15="F5/F5/F5" # Base 07 - Bright White
+else
+  color08="50/50/50" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="F5/F5/F5" # Base 07 - Bright White
+  color16="D2/84/45" # Base 09
+  color17="8F/55/36" # Base 0F
+  color18="20/20/20" # Base 01
+  color19="30/30/30" # Base 02
+  color20="B0/B0/B0" # Base 04
+  color21="E0/E0/E0" # Base 06
+fi;
 color_foreground="D0/D0/D0" # Base 05
 color_background="15/15/15" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-classic-light.sh
+++ b/scripts/base16-classic-light.sh
@@ -11,20 +11,31 @@ color04="6A/9F/B5" # Base 0D - Blue
 color05="AA/75/9F" # Base 0E - Magenta
 color06="75/B5/AA" # Base 0C - Cyan
 color07="30/30/30" # Base 05 - White
-color08="B0/B0/B0" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="15/15/15" # Base 07 - Bright White
-color16="D2/84/45" # Base 09
-color17="8F/55/36" # Base 0F
-color18="E0/E0/E0" # Base 01
-color19="D0/D0/D0" # Base 02
-color20="50/50/50" # Base 04
-color21="20/20/20" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="B0/B0/B0" # Base 03 - Bright Black
+  color09="D2/84/45" # Base 09
+  color10="E0/E0/E0" # Base 01
+  color11="D0/D0/D0" # Base 02
+  color12="50/50/50" # Base 04
+  color13="20/20/20" # Base 06
+  color14="8F/55/36" # Base 0F
+  color15="15/15/15" # Base 07 - Bright White
+else
+  color08="B0/B0/B0" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="15/15/15" # Base 07 - Bright White
+  color16="D2/84/45" # Base 09
+  color17="8F/55/36" # Base 0F
+  color18="E0/E0/E0" # Base 01
+  color19="D0/D0/D0" # Base 02
+  color20="50/50/50" # Base 04
+  color21="20/20/20" # Base 06
+fi;
 color_foreground="30/30/30" # Base 05
 color_background="F5/F5/F5" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-codeschool.sh
+++ b/scripts/base16-codeschool.sh
@@ -11,20 +11,31 @@ color04="48/4d/79" # Base 0D - Blue
 color05="c5/98/20" # Base 0E - Magenta
 color06="b0/2f/30" # Base 0C - Cyan
 color07="9e/a7/a6" # Base 05 - White
-color08="3f/49/44" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="b5/d8/f6" # Base 07 - Bright White
-color16="43/82/0d" # Base 09
-color17="c9/83/44" # Base 0F
-color18="1c/36/57" # Base 01
-color19="2a/34/3a" # Base 02
-color20="84/89/8c" # Base 04
-color21="a7/cf/a3" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="3f/49/44" # Base 03 - Bright Black
+  color09="43/82/0d" # Base 09
+  color10="1c/36/57" # Base 01
+  color11="2a/34/3a" # Base 02
+  color12="84/89/8c" # Base 04
+  color13="a7/cf/a3" # Base 06
+  color14="c9/83/44" # Base 0F
+  color15="b5/d8/f6" # Base 07 - Bright White
+else
+  color08="3f/49/44" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="b5/d8/f6" # Base 07 - Bright White
+  color16="43/82/0d" # Base 09
+  color17="c9/83/44" # Base 0F
+  color18="1c/36/57" # Base 01
+  color19="2a/34/3a" # Base 02
+  color20="84/89/8c" # Base 04
+  color21="a7/cf/a3" # Base 06
+fi;
 color_foreground="9e/a7/a6" # Base 05
 color_background="23/2c/31" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-cupcake.sh
+++ b/scripts/base16-cupcake.sh
@@ -11,20 +11,31 @@ color04="72/97/B9" # Base 0D - Blue
 color05="BB/99/B4" # Base 0E - Magenta
 color06="69/A9/A7" # Base 0C - Cyan
 color07="8b/81/98" # Base 05 - White
-color08="bf/b9/c6" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="58/50/62" # Base 07 - Bright White
-color16="EB/B7/90" # Base 09
-color17="BA/A5/8C" # Base 0F
-color18="f2/f1/f4" # Base 01
-color19="d8/d5/dd" # Base 02
-color20="a5/9d/af" # Base 04
-color21="72/67/7E" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="bf/b9/c6" # Base 03 - Bright Black
+  color09="EB/B7/90" # Base 09
+  color10="f2/f1/f4" # Base 01
+  color11="d8/d5/dd" # Base 02
+  color12="a5/9d/af" # Base 04
+  color13="72/67/7E" # Base 06
+  color14="BA/A5/8C" # Base 0F
+  color15="58/50/62" # Base 07 - Bright White
+else
+  color08="bf/b9/c6" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="58/50/62" # Base 07 - Bright White
+  color16="EB/B7/90" # Base 09
+  color17="BA/A5/8C" # Base 0F
+  color18="f2/f1/f4" # Base 01
+  color19="d8/d5/dd" # Base 02
+  color20="a5/9d/af" # Base 04
+  color21="72/67/7E" # Base 06
+fi;
 color_foreground="8b/81/98" # Base 05
 color_background="fb/f1/f2" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-cupertino.sh
+++ b/scripts/base16-cupertino.sh
@@ -11,20 +11,31 @@ color04="00/00/ff" # Base 0D - Blue
 color05="a9/0d/91" # Base 0E - Magenta
 color06="31/84/95" # Base 0C - Cyan
 color07="40/40/40" # Base 05 - White
-color08="80/80/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="5e/5e/5e" # Base 07 - Bright White
-color16="eb/85/00" # Base 09
-color17="82/6b/28" # Base 0F
-color18="c0/c0/c0" # Base 01
-color19="c0/c0/c0" # Base 02
-color20="80/80/80" # Base 04
-color21="40/40/40" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="80/80/80" # Base 03 - Bright Black
+  color09="eb/85/00" # Base 09
+  color10="c0/c0/c0" # Base 01
+  color11="c0/c0/c0" # Base 02
+  color12="80/80/80" # Base 04
+  color13="40/40/40" # Base 06
+  color14="82/6b/28" # Base 0F
+  color15="5e/5e/5e" # Base 07 - Bright White
+else
+  color08="80/80/80" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="5e/5e/5e" # Base 07 - Bright White
+  color16="eb/85/00" # Base 09
+  color17="82/6b/28" # Base 0F
+  color18="c0/c0/c0" # Base 01
+  color19="c0/c0/c0" # Base 02
+  color20="80/80/80" # Base 04
+  color21="40/40/40" # Base 06
+fi;
 color_foreground="40/40/40" # Base 05
 color_background="ff/ff/ff" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-darktooth.sh
+++ b/scripts/base16-darktooth.sh
@@ -11,20 +11,31 @@ color04="0D/66/78" # Base 0D - Blue
 color05="8F/46/73" # Base 0E - Magenta
 color06="8B/A5/9B" # Base 0C - Cyan
 color07="A8/99/84" # Base 05 - White
-color08="66/5C/54" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FD/F4/C1" # Base 07 - Bright White
-color16="FE/86/25" # Base 09
-color17="A8/73/22" # Base 0F
-color18="32/30/2F" # Base 01
-color19="50/49/45" # Base 02
-color20="92/83/74" # Base 04
-color21="D5/C4/A1" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="66/5C/54" # Base 03 - Bright Black
+  color09="FE/86/25" # Base 09
+  color10="32/30/2F" # Base 01
+  color11="50/49/45" # Base 02
+  color12="92/83/74" # Base 04
+  color13="D5/C4/A1" # Base 06
+  color14="A8/73/22" # Base 0F
+  color15="FD/F4/C1" # Base 07 - Bright White
+else
+  color08="66/5C/54" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="FD/F4/C1" # Base 07 - Bright White
+  color16="FE/86/25" # Base 09
+  color17="A8/73/22" # Base 0F
+  color18="32/30/2F" # Base 01
+  color19="50/49/45" # Base 02
+  color20="92/83/74" # Base 04
+  color21="D5/C4/A1" # Base 06
+fi;
 color_foreground="A8/99/84" # Base 05
 color_background="1D/20/21" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-decaf.sh
+++ b/scripts/base16-decaf.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Decaf scheme by Alex Mirrington (https://github.com/alexmirrington)
+
+color00="2d/2d/2d" # Base 00 - Black
+color01="ff/7f/7b" # Base 08 - Red
+color02="be/da/78" # Base 0B - Green
+color03="ff/d6/7c" # Base 0A - Yellow
+color04="90/be/e1" # Base 0D - Blue
+color05="ef/b3/f7" # Base 0E - Magenta
+color06="be/d6/ff" # Base 0C - Cyan
+color07="cc/cc/cc" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="77/77/77" # Base 03 - Bright Black
+  color09="ff/bf/70" # Base 09
+  color10="39/39/39" # Base 01
+  color11="51/51/51" # Base 02
+  color12="b4/b7/b4" # Base 04
+  color13="e0/e0/e0" # Base 06
+  color14="ff/93/b3" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="77/77/77" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="ff/bf/70" # Base 09
+  color17="ff/93/b3" # Base 0F
+  color18="39/39/39" # Base 01
+  color19="51/51/51" # Base 02
+  color20="b4/b7/b4" # Base 04
+  color21="e0/e0/e0" # Base 06
+fi;
+color_foreground="cc/cc/cc" # Base 05
+color_background="2d/2d/2d" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg cccccc # foreground
+  put_template_custom Ph 2d2d2d # background
+  put_template_custom Pi cccccc # bold color
+  put_template_custom Pj 515151 # selection color
+  put_template_custom Pk cccccc # selected text color
+  put_template_custom Pl cccccc # cursor
+  put_template_custom Pm 2d2d2d # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-default-dark.sh
+++ b/scripts/base16-default-dark.sh
@@ -11,20 +11,31 @@ color04="7c/af/c2" # Base 0D - Blue
 color05="ba/8b/af" # Base 0E - Magenta
 color06="86/c1/b9" # Base 0C - Cyan
 color07="d8/d8/d8" # Base 05 - White
-color08="58/58/58" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/f8/f8" # Base 07 - Bright White
-color16="dc/96/56" # Base 09
-color17="a1/69/46" # Base 0F
-color18="28/28/28" # Base 01
-color19="38/38/38" # Base 02
-color20="b8/b8/b8" # Base 04
-color21="e8/e8/e8" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="58/58/58" # Base 03 - Bright Black
+  color09="dc/96/56" # Base 09
+  color10="28/28/28" # Base 01
+  color11="38/38/38" # Base 02
+  color12="b8/b8/b8" # Base 04
+  color13="e8/e8/e8" # Base 06
+  color14="a1/69/46" # Base 0F
+  color15="f8/f8/f8" # Base 07 - Bright White
+else
+  color08="58/58/58" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f8/f8/f8" # Base 07 - Bright White
+  color16="dc/96/56" # Base 09
+  color17="a1/69/46" # Base 0F
+  color18="28/28/28" # Base 01
+  color19="38/38/38" # Base 02
+  color20="b8/b8/b8" # Base 04
+  color21="e8/e8/e8" # Base 06
+fi;
 color_foreground="d8/d8/d8" # Base 05
 color_background="18/18/18" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-default-light.sh
+++ b/scripts/base16-default-light.sh
@@ -11,20 +11,31 @@ color04="7c/af/c2" # Base 0D - Blue
 color05="ba/8b/af" # Base 0E - Magenta
 color06="86/c1/b9" # Base 0C - Cyan
 color07="38/38/38" # Base 05 - White
-color08="b8/b8/b8" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="18/18/18" # Base 07 - Bright White
-color16="dc/96/56" # Base 09
-color17="a1/69/46" # Base 0F
-color18="e8/e8/e8" # Base 01
-color19="d8/d8/d8" # Base 02
-color20="58/58/58" # Base 04
-color21="28/28/28" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="b8/b8/b8" # Base 03 - Bright Black
+  color09="dc/96/56" # Base 09
+  color10="e8/e8/e8" # Base 01
+  color11="d8/d8/d8" # Base 02
+  color12="58/58/58" # Base 04
+  color13="28/28/28" # Base 06
+  color14="a1/69/46" # Base 0F
+  color15="18/18/18" # Base 07 - Bright White
+else
+  color08="b8/b8/b8" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="18/18/18" # Base 07 - Bright White
+  color16="dc/96/56" # Base 09
+  color17="a1/69/46" # Base 0F
+  color18="e8/e8/e8" # Base 01
+  color19="d8/d8/d8" # Base 02
+  color20="58/58/58" # Base 04
+  color21="28/28/28" # Base 06
+fi;
 color_foreground="38/38/38" # Base 05
 color_background="f8/f8/f8" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-dracula.sh
+++ b/scripts/base16-dracula.sh
@@ -11,20 +11,31 @@ color04="62/d6/e8" # Base 0D - Blue
 color05="b4/5b/cf" # Base 0E - Magenta
 color06="a1/ef/e4" # Base 0C - Cyan
 color07="e9/e9/f4" # Base 05 - White
-color08="62/64/83" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f7/fb" # Base 07 - Bright White
-color16="b4/5b/cf" # Base 09
-color17="00/f7/69" # Base 0F
-color18="3a/3c/4e" # Base 01
-color19="4d/4f/68" # Base 02
-color20="62/d6/e8" # Base 04
-color21="f1/f2/f8" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="62/64/83" # Base 03 - Bright Black
+  color09="b4/5b/cf" # Base 09
+  color10="3a/3c/4e" # Base 01
+  color11="4d/4f/68" # Base 02
+  color12="62/d6/e8" # Base 04
+  color13="f1/f2/f8" # Base 06
+  color14="00/f7/69" # Base 0F
+  color15="f7/f7/fb" # Base 07 - Bright White
+else
+  color08="62/64/83" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f7/f7/fb" # Base 07 - Bright White
+  color16="b4/5b/cf" # Base 09
+  color17="00/f7/69" # Base 0F
+  color18="3a/3c/4e" # Base 01
+  color19="4d/4f/68" # Base 02
+  color20="62/d6/e8" # Base 04
+  color21="f1/f2/f8" # Base 06
+fi;
 color_foreground="e9/e9/f4" # Base 05
 color_background="28/29/36" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-edge-dark.sh
+++ b/scripts/base16-edge-dark.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Edge Dark scheme by cjayross (https://github.com/cjayross)
+
+color00="26/27/29" # Base 00 - Black
+color01="e7/71/71" # Base 08 - Red
+color02="a1/bf/78" # Base 0B - Green
+color03="db/b7/74" # Base 0A - Yellow
+color04="73/b3/e7" # Base 0D - Blue
+color05="d3/90/e7" # Base 0E - Magenta
+color06="5e/ba/a5" # Base 0C - Cyan
+color07="b7/be/c9" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="3e/42/49" # Base 03 - Bright Black
+  color09="e7/71/71" # Base 09
+  color10="88/90/9f" # Base 01
+  color11="b7/be/c9" # Base 02
+  color12="73/b3/e7" # Base 04
+  color13="d3/90/e7" # Base 06
+  color14="5e/ba/a5" # Base 0F
+  color15="3e/42/49" # Base 07 - Bright White
+else
+  color08="3e/42/49" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="3e/42/49" # Base 07 - Bright White
+  color16="e7/71/71" # Base 09
+  color17="5e/ba/a5" # Base 0F
+  color18="88/90/9f" # Base 01
+  color19="b7/be/c9" # Base 02
+  color20="73/b3/e7" # Base 04
+  color21="d3/90/e7" # Base 06
+fi;
+color_foreground="b7/be/c9" # Base 05
+color_background="26/27/29" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg b7bec9 # foreground
+  put_template_custom Ph 262729 # background
+  put_template_custom Pi b7bec9 # bold color
+  put_template_custom Pj b7bec9 # selection color
+  put_template_custom Pk b7bec9 # selected text color
+  put_template_custom Pl b7bec9 # cursor
+  put_template_custom Pm 262729 # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-edge-light.sh
+++ b/scripts/base16-edge-light.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Edge Light scheme by cjayross (https://github.com/cjayross)
+
+color00="fa/fa/fa" # Base 00 - Black
+color01="db/70/70" # Base 08 - Red
+color02="7c/9f/4b" # Base 0B - Green
+color03="d6/98/22" # Base 0A - Yellow
+color04="65/87/bf" # Base 0D - Blue
+color05="b8/70/ce" # Base 0E - Magenta
+color06="50/9c/93" # Base 0C - Cyan
+color07="5e/64/6f" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="5e/64/6f" # Base 03 - Bright Black
+  color09="db/70/70" # Base 09
+  color10="7c/9f/4b" # Base 01
+  color11="d6/98/22" # Base 02
+  color12="65/87/bf" # Base 04
+  color13="b8/70/ce" # Base 06
+  color14="50/9c/93" # Base 0F
+  color15="5e/64/6f" # Base 07 - Bright White
+else
+  color08="5e/64/6f" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="5e/64/6f" # Base 07 - Bright White
+  color16="db/70/70" # Base 09
+  color17="50/9c/93" # Base 0F
+  color18="7c/9f/4b" # Base 01
+  color19="d6/98/22" # Base 02
+  color20="65/87/bf" # Base 04
+  color21="b8/70/ce" # Base 06
+fi;
+color_foreground="5e/64/6f" # Base 05
+color_background="fa/fa/fa" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg 5e646f # foreground
+  put_template_custom Ph fafafa # background
+  put_template_custom Pi 5e646f # bold color
+  put_template_custom Pj d69822 # selection color
+  put_template_custom Pk 5e646f # selected text color
+  put_template_custom Pl 5e646f # cursor
+  put_template_custom Pm fafafa # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-eighties.sh
+++ b/scripts/base16-eighties.sh
@@ -11,20 +11,31 @@ color04="66/99/cc" # Base 0D - Blue
 color05="cc/99/cc" # Base 0E - Magenta
 color06="66/cc/cc" # Base 0C - Cyan
 color07="d3/d0/c8" # Base 05 - White
-color08="74/73/69" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f2/f0/ec" # Base 07 - Bright White
-color16="f9/91/57" # Base 09
-color17="d2/7b/53" # Base 0F
-color18="39/39/39" # Base 01
-color19="51/51/51" # Base 02
-color20="a0/9f/93" # Base 04
-color21="e8/e6/df" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="74/73/69" # Base 03 - Bright Black
+  color09="f9/91/57" # Base 09
+  color10="39/39/39" # Base 01
+  color11="51/51/51" # Base 02
+  color12="a0/9f/93" # Base 04
+  color13="e8/e6/df" # Base 06
+  color14="d2/7b/53" # Base 0F
+  color15="f2/f0/ec" # Base 07 - Bright White
+else
+  color08="74/73/69" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f2/f0/ec" # Base 07 - Bright White
+  color16="f9/91/57" # Base 09
+  color17="d2/7b/53" # Base 0F
+  color18="39/39/39" # Base 01
+  color19="51/51/51" # Base 02
+  color20="a0/9f/93" # Base 04
+  color21="e8/e6/df" # Base 06
+fi;
 color_foreground="d3/d0/c8" # Base 05
 color_background="2d/2d/2d" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-embers.sh
+++ b/scripts/base16-embers.sh
@@ -11,20 +11,31 @@ color04="6D/57/82" # Base 0D - Blue
 color05="82/57/6D" # Base 0E - Magenta
 color06="57/6D/82" # Base 0C - Cyan
 color07="A3/9A/90" # Base 05 - White
-color08="5A/50/47" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="DB/D6/D1" # Base 07 - Bright White
-color16="82/82/57" # Base 09
-color17="82/57/57" # Base 0F
-color18="2C/26/20" # Base 01
-color19="43/3B/32" # Base 02
-color20="8A/80/75" # Base 04
-color21="BE/B6/AE" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="5A/50/47" # Base 03 - Bright Black
+  color09="82/82/57" # Base 09
+  color10="2C/26/20" # Base 01
+  color11="43/3B/32" # Base 02
+  color12="8A/80/75" # Base 04
+  color13="BE/B6/AE" # Base 06
+  color14="82/57/57" # Base 0F
+  color15="DB/D6/D1" # Base 07 - Bright White
+else
+  color08="5A/50/47" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="DB/D6/D1" # Base 07 - Bright White
+  color16="82/82/57" # Base 09
+  color17="82/57/57" # Base 0F
+  color18="2C/26/20" # Base 01
+  color19="43/3B/32" # Base 02
+  color20="8A/80/75" # Base 04
+  color21="BE/B6/AE" # Base 06
+fi;
 color_foreground="A3/9A/90" # Base 05
 color_background="16/13/0F" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-espresso.sh
+++ b/scripts/base16-espresso.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Espresso scheme by Alex Mirrington (https://github.com/alexmirrington)
+
+color00="2d/2d/2d" # Base 00 - Black
+color01="d2/52/52" # Base 08 - Red
+color02="a5/c2/61" # Base 0B - Green
+color03="ff/c6/6d" # Base 0A - Yellow
+color04="6c/99/bb" # Base 0D - Blue
+color05="d1/97/d9" # Base 0E - Magenta
+color06="be/d6/ff" # Base 0C - Cyan
+color07="cc/cc/cc" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="77/77/77" # Base 03 - Bright Black
+  color09="f9/a9/59" # Base 09
+  color10="39/39/39" # Base 01
+  color11="51/51/51" # Base 02
+  color12="b4/b7/b4" # Base 04
+  color13="e0/e0/e0" # Base 06
+  color14="f9/73/94" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="77/77/77" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="f9/a9/59" # Base 09
+  color17="f9/73/94" # Base 0F
+  color18="39/39/39" # Base 01
+  color19="51/51/51" # Base 02
+  color20="b4/b7/b4" # Base 04
+  color21="e0/e0/e0" # Base 06
+fi;
+color_foreground="cc/cc/cc" # Base 05
+color_background="2d/2d/2d" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg cccccc # foreground
+  put_template_custom Ph 2d2d2d # background
+  put_template_custom Pi cccccc # bold color
+  put_template_custom Pj 515151 # selection color
+  put_template_custom Pk cccccc # selected text color
+  put_template_custom Pl cccccc # cursor
+  put_template_custom Pm 2d2d2d # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-flat.sh
+++ b/scripts/base16-flat.sh
@@ -11,20 +11,31 @@ color04="34/98/DB" # Base 0D - Blue
 color05="9B/59/B6" # Base 0E - Magenta
 color06="1A/BC/9C" # Base 0C - Cyan
 color07="e0/e0/e0" # Base 05 - White
-color08="95/A5/A6" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="EC/F0/F1" # Base 07 - Bright White
-color16="E6/7E/22" # Base 09
-color17="be/64/3c" # Base 0F
-color18="34/49/5E" # Base 01
-color19="7F/8C/8D" # Base 02
-color20="BD/C3/C7" # Base 04
-color21="f5/f5/f5" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="95/A5/A6" # Base 03 - Bright Black
+  color09="E6/7E/22" # Base 09
+  color10="34/49/5E" # Base 01
+  color11="7F/8C/8D" # Base 02
+  color12="BD/C3/C7" # Base 04
+  color13="f5/f5/f5" # Base 06
+  color14="be/64/3c" # Base 0F
+  color15="EC/F0/F1" # Base 07 - Bright White
+else
+  color08="95/A5/A6" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="EC/F0/F1" # Base 07 - Bright White
+  color16="E6/7E/22" # Base 09
+  color17="be/64/3c" # Base 0F
+  color18="34/49/5E" # Base 01
+  color19="7F/8C/8D" # Base 02
+  color20="BD/C3/C7" # Base 04
+  color21="f5/f5/f5" # Base 06
+fi;
 color_foreground="e0/e0/e0" # Base 05
 color_background="2C/3E/50" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-framer.sh
+++ b/scripts/base16-framer.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Framer scheme by Framer (Maintained by Jesse Hoyos)
+
+color00="18/18/18" # Base 00 - Black
+color01="FD/88/6B" # Base 08 - Red
+color02="32/CC/DC" # Base 0B - Green
+color03="FE/CB/6E" # Base 0A - Yellow
+color04="20/BC/FC" # Base 0D - Blue
+color05="BA/8C/FC" # Base 0E - Magenta
+color06="AC/DD/FD" # Base 0C - Cyan
+color07="D0/D0/D0" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="74/74/74" # Base 03 - Bright Black
+  color09="FC/47/69" # Base 09
+  color10="15/15/15" # Base 01
+  color11="46/46/46" # Base 02
+  color12="B9/B9/B9" # Base 04
+  color13="E8/E8/E8" # Base 06
+  color14="B1/5F/4A" # Base 0F
+  color15="EE/EE/EE" # Base 07 - Bright White
+else
+  color08="74/74/74" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="EE/EE/EE" # Base 07 - Bright White
+  color16="FC/47/69" # Base 09
+  color17="B1/5F/4A" # Base 0F
+  color18="15/15/15" # Base 01
+  color19="46/46/46" # Base 02
+  color20="B9/B9/B9" # Base 04
+  color21="E8/E8/E8" # Base 06
+fi;
+color_foreground="D0/D0/D0" # Base 05
+color_background="18/18/18" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg D0D0D0 # foreground
+  put_template_custom Ph 181818 # background
+  put_template_custom Pi D0D0D0 # bold color
+  put_template_custom Pj 464646 # selection color
+  put_template_custom Pk D0D0D0 # selected text color
+  put_template_custom Pl D0D0D0 # cursor
+  put_template_custom Pm 181818 # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-fruit-soda.sh
+++ b/scripts/base16-fruit-soda.sh
@@ -11,20 +11,31 @@ color04="29/31/df" # Base 0D - Blue
 color05="61/1f/ce" # Base 0E - Magenta
 color06="0f/9c/fd" # Base 0C - Cyan
 color07="51/51/51" # Base 05 - White
-color08="b5/b4/b6" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="2d/2c/2c" # Base 07 - Bright White
-color16="fe/6d/08" # Base 09
-color17="b1/6f/40" # Base 0F
-color18="e0/de/e0" # Base 01
-color19="d8/d5/d5" # Base 02
-color20="97/95/98" # Base 04
-color21="47/45/45" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="b5/b4/b6" # Base 03 - Bright Black
+  color09="fe/6d/08" # Base 09
+  color10="e0/de/e0" # Base 01
+  color11="d8/d5/d5" # Base 02
+  color12="97/95/98" # Base 04
+  color13="47/45/45" # Base 06
+  color14="b1/6f/40" # Base 0F
+  color15="2d/2c/2c" # Base 07 - Bright White
+else
+  color08="b5/b4/b6" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="2d/2c/2c" # Base 07 - Bright White
+  color16="fe/6d/08" # Base 09
+  color17="b1/6f/40" # Base 0F
+  color18="e0/de/e0" # Base 01
+  color19="d8/d5/d5" # Base 02
+  color20="97/95/98" # Base 04
+  color21="47/45/45" # Base 06
+fi;
 color_foreground="51/51/51" # Base 05
 color_background="f1/ec/f1" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-gigavolt.sh
+++ b/scripts/base16-gigavolt.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Gigavolt scheme by Aidan Swope (http://github.com/Whillikers)
+
+color00="20/21/26" # Base 00 - Black
+color01="ff/66/1a" # Base 08 - Red
+color02="f2/e6/a9" # Base 0B - Green
+color03="ff/dc/2d" # Base 0A - Yellow
+color04="40/bf/ff" # Base 0D - Blue
+color05="ae/94/f9" # Base 0E - Magenta
+color06="fb/6a/cb" # Base 0C - Cyan
+color07="e9/e7/e1" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="a1/d2/e6" # Base 03 - Bright Black
+  color09="19/f9/88" # Base 09
+  color10="2d/30/3d" # Base 01
+  color11="5a/57/6e" # Base 02
+  color12="ca/d3/ff" # Base 04
+  color13="ef/f0/f9" # Base 06
+  color14="61/87/ff" # Base 0F
+  color15="f2/fb/ff" # Base 07 - Bright White
+else
+  color08="a1/d2/e6" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f2/fb/ff" # Base 07 - Bright White
+  color16="19/f9/88" # Base 09
+  color17="61/87/ff" # Base 0F
+  color18="2d/30/3d" # Base 01
+  color19="5a/57/6e" # Base 02
+  color20="ca/d3/ff" # Base 04
+  color21="ef/f0/f9" # Base 06
+fi;
+color_foreground="e9/e7/e1" # Base 05
+color_background="20/21/26" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg e9e7e1 # foreground
+  put_template_custom Ph 202126 # background
+  put_template_custom Pi e9e7e1 # bold color
+  put_template_custom Pj 5a576e # selection color
+  put_template_custom Pk e9e7e1 # selected text color
+  put_template_custom Pl e9e7e1 # cursor
+  put_template_custom Pm 202126 # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-github.sh
+++ b/scripts/base16-github.sh
@@ -11,20 +11,31 @@ color04="79/5d/a3" # Base 0D - Blue
 color05="a7/1d/5d" # Base 0E - Magenta
 color06="18/36/91" # Base 0C - Cyan
 color07="33/33/33" # Base 05 - White
-color08="96/98/96" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="00/86/b3" # Base 09
-color17="33/33/33" # Base 0F
-color18="f5/f5/f5" # Base 01
-color19="c8/c8/fa" # Base 02
-color20="e8/e8/e8" # Base 04
-color21="ff/ff/ff" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="96/98/96" # Base 03 - Bright Black
+  color09="00/86/b3" # Base 09
+  color10="f5/f5/f5" # Base 01
+  color11="c8/c8/fa" # Base 02
+  color12="e8/e8/e8" # Base 04
+  color13="ff/ff/ff" # Base 06
+  color14="33/33/33" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="96/98/96" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="00/86/b3" # Base 09
+  color17="33/33/33" # Base 0F
+  color18="f5/f5/f5" # Base 01
+  color19="c8/c8/fa" # Base 02
+  color20="e8/e8/e8" # Base 04
+  color21="ff/ff/ff" # Base 06
+fi;
 color_foreground="33/33/33" # Base 05
 color_background="ff/ff/ff" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-google-dark.sh
+++ b/scripts/base16-google-dark.sh
@@ -11,20 +11,31 @@ color04="39/71/ED" # Base 0D - Blue
 color05="A3/6A/C7" # Base 0E - Magenta
 color06="39/71/ED" # Base 0C - Cyan
 color07="c5/c8/c6" # Base 05 - White
-color08="96/98/96" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="F9/6A/38" # Base 09
-color17="39/71/ED" # Base 0F
-color18="28/2a/2e" # Base 01
-color19="37/3b/41" # Base 02
-color20="b4/b7/b4" # Base 04
-color21="e0/e0/e0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="96/98/96" # Base 03 - Bright Black
+  color09="F9/6A/38" # Base 09
+  color10="28/2a/2e" # Base 01
+  color11="37/3b/41" # Base 02
+  color12="b4/b7/b4" # Base 04
+  color13="e0/e0/e0" # Base 06
+  color14="39/71/ED" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="96/98/96" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="F9/6A/38" # Base 09
+  color17="39/71/ED" # Base 0F
+  color18="28/2a/2e" # Base 01
+  color19="37/3b/41" # Base 02
+  color20="b4/b7/b4" # Base 04
+  color21="e0/e0/e0" # Base 06
+fi;
 color_foreground="c5/c8/c6" # Base 05
 color_background="1d/1f/21" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-google-light.sh
+++ b/scripts/base16-google-light.sh
@@ -11,20 +11,31 @@ color04="39/71/ED" # Base 0D - Blue
 color05="A3/6A/C7" # Base 0E - Magenta
 color06="39/71/ED" # Base 0C - Cyan
 color07="37/3b/41" # Base 05 - White
-color08="b4/b7/b4" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="1d/1f/21" # Base 07 - Bright White
-color16="F9/6A/38" # Base 09
-color17="39/71/ED" # Base 0F
-color18="e0/e0/e0" # Base 01
-color19="c5/c8/c6" # Base 02
-color20="96/98/96" # Base 04
-color21="28/2a/2e" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="b4/b7/b4" # Base 03 - Bright Black
+  color09="F9/6A/38" # Base 09
+  color10="e0/e0/e0" # Base 01
+  color11="c5/c8/c6" # Base 02
+  color12="96/98/96" # Base 04
+  color13="28/2a/2e" # Base 06
+  color14="39/71/ED" # Base 0F
+  color15="1d/1f/21" # Base 07 - Bright White
+else
+  color08="b4/b7/b4" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="1d/1f/21" # Base 07 - Bright White
+  color16="F9/6A/38" # Base 09
+  color17="39/71/ED" # Base 0F
+  color18="e0/e0/e0" # Base 01
+  color19="c5/c8/c6" # Base 02
+  color20="96/98/96" # Base 04
+  color21="28/2a/2e" # Base 06
+fi;
 color_foreground="37/3b/41" # Base 05
 color_background="ff/ff/ff" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-grayscale-dark.sh
+++ b/scripts/base16-grayscale-dark.sh
@@ -11,20 +11,31 @@ color04="68/68/68" # Base 0D - Blue
 color05="74/74/74" # Base 0E - Magenta
 color06="86/86/86" # Base 0C - Cyan
 color07="b9/b9/b9" # Base 05 - White
-color08="52/52/52" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f7/f7" # Base 07 - Bright White
-color16="99/99/99" # Base 09
-color17="5e/5e/5e" # Base 0F
-color18="25/25/25" # Base 01
-color19="46/46/46" # Base 02
-color20="ab/ab/ab" # Base 04
-color21="e3/e3/e3" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="52/52/52" # Base 03 - Bright Black
+  color09="99/99/99" # Base 09
+  color10="25/25/25" # Base 01
+  color11="46/46/46" # Base 02
+  color12="ab/ab/ab" # Base 04
+  color13="e3/e3/e3" # Base 06
+  color14="5e/5e/5e" # Base 0F
+  color15="f7/f7/f7" # Base 07 - Bright White
+else
+  color08="52/52/52" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f7/f7/f7" # Base 07 - Bright White
+  color16="99/99/99" # Base 09
+  color17="5e/5e/5e" # Base 0F
+  color18="25/25/25" # Base 01
+  color19="46/46/46" # Base 02
+  color20="ab/ab/ab" # Base 04
+  color21="e3/e3/e3" # Base 06
+fi;
 color_foreground="b9/b9/b9" # Base 05
 color_background="10/10/10" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-grayscale-light.sh
+++ b/scripts/base16-grayscale-light.sh
@@ -11,20 +11,31 @@ color04="68/68/68" # Base 0D - Blue
 color05="74/74/74" # Base 0E - Magenta
 color06="86/86/86" # Base 0C - Cyan
 color07="46/46/46" # Base 05 - White
-color08="ab/ab/ab" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="10/10/10" # Base 07 - Bright White
-color16="99/99/99" # Base 09
-color17="5e/5e/5e" # Base 0F
-color18="e3/e3/e3" # Base 01
-color19="b9/b9/b9" # Base 02
-color20="52/52/52" # Base 04
-color21="25/25/25" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="ab/ab/ab" # Base 03 - Bright Black
+  color09="99/99/99" # Base 09
+  color10="e3/e3/e3" # Base 01
+  color11="b9/b9/b9" # Base 02
+  color12="52/52/52" # Base 04
+  color13="25/25/25" # Base 06
+  color14="5e/5e/5e" # Base 0F
+  color15="10/10/10" # Base 07 - Bright White
+else
+  color08="ab/ab/ab" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="10/10/10" # Base 07 - Bright White
+  color16="99/99/99" # Base 09
+  color17="5e/5e/5e" # Base 0F
+  color18="e3/e3/e3" # Base 01
+  color19="b9/b9/b9" # Base 02
+  color20="52/52/52" # Base 04
+  color21="25/25/25" # Base 06
+fi;
 color_foreground="46/46/46" # Base 05
 color_background="f7/f7/f7" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-greenscreen.sh
+++ b/scripts/base16-greenscreen.sh
@@ -11,20 +11,31 @@ color04="00/99/00" # Base 0D - Blue
 color05="00/bb/00" # Base 0E - Magenta
 color06="00/55/00" # Base 0C - Cyan
 color07="00/bb/00" # Base 05 - White
-color08="00/77/00" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="00/ff/00" # Base 07 - Bright White
-color16="00/99/00" # Base 09
-color17="00/55/00" # Base 0F
-color18="00/33/00" # Base 01
-color19="00/55/00" # Base 02
-color20="00/99/00" # Base 04
-color21="00/dd/00" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="00/77/00" # Base 03 - Bright Black
+  color09="00/99/00" # Base 09
+  color10="00/33/00" # Base 01
+  color11="00/55/00" # Base 02
+  color12="00/99/00" # Base 04
+  color13="00/dd/00" # Base 06
+  color14="00/55/00" # Base 0F
+  color15="00/ff/00" # Base 07 - Bright White
+else
+  color08="00/77/00" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="00/ff/00" # Base 07 - Bright White
+  color16="00/99/00" # Base 09
+  color17="00/55/00" # Base 0F
+  color18="00/33/00" # Base 01
+  color19="00/55/00" # Base 02
+  color20="00/99/00" # Base 04
+  color21="00/dd/00" # Base 06
+fi;
 color_foreground="00/bb/00" # Base 05
 color_background="00/11/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-gruvbox-dark-hard.sh
+++ b/scripts/base16-gruvbox-dark-hard.sh
@@ -11,20 +11,31 @@ color04="83/a5/98" # Base 0D - Blue
 color05="d3/86/9b" # Base 0E - Magenta
 color06="8e/c0/7c" # Base 0C - Cyan
 color07="d5/c4/a1" # Base 05 - White
-color08="66/5c/54" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fb/f1/c7" # Base 07 - Bright White
-color16="fe/80/19" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="3c/38/36" # Base 01
-color19="50/49/45" # Base 02
-color20="bd/ae/93" # Base 04
-color21="eb/db/b2" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="66/5c/54" # Base 03 - Bright Black
+  color09="fe/80/19" # Base 09
+  color10="3c/38/36" # Base 01
+  color11="50/49/45" # Base 02
+  color12="bd/ae/93" # Base 04
+  color13="eb/db/b2" # Base 06
+  color14="d6/5d/0e" # Base 0F
+  color15="fb/f1/c7" # Base 07 - Bright White
+else
+  color08="66/5c/54" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="fb/f1/c7" # Base 07 - Bright White
+  color16="fe/80/19" # Base 09
+  color17="d6/5d/0e" # Base 0F
+  color18="3c/38/36" # Base 01
+  color19="50/49/45" # Base 02
+  color20="bd/ae/93" # Base 04
+  color21="eb/db/b2" # Base 06
+fi;
 color_foreground="d5/c4/a1" # Base 05
 color_background="1d/20/21" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-gruvbox-dark-medium.sh
+++ b/scripts/base16-gruvbox-dark-medium.sh
@@ -11,20 +11,31 @@ color04="83/a5/98" # Base 0D - Blue
 color05="d3/86/9b" # Base 0E - Magenta
 color06="8e/c0/7c" # Base 0C - Cyan
 color07="d5/c4/a1" # Base 05 - White
-color08="66/5c/54" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fb/f1/c7" # Base 07 - Bright White
-color16="fe/80/19" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="3c/38/36" # Base 01
-color19="50/49/45" # Base 02
-color20="bd/ae/93" # Base 04
-color21="eb/db/b2" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="66/5c/54" # Base 03 - Bright Black
+  color09="fe/80/19" # Base 09
+  color10="3c/38/36" # Base 01
+  color11="50/49/45" # Base 02
+  color12="bd/ae/93" # Base 04
+  color13="eb/db/b2" # Base 06
+  color14="d6/5d/0e" # Base 0F
+  color15="fb/f1/c7" # Base 07 - Bright White
+else
+  color08="66/5c/54" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="fb/f1/c7" # Base 07 - Bright White
+  color16="fe/80/19" # Base 09
+  color17="d6/5d/0e" # Base 0F
+  color18="3c/38/36" # Base 01
+  color19="50/49/45" # Base 02
+  color20="bd/ae/93" # Base 04
+  color21="eb/db/b2" # Base 06
+fi;
 color_foreground="d5/c4/a1" # Base 05
 color_background="28/28/28" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-gruvbox-dark-pale.sh
+++ b/scripts/base16-gruvbox-dark-pale.sh
@@ -11,20 +11,31 @@ color04="83/ad/ad" # Base 0D - Blue
 color05="d4/85/ad" # Base 0E - Magenta
 color06="85/ad/85" # Base 0C - Cyan
 color07="da/b9/97" # Base 05 - White
-color08="8a/8a/8a" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="eb/db/b2" # Base 07 - Bright White
-color16="ff/87/00" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="3a/3a/3a" # Base 01
-color19="4e/4e/4e" # Base 02
-color20="94/94/94" # Base 04
-color21="d5/c4/a1" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="8a/8a/8a" # Base 03 - Bright Black
+  color09="ff/87/00" # Base 09
+  color10="3a/3a/3a" # Base 01
+  color11="4e/4e/4e" # Base 02
+  color12="94/94/94" # Base 04
+  color13="d5/c4/a1" # Base 06
+  color14="d6/5d/0e" # Base 0F
+  color15="eb/db/b2" # Base 07 - Bright White
+else
+  color08="8a/8a/8a" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="eb/db/b2" # Base 07 - Bright White
+  color16="ff/87/00" # Base 09
+  color17="d6/5d/0e" # Base 0F
+  color18="3a/3a/3a" # Base 01
+  color19="4e/4e/4e" # Base 02
+  color20="94/94/94" # Base 04
+  color21="d5/c4/a1" # Base 06
+fi;
 color_foreground="da/b9/97" # Base 05
 color_background="26/26/26" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-gruvbox-dark-soft.sh
+++ b/scripts/base16-gruvbox-dark-soft.sh
@@ -11,20 +11,31 @@ color04="83/a5/98" # Base 0D - Blue
 color05="d3/86/9b" # Base 0E - Magenta
 color06="8e/c0/7c" # Base 0C - Cyan
 color07="d5/c4/a1" # Base 05 - White
-color08="66/5c/54" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fb/f1/c7" # Base 07 - Bright White
-color16="fe/80/19" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="3c/38/36" # Base 01
-color19="50/49/45" # Base 02
-color20="bd/ae/93" # Base 04
-color21="eb/db/b2" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="66/5c/54" # Base 03 - Bright Black
+  color09="fe/80/19" # Base 09
+  color10="3c/38/36" # Base 01
+  color11="50/49/45" # Base 02
+  color12="bd/ae/93" # Base 04
+  color13="eb/db/b2" # Base 06
+  color14="d6/5d/0e" # Base 0F
+  color15="fb/f1/c7" # Base 07 - Bright White
+else
+  color08="66/5c/54" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="fb/f1/c7" # Base 07 - Bright White
+  color16="fe/80/19" # Base 09
+  color17="d6/5d/0e" # Base 0F
+  color18="3c/38/36" # Base 01
+  color19="50/49/45" # Base 02
+  color20="bd/ae/93" # Base 04
+  color21="eb/db/b2" # Base 06
+fi;
 color_foreground="d5/c4/a1" # Base 05
 color_background="32/30/2f" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-gruvbox-light-hard.sh
+++ b/scripts/base16-gruvbox-light-hard.sh
@@ -11,20 +11,31 @@ color04="07/66/78" # Base 0D - Blue
 color05="8f/3f/71" # Base 0E - Magenta
 color06="42/7b/58" # Base 0C - Cyan
 color07="50/49/45" # Base 05 - White
-color08="bd/ae/93" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="28/28/28" # Base 07 - Bright White
-color16="af/3a/03" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="eb/db/b2" # Base 01
-color19="d5/c4/a1" # Base 02
-color20="66/5c/54" # Base 04
-color21="3c/38/36" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="bd/ae/93" # Base 03 - Bright Black
+  color09="af/3a/03" # Base 09
+  color10="eb/db/b2" # Base 01
+  color11="d5/c4/a1" # Base 02
+  color12="66/5c/54" # Base 04
+  color13="3c/38/36" # Base 06
+  color14="d6/5d/0e" # Base 0F
+  color15="28/28/28" # Base 07 - Bright White
+else
+  color08="bd/ae/93" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="28/28/28" # Base 07 - Bright White
+  color16="af/3a/03" # Base 09
+  color17="d6/5d/0e" # Base 0F
+  color18="eb/db/b2" # Base 01
+  color19="d5/c4/a1" # Base 02
+  color20="66/5c/54" # Base 04
+  color21="3c/38/36" # Base 06
+fi;
 color_foreground="50/49/45" # Base 05
 color_background="f9/f5/d7" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-gruvbox-light-medium.sh
+++ b/scripts/base16-gruvbox-light-medium.sh
@@ -11,20 +11,31 @@ color04="07/66/78" # Base 0D - Blue
 color05="8f/3f/71" # Base 0E - Magenta
 color06="42/7b/58" # Base 0C - Cyan
 color07="50/49/45" # Base 05 - White
-color08="bd/ae/93" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="28/28/28" # Base 07 - Bright White
-color16="af/3a/03" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="eb/db/b2" # Base 01
-color19="d5/c4/a1" # Base 02
-color20="66/5c/54" # Base 04
-color21="3c/38/36" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="bd/ae/93" # Base 03 - Bright Black
+  color09="af/3a/03" # Base 09
+  color10="eb/db/b2" # Base 01
+  color11="d5/c4/a1" # Base 02
+  color12="66/5c/54" # Base 04
+  color13="3c/38/36" # Base 06
+  color14="d6/5d/0e" # Base 0F
+  color15="28/28/28" # Base 07 - Bright White
+else
+  color08="bd/ae/93" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="28/28/28" # Base 07 - Bright White
+  color16="af/3a/03" # Base 09
+  color17="d6/5d/0e" # Base 0F
+  color18="eb/db/b2" # Base 01
+  color19="d5/c4/a1" # Base 02
+  color20="66/5c/54" # Base 04
+  color21="3c/38/36" # Base 06
+fi;
 color_foreground="50/49/45" # Base 05
 color_background="fb/f1/c7" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-gruvbox-light-soft.sh
+++ b/scripts/base16-gruvbox-light-soft.sh
@@ -11,20 +11,31 @@ color04="07/66/78" # Base 0D - Blue
 color05="8f/3f/71" # Base 0E - Magenta
 color06="42/7b/58" # Base 0C - Cyan
 color07="50/49/45" # Base 05 - White
-color08="bd/ae/93" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="28/28/28" # Base 07 - Bright White
-color16="af/3a/03" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="eb/db/b2" # Base 01
-color19="d5/c4/a1" # Base 02
-color20="66/5c/54" # Base 04
-color21="3c/38/36" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="bd/ae/93" # Base 03 - Bright Black
+  color09="af/3a/03" # Base 09
+  color10="eb/db/b2" # Base 01
+  color11="d5/c4/a1" # Base 02
+  color12="66/5c/54" # Base 04
+  color13="3c/38/36" # Base 06
+  color14="d6/5d/0e" # Base 0F
+  color15="28/28/28" # Base 07 - Bright White
+else
+  color08="bd/ae/93" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="28/28/28" # Base 07 - Bright White
+  color16="af/3a/03" # Base 09
+  color17="d6/5d/0e" # Base 0F
+  color18="eb/db/b2" # Base 01
+  color19="d5/c4/a1" # Base 02
+  color20="66/5c/54" # Base 04
+  color21="3c/38/36" # Base 06
+fi;
 color_foreground="50/49/45" # Base 05
 color_background="f2/e5/bc" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-hardcore.sh
+++ b/scripts/base16-hardcore.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Hardcore scheme by Chris Caller
+
+color00="21/21/21" # Base 00 - Black
+color01="f9/26/72" # Base 08 - Red
+color02="a6/e2/2e" # Base 0B - Green
+color03="e6/db/74" # Base 0A - Yellow
+color04="66/d9/ef" # Base 0D - Blue
+color05="9e/6f/fe" # Base 0E - Magenta
+color06="70/83/87" # Base 0C - Cyan
+color07="cd/cd/cd" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="4A/4A/4A" # Base 03 - Bright Black
+  color09="fd/97/1f" # Base 09
+  color10="30/30/30" # Base 01
+  color11="35/35/35" # Base 02
+  color12="70/70/70" # Base 04
+  color13="e5/e5/e5" # Base 06
+  color14="e8/b8/82" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="4A/4A/4A" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="fd/97/1f" # Base 09
+  color17="e8/b8/82" # Base 0F
+  color18="30/30/30" # Base 01
+  color19="35/35/35" # Base 02
+  color20="70/70/70" # Base 04
+  color21="e5/e5/e5" # Base 06
+fi;
+color_foreground="cd/cd/cd" # Base 05
+color_background="21/21/21" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg cdcdcd # foreground
+  put_template_custom Ph 212121 # background
+  put_template_custom Pi cdcdcd # bold color
+  put_template_custom Pj 353535 # selection color
+  put_template_custom Pk cdcdcd # selected text color
+  put_template_custom Pl cdcdcd # cursor
+  put_template_custom Pm 212121 # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-harmonic-dark.sh
+++ b/scripts/base16-harmonic-dark.sh
@@ -11,20 +11,31 @@ color04="8b/56/bf" # Base 0D - Blue
 color05="bf/56/8b" # Base 0E - Magenta
 color06="56/8b/bf" # Base 0C - Cyan
 color07="cb/d6/e2" # Base 05 - White
-color08="62/7e/99" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f9/fb" # Base 07 - Bright White
-color16="bf/bf/56" # Base 09
-color17="bf/56/56" # Base 0F
-color18="22/3b/54" # Base 01
-color19="40/5c/79" # Base 02
-color20="aa/bc/ce" # Base 04
-color21="e5/eb/f1" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="62/7e/99" # Base 03 - Bright Black
+  color09="bf/bf/56" # Base 09
+  color10="22/3b/54" # Base 01
+  color11="40/5c/79" # Base 02
+  color12="aa/bc/ce" # Base 04
+  color13="e5/eb/f1" # Base 06
+  color14="bf/56/56" # Base 0F
+  color15="f7/f9/fb" # Base 07 - Bright White
+else
+  color08="62/7e/99" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f7/f9/fb" # Base 07 - Bright White
+  color16="bf/bf/56" # Base 09
+  color17="bf/56/56" # Base 0F
+  color18="22/3b/54" # Base 01
+  color19="40/5c/79" # Base 02
+  color20="aa/bc/ce" # Base 04
+  color21="e5/eb/f1" # Base 06
+fi;
 color_foreground="cb/d6/e2" # Base 05
 color_background="0b/1c/2c" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-harmonic-light.sh
+++ b/scripts/base16-harmonic-light.sh
@@ -11,20 +11,31 @@ color04="8b/56/bf" # Base 0D - Blue
 color05="bf/56/8b" # Base 0E - Magenta
 color06="56/8b/bf" # Base 0C - Cyan
 color07="40/5c/79" # Base 05 - White
-color08="aa/bc/ce" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="0b/1c/2c" # Base 07 - Bright White
-color16="bf/bf/56" # Base 09
-color17="bf/56/56" # Base 0F
-color18="e5/eb/f1" # Base 01
-color19="cb/d6/e2" # Base 02
-color20="62/7e/99" # Base 04
-color21="22/3b/54" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="aa/bc/ce" # Base 03 - Bright Black
+  color09="bf/bf/56" # Base 09
+  color10="e5/eb/f1" # Base 01
+  color11="cb/d6/e2" # Base 02
+  color12="62/7e/99" # Base 04
+  color13="22/3b/54" # Base 06
+  color14="bf/56/56" # Base 0F
+  color15="0b/1c/2c" # Base 07 - Bright White
+else
+  color08="aa/bc/ce" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="0b/1c/2c" # Base 07 - Bright White
+  color16="bf/bf/56" # Base 09
+  color17="bf/56/56" # Base 0F
+  color18="e5/eb/f1" # Base 01
+  color19="cb/d6/e2" # Base 02
+  color20="62/7e/99" # Base 04
+  color21="22/3b/54" # Base 06
+fi;
 color_foreground="40/5c/79" # Base 05
 color_background="f7/f9/fb" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-heetch-light.sh
+++ b/scripts/base16-heetch-light.sh
@@ -11,20 +11,31 @@ color04="47/f9/f5" # Base 0D - Blue
 color05="bd/01/52" # Base 0E - Magenta
 color06="c3/36/78" # Base 0C - Cyan
 color07="5a/49/6e" # Base 05 - White
-color08="9c/92/a8" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="19/01/34" # Base 07 - Bright White
-color16="bd/b6/c5" # Base 09
-color17="de/da/e2" # Base 0F
-color18="39/25/51" # Base 01
-color19="7b/6d/8b" # Base 02
-color20="dd/d6/e5" # Base 04
-color21="47/05/46" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="9c/92/a8" # Base 03 - Bright Black
+  color09="bd/b6/c5" # Base 09
+  color10="39/25/51" # Base 01
+  color11="7b/6d/8b" # Base 02
+  color12="dd/d6/e5" # Base 04
+  color13="47/05/46" # Base 06
+  color14="de/da/e2" # Base 0F
+  color15="19/01/34" # Base 07 - Bright White
+else
+  color08="9c/92/a8" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="19/01/34" # Base 07 - Bright White
+  color16="bd/b6/c5" # Base 09
+  color17="de/da/e2" # Base 0F
+  color18="39/25/51" # Base 01
+  color19="7b/6d/8b" # Base 02
+  color20="dd/d6/e5" # Base 04
+  color21="47/05/46" # Base 06
+fi;
 color_foreground="5a/49/6e" # Base 05
 color_background="fe/ff/ff" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-heetch.sh
+++ b/scripts/base16-heetch.sh
@@ -11,20 +11,31 @@ color04="BD/01/52" # Base 0D - Blue
 color05="82/03/4C" # Base 0E - Magenta
 color06="F8/00/59" # Base 0C - Cyan
 color07="BD/B6/C5" # Base 05 - White
-color08="7B/6D/8B" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FE/FF/FF" # Base 07 - Bright White
-color16="5B/A2/B6" # Base 09
-color17="47/05/46" # Base 0F
-color18="39/25/51" # Base 01
-color19="5A/49/6E" # Base 02
-color20="9C/92/A8" # Base 04
-color21="DE/DA/E2" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="7B/6D/8B" # Base 03 - Bright Black
+  color09="5B/A2/B6" # Base 09
+  color10="39/25/51" # Base 01
+  color11="5A/49/6E" # Base 02
+  color12="9C/92/A8" # Base 04
+  color13="DE/DA/E2" # Base 06
+  color14="47/05/46" # Base 0F
+  color15="FE/FF/FF" # Base 07 - Bright White
+else
+  color08="7B/6D/8B" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="FE/FF/FF" # Base 07 - Bright White
+  color16="5B/A2/B6" # Base 09
+  color17="47/05/46" # Base 0F
+  color18="39/25/51" # Base 01
+  color19="5A/49/6E" # Base 02
+  color20="9C/92/A8" # Base 04
+  color21="DE/DA/E2" # Base 06
+fi;
 color_foreground="BD/B6/C5" # Base 05
 color_background="19/01/34" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-helios.sh
+++ b/scripts/base16-helios.sh
@@ -11,20 +11,31 @@ color04="1e/8b/ac" # Base 0D - Blue
 color05="be/42/64" # Base 0E - Magenta
 color06="1b/a5/95" # Base 0C - Cyan
 color07="d5/d5/d5" # Base 05 - White
-color08="6f/75/79" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="e5/e5/e5" # Base 07 - Bright White
-color16="eb/84/13" # Base 09
-color17="c8/5e/0d" # Base 0F
-color18="38/3c/3e" # Base 01
-color19="53/58/5b" # Base 02
-color20="cd/cd/cd" # Base 04
-color21="dd/dd/dd" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="6f/75/79" # Base 03 - Bright Black
+  color09="eb/84/13" # Base 09
+  color10="38/3c/3e" # Base 01
+  color11="53/58/5b" # Base 02
+  color12="cd/cd/cd" # Base 04
+  color13="dd/dd/dd" # Base 06
+  color14="c8/5e/0d" # Base 0F
+  color15="e5/e5/e5" # Base 07 - Bright White
+else
+  color08="6f/75/79" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="e5/e5/e5" # Base 07 - Bright White
+  color16="eb/84/13" # Base 09
+  color17="c8/5e/0d" # Base 0F
+  color18="38/3c/3e" # Base 01
+  color19="53/58/5b" # Base 02
+  color20="cd/cd/cd" # Base 04
+  color21="dd/dd/dd" # Base 06
+fi;
 color_foreground="d5/d5/d5" # Base 05
 color_background="1d/20/21" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-hopscotch.sh
+++ b/scripts/base16-hopscotch.sh
@@ -11,20 +11,31 @@ color04="12/90/bf" # Base 0D - Blue
 color05="c8/5e/7c" # Base 0E - Magenta
 color06="14/9b/93" # Base 0C - Cyan
 color07="b9/b5/b8" # Base 05 - White
-color08="79/73/79" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="fd/8b/19" # Base 09
-color17="b3/35/08" # Base 0F
-color18="43/3b/42" # Base 01
-color19="5c/54/5b" # Base 02
-color20="98/94/98" # Base 04
-color21="d5/d3/d5" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="79/73/79" # Base 03 - Bright Black
+  color09="fd/8b/19" # Base 09
+  color10="43/3b/42" # Base 01
+  color11="5c/54/5b" # Base 02
+  color12="98/94/98" # Base 04
+  color13="d5/d3/d5" # Base 06
+  color14="b3/35/08" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="79/73/79" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="fd/8b/19" # Base 09
+  color17="b3/35/08" # Base 0F
+  color18="43/3b/42" # Base 01
+  color19="5c/54/5b" # Base 02
+  color20="98/94/98" # Base 04
+  color21="d5/d3/d5" # Base 06
+fi;
 color_foreground="b9/b5/b8" # Base 05
 color_background="32/29/31" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-horizon-dark.sh
+++ b/scripts/base16-horizon-dark.sh
@@ -11,20 +11,31 @@ color04="DF/52/73" # Base 0D - Blue
 color05="B0/72/D1" # Base 0E - Magenta
 color06="24/A8/B4" # Base 0C - Cyan
 color07="CB/CE/D0" # Base 05 - White
-color08="67/6A/8D" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="E3/E6/EE" # Base 07 - Bright White
-color16="E5/8D/7D" # Base 09
-color17="E4/A3/82" # Base 0F
-color18="23/25/30" # Base 01
-color19="2E/30/3E" # Base 02
-color20="CE/D1/D0" # Base 04
-color21="DC/DF/E4" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="6F/6F/70" # Base 03 - Bright Black
+  color09="E5/8D/7D" # Base 09
+  color10="23/25/30" # Base 01
+  color11="2E/30/3E" # Base 02
+  color12="9D/A0/A2" # Base 04
+  color13="DC/DF/E4" # Base 06
+  color14="E4/A3/82" # Base 0F
+  color15="E3/E6/EE" # Base 07 - Bright White
+else
+  color08="6F/6F/70" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="E3/E6/EE" # Base 07 - Bright White
+  color16="E5/8D/7D" # Base 09
+  color17="E4/A3/82" # Base 0F
+  color18="23/25/30" # Base 01
+  color19="2E/30/3E" # Base 02
+  color20="9D/A0/A2" # Base 04
+  color21="DC/DF/E4" # Base 06
+fi;
 color_foreground="CB/CE/D0" # Base 05
 color_background="1C/1E/26" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-horizon-light.sh
+++ b/scripts/base16-horizon-light.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Horizon Light scheme by Michaël Ball (http://github.com/michael-ball/)
+
+color00="FD/F0/ED" # Base 00 - Black
+color01="F7/93/9B" # Base 08 - Red
+color02="94/E1/B0" # Base 0B - Green
+color03="FB/E0/D9" # Base 0A - Yellow
+color04="DA/10/3F" # Base 0D - Blue
+color05="1D/89/91" # Base 0E - Magenta
+color06="DC/33/18" # Base 0C - Cyan
+color07="40/3C/3D" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="BD/B3/B1" # Base 03 - Bright Black
+  color09="F6/66/1E" # Base 09
+  color10="FA/DA/D1" # Base 01
+  color11="F9/CB/BE" # Base 02
+  color12="94/8C/8A" # Base 04
+  color13="30/2C/2D" # Base 06
+  color14="E5/8C/92" # Base 0F
+  color15="20/1C/1D" # Base 07 - Bright White
+else
+  color08="BD/B3/B1" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="20/1C/1D" # Base 07 - Bright White
+  color16="F6/66/1E" # Base 09
+  color17="E5/8C/92" # Base 0F
+  color18="FA/DA/D1" # Base 01
+  color19="F9/CB/BE" # Base 02
+  color20="94/8C/8A" # Base 04
+  color21="30/2C/2D" # Base 06
+fi;
+color_foreground="40/3C/3D" # Base 05
+color_background="FD/F0/ED" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg 403C3D # foreground
+  put_template_custom Ph FDF0ED # background
+  put_template_custom Pi 403C3D # bold color
+  put_template_custom Pj F9CBBE # selection color
+  put_template_custom Pk 403C3D # selected text color
+  put_template_custom Pl 403C3D # cursor
+  put_template_custom Pm FDF0ED # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-horizon-terminal-dark.sh
+++ b/scripts/base16-horizon-terminal-dark.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Horizon Dark scheme by Michaël Ball (http://github.com/michael-ball/)
+
+color00="1C/1E/26" # Base 00 - Black
+color01="E9/56/78" # Base 08 - Red
+color02="29/D3/98" # Base 0B - Green
+color03="FA/C2/9A" # Base 0A - Yellow
+color04="26/BB/D9" # Base 0D - Blue
+color05="EE/64/AC" # Base 0E - Magenta
+color06="59/E1/E3" # Base 0C - Cyan
+color07="CB/CE/D0" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="6F/6F/70" # Base 03 - Bright Black
+  color09="FA/B7/95" # Base 09
+  color10="23/25/30" # Base 01
+  color11="2E/30/3E" # Base 02
+  color12="9D/A0/A2" # Base 04
+  color13="DC/DF/E4" # Base 06
+  color14="F0/93/83" # Base 0F
+  color15="E3/E6/EE" # Base 07 - Bright White
+else
+  color08="6F/6F/70" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="E3/E6/EE" # Base 07 - Bright White
+  color16="FA/B7/95" # Base 09
+  color17="F0/93/83" # Base 0F
+  color18="23/25/30" # Base 01
+  color19="2E/30/3E" # Base 02
+  color20="9D/A0/A2" # Base 04
+  color21="DC/DF/E4" # Base 06
+fi;
+color_foreground="CB/CE/D0" # Base 05
+color_background="1C/1E/26" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg CBCED0 # foreground
+  put_template_custom Ph 1C1E26 # background
+  put_template_custom Pi CBCED0 # bold color
+  put_template_custom Pj 2E303E # selection color
+  put_template_custom Pk CBCED0 # selected text color
+  put_template_custom Pl CBCED0 # cursor
+  put_template_custom Pm 1C1E26 # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-horizon-terminal-light.sh
+++ b/scripts/base16-horizon-terminal-light.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Horizon Light scheme by Michaël Ball (http://github.com/michael-ball/)
+
+color00="FD/F0/ED" # Base 00 - Black
+color01="E9/56/78" # Base 08 - Red
+color02="29/D3/98" # Base 0B - Green
+color03="FA/DA/D1" # Base 0A - Yellow
+color04="26/BB/D9" # Base 0D - Blue
+color05="EE/64/AC" # Base 0E - Magenta
+color06="59/E1/E3" # Base 0C - Cyan
+color07="40/3C/3D" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="BD/B3/B1" # Base 03 - Bright Black
+  color09="F9/CE/C3" # Base 09
+  color10="FA/DA/D1" # Base 01
+  color11="F9/CB/BE" # Base 02
+  color12="94/8C/8A" # Base 04
+  color13="30/2C/2D" # Base 06
+  color14="F9/CB/BE" # Base 0F
+  color15="20/1C/1D" # Base 07 - Bright White
+else
+  color08="BD/B3/B1" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="20/1C/1D" # Base 07 - Bright White
+  color16="F9/CE/C3" # Base 09
+  color17="F9/CB/BE" # Base 0F
+  color18="FA/DA/D1" # Base 01
+  color19="F9/CB/BE" # Base 02
+  color20="94/8C/8A" # Base 04
+  color21="30/2C/2D" # Base 06
+fi;
+color_foreground="40/3C/3D" # Base 05
+color_background="FD/F0/ED" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg 403C3D # foreground
+  put_template_custom Ph FDF0ED # background
+  put_template_custom Pi 403C3D # bold color
+  put_template_custom Pj F9CBBE # selection color
+  put_template_custom Pk 403C3D # selected text color
+  put_template_custom Pl 403C3D # cursor
+  put_template_custom Pm FDF0ED # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-ia-dark.sh
+++ b/scripts/base16-ia-dark.sh
@@ -11,20 +11,31 @@ color04="8e/cc/dd" # Base 0D - Blue
 color05="b9/8e/b2" # Base 0E - Magenta
 color06="7c/9c/ae" # Base 0C - Cyan
 color07="cc/cc/cc" # Base 05 - White
-color08="76/76/76" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/f8/f8" # Base 07 - Bright White
-color16="d8/68/68" # Base 09
-color17="8b/6c/37" # Base 0F
-color18="22/22/22" # Base 01
-color19="1d/41/4d" # Base 02
-color20="b8/b8/b8" # Base 04
-color21="e8/e8/e8" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="76/76/76" # Base 03 - Bright Black
+  color09="d8/68/68" # Base 09
+  color10="22/22/22" # Base 01
+  color11="1d/41/4d" # Base 02
+  color12="b8/b8/b8" # Base 04
+  color13="e8/e8/e8" # Base 06
+  color14="8b/6c/37" # Base 0F
+  color15="f8/f8/f8" # Base 07 - Bright White
+else
+  color08="76/76/76" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f8/f8/f8" # Base 07 - Bright White
+  color16="d8/68/68" # Base 09
+  color17="8b/6c/37" # Base 0F
+  color18="22/22/22" # Base 01
+  color19="1d/41/4d" # Base 02
+  color20="b8/b8/b8" # Base 04
+  color21="e8/e8/e8" # Base 06
+fi;
 color_foreground="cc/cc/cc" # Base 05
 color_background="1a/1a/1a" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-ia-light.sh
+++ b/scripts/base16-ia-light.sh
@@ -11,20 +11,31 @@ color04="48/ba/c2" # Base 0D - Blue
 color05="a9/45/98" # Base 0E - Magenta
 color06="2d/6b/b1" # Base 0C - Cyan
 color07="18/18/18" # Base 05 - White
-color08="89/89/89" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/f8/f8" # Base 07 - Bright White
-color16="c4/3e/18" # Base 09
-color17="8b/6c/37" # Base 0F
-color18="de/de/de" # Base 01
-color19="bd/e5/f2" # Base 02
-color20="76/76/76" # Base 04
-color21="e8/e8/e8" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="89/89/89" # Base 03 - Bright Black
+  color09="c4/3e/18" # Base 09
+  color10="de/de/de" # Base 01
+  color11="bd/e5/f2" # Base 02
+  color12="76/76/76" # Base 04
+  color13="e8/e8/e8" # Base 06
+  color14="8b/6c/37" # Base 0F
+  color15="f8/f8/f8" # Base 07 - Bright White
+else
+  color08="89/89/89" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f8/f8/f8" # Base 07 - Bright White
+  color16="c4/3e/18" # Base 09
+  color17="8b/6c/37" # Base 0F
+  color18="de/de/de" # Base 01
+  color19="bd/e5/f2" # Base 02
+  color20="76/76/76" # Base 04
+  color21="e8/e8/e8" # Base 06
+fi;
 color_foreground="18/18/18" # Base 05
 color_background="f6/f6/f6" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-icy.sh
+++ b/scripts/base16-icy.sh
@@ -11,20 +11,31 @@ color04="00/bc/d4" # Base 0D - Blue
 color05="00/ac/c1" # Base 0E - Magenta
 color06="26/c6/da" # Base 0C - Cyan
 color07="09/5b/67" # Base 05 - White
-color08="05/2e/34" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="10/9c/b0" # Base 07 - Bright White
-color16="b3/eb/f2" # Base 09
-color17="00/97/a7" # Base 0F
-color18="03/16/19" # Base 01
-color19="04/1f/23" # Base 02
-color20="06/40/48" # Base 04
-color21="0c/7c/8c" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="05/2e/34" # Base 03 - Bright Black
+  color09="b3/eb/f2" # Base 09
+  color10="03/16/19" # Base 01
+  color11="04/1f/23" # Base 02
+  color12="06/40/48" # Base 04
+  color13="0c/7c/8c" # Base 06
+  color14="00/97/a7" # Base 0F
+  color15="10/9c/b0" # Base 07 - Bright White
+else
+  color08="05/2e/34" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="10/9c/b0" # Base 07 - Bright White
+  color16="b3/eb/f2" # Base 09
+  color17="00/97/a7" # Base 0F
+  color18="03/16/19" # Base 01
+  color19="04/1f/23" # Base 02
+  color20="06/40/48" # Base 04
+  color21="0c/7c/8c" # Base 06
+fi;
 color_foreground="09/5b/67" # Base 05
 color_background="02/10/12" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-irblack.sh
+++ b/scripts/base16-irblack.sh
@@ -11,20 +11,31 @@ color04="96/cb/fe" # Base 0D - Blue
 color05="ff/73/fd" # Base 0E - Magenta
 color06="c6/c5/fe" # Base 0C - Cyan
 color07="b5/b3/aa" # Base 05 - White
-color08="6c/6c/66" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fd/fb/ee" # Base 07 - Bright White
-color16="e9/c0/62" # Base 09
-color17="b1/8a/3d" # Base 0F
-color18="24/24/22" # Base 01
-color19="48/48/44" # Base 02
-color20="91/8f/88" # Base 04
-color21="d9/d7/cc" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="6c/6c/66" # Base 03 - Bright Black
+  color09="e9/c0/62" # Base 09
+  color10="24/24/22" # Base 01
+  color11="48/48/44" # Base 02
+  color12="91/8f/88" # Base 04
+  color13="d9/d7/cc" # Base 06
+  color14="b1/8a/3d" # Base 0F
+  color15="fd/fb/ee" # Base 07 - Bright White
+else
+  color08="6c/6c/66" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="fd/fb/ee" # Base 07 - Bright White
+  color16="e9/c0/62" # Base 09
+  color17="b1/8a/3d" # Base 0F
+  color18="24/24/22" # Base 01
+  color19="48/48/44" # Base 02
+  color20="91/8f/88" # Base 04
+  color21="d9/d7/cc" # Base 06
+fi;
 color_foreground="b5/b3/aa" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-isotope.sh
+++ b/scripts/base16-isotope.sh
@@ -11,20 +11,31 @@ color04="00/66/ff" # Base 0D - Blue
 color05="cc/00/ff" # Base 0E - Magenta
 color06="00/ff/ff" # Base 0C - Cyan
 color07="d0/d0/d0" # Base 05 - White
-color08="80/80/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="ff/99/00" # Base 09
-color17="33/00/ff" # Base 0F
-color18="40/40/40" # Base 01
-color19="60/60/60" # Base 02
-color20="c0/c0/c0" # Base 04
-color21="e0/e0/e0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="80/80/80" # Base 03 - Bright Black
+  color09="ff/99/00" # Base 09
+  color10="40/40/40" # Base 01
+  color11="60/60/60" # Base 02
+  color12="c0/c0/c0" # Base 04
+  color13="e0/e0/e0" # Base 06
+  color14="33/00/ff" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="80/80/80" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="ff/99/00" # Base 09
+  color17="33/00/ff" # Base 0F
+  color18="40/40/40" # Base 01
+  color19="60/60/60" # Base 02
+  color20="c0/c0/c0" # Base 04
+  color21="e0/e0/e0" # Base 06
+fi;
 color_foreground="d0/d0/d0" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-macintosh.sh
+++ b/scripts/base16-macintosh.sh
@@ -11,20 +11,31 @@ color04="00/00/d3" # Base 0D - Blue
 color05="47/00/a5" # Base 0E - Magenta
 color06="02/ab/ea" # Base 0C - Cyan
 color07="c0/c0/c0" # Base 05 - White
-color08="80/80/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="ff/64/03" # Base 09
-color17="90/71/3a" # Base 0F
-color18="40/40/40" # Base 01
-color19="40/40/40" # Base 02
-color20="80/80/80" # Base 04
-color21="c0/c0/c0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="80/80/80" # Base 03 - Bright Black
+  color09="ff/64/03" # Base 09
+  color10="40/40/40" # Base 01
+  color11="40/40/40" # Base 02
+  color12="80/80/80" # Base 04
+  color13="c0/c0/c0" # Base 06
+  color14="90/71/3a" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="80/80/80" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="ff/64/03" # Base 09
+  color17="90/71/3a" # Base 0F
+  color18="40/40/40" # Base 01
+  color19="40/40/40" # Base 02
+  color20="80/80/80" # Base 04
+  color21="c0/c0/c0" # Base 06
+fi;
 color_foreground="c0/c0/c0" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-marrakesh.sh
+++ b/scripts/base16-marrakesh.sh
@@ -11,20 +11,31 @@ color04="47/7c/a1" # Base 0D - Blue
 color05="88/68/b3" # Base 0E - Magenta
 color06="75/a7/38" # Base 0C - Cyan
 color07="94/8e/48" # Base 05 - White
-color08="6c/68/23" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fa/f0/a5" # Base 07 - Bright White
-color16="b3/61/44" # Base 09
-color17="b3/58/8e" # Base 0F
-color18="30/2e/00" # Base 01
-color19="5f/5b/17" # Base 02
-color20="86/81/3b" # Base 04
-color21="cc/c3/7a" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="6c/68/23" # Base 03 - Bright Black
+  color09="b3/61/44" # Base 09
+  color10="30/2e/00" # Base 01
+  color11="5f/5b/17" # Base 02
+  color12="86/81/3b" # Base 04
+  color13="cc/c3/7a" # Base 06
+  color14="b3/58/8e" # Base 0F
+  color15="fa/f0/a5" # Base 07 - Bright White
+else
+  color08="6c/68/23" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="fa/f0/a5" # Base 07 - Bright White
+  color16="b3/61/44" # Base 09
+  color17="b3/58/8e" # Base 0F
+  color18="30/2e/00" # Base 01
+  color19="5f/5b/17" # Base 02
+  color20="86/81/3b" # Base 04
+  color21="cc/c3/7a" # Base 06
+fi;
 color_foreground="94/8e/48" # Base 05
 color_background="20/16/02" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-materia.sh
+++ b/scripts/base16-materia.sh
@@ -11,20 +11,31 @@ color04="89/DD/FF" # Base 0D - Blue
 color05="82/AA/FF" # Base 0E - Magenta
 color06="80/CB/C4" # Base 0C - Cyan
 color07="CD/D3/DE" # Base 05 - White
-color08="70/78/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="EA/95/60" # Base 09
-color17="EC/5F/67" # Base 0F
-color18="2C/39/3F" # Base 01
-color19="37/47/4F" # Base 02
-color20="C9/CC/D3" # Base 04
-color21="D5/DB/E5" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="70/78/80" # Base 03 - Bright Black
+  color09="EA/95/60" # Base 09
+  color10="2C/39/3F" # Base 01
+  color11="37/47/4F" # Base 02
+  color12="C9/CC/D3" # Base 04
+  color13="D5/DB/E5" # Base 06
+  color14="EC/5F/67" # Base 0F
+  color15="FF/FF/FF" # Base 07 - Bright White
+else
+  color08="70/78/80" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="FF/FF/FF" # Base 07 - Bright White
+  color16="EA/95/60" # Base 09
+  color17="EC/5F/67" # Base 0F
+  color18="2C/39/3F" # Base 01
+  color19="37/47/4F" # Base 02
+  color20="C9/CC/D3" # Base 04
+  color21="D5/DB/E5" # Base 06
+fi;
 color_foreground="CD/D3/DE" # Base 05
 color_background="26/32/38" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-material-darker.sh
+++ b/scripts/base16-material-darker.sh
@@ -11,20 +11,31 @@ color04="82/AA/FF" # Base 0D - Blue
 color05="C7/92/EA" # Base 0E - Magenta
 color06="89/DD/FF" # Base 0C - Cyan
 color07="EE/FF/FF" # Base 05 - White
-color08="4A/4A/4A" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="F7/8C/6C" # Base 09
-color17="FF/53/70" # Base 0F
-color18="30/30/30" # Base 01
-color19="35/35/35" # Base 02
-color20="B2/CC/D6" # Base 04
-color21="EE/FF/FF" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="4A/4A/4A" # Base 03 - Bright Black
+  color09="F7/8C/6C" # Base 09
+  color10="30/30/30" # Base 01
+  color11="35/35/35" # Base 02
+  color12="B2/CC/D6" # Base 04
+  color13="EE/FF/FF" # Base 06
+  color14="FF/53/70" # Base 0F
+  color15="FF/FF/FF" # Base 07 - Bright White
+else
+  color08="4A/4A/4A" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="FF/FF/FF" # Base 07 - Bright White
+  color16="F7/8C/6C" # Base 09
+  color17="FF/53/70" # Base 0F
+  color18="30/30/30" # Base 01
+  color19="35/35/35" # Base 02
+  color20="B2/CC/D6" # Base 04
+  color21="EE/FF/FF" # Base 06
+fi;
 color_foreground="EE/FF/FF" # Base 05
 color_background="21/21/21" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-material-lighter.sh
+++ b/scripts/base16-material-lighter.sh
@@ -11,20 +11,31 @@ color04="61/82/B8" # Base 0D - Blue
 color05="7C/4D/FF" # Base 0E - Magenta
 color06="39/AD/B5" # Base 0C - Cyan
 color07="80/CB/C4" # Base 05 - White
-color08="CC/D7/DA" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="F7/6D/47" # Base 09
-color17="E5/39/35" # Base 0F
-color18="E7/EA/EC" # Base 01
-color19="CC/EA/E7" # Base 02
-color20="87/96/B0" # Base 04
-color21="80/CB/C4" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="CC/D7/DA" # Base 03 - Bright Black
+  color09="F7/6D/47" # Base 09
+  color10="E7/EA/EC" # Base 01
+  color11="CC/EA/E7" # Base 02
+  color12="87/96/B0" # Base 04
+  color13="80/CB/C4" # Base 06
+  color14="E5/39/35" # Base 0F
+  color15="FF/FF/FF" # Base 07 - Bright White
+else
+  color08="CC/D7/DA" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="FF/FF/FF" # Base 07 - Bright White
+  color16="F7/6D/47" # Base 09
+  color17="E5/39/35" # Base 0F
+  color18="E7/EA/EC" # Base 01
+  color19="CC/EA/E7" # Base 02
+  color20="87/96/B0" # Base 04
+  color21="80/CB/C4" # Base 06
+fi;
 color_foreground="80/CB/C4" # Base 05
 color_background="FA/FA/FA" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-material-palenight.sh
+++ b/scripts/base16-material-palenight.sh
@@ -11,20 +11,31 @@ color04="82/AA/FF" # Base 0D - Blue
 color05="C7/92/EA" # Base 0E - Magenta
 color06="89/DD/FF" # Base 0C - Cyan
 color07="95/9D/CB" # Base 05 - White
-color08="67/6E/95" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="F7/8C/6C" # Base 09
-color17="FF/53/70" # Base 0F
-color18="44/42/67" # Base 01
-color19="32/37/4D" # Base 02
-color20="87/96/B0" # Base 04
-color21="95/9D/CB" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="67/6E/95" # Base 03 - Bright Black
+  color09="F7/8C/6C" # Base 09
+  color10="44/42/67" # Base 01
+  color11="32/37/4D" # Base 02
+  color12="87/96/B0" # Base 04
+  color13="95/9D/CB" # Base 06
+  color14="FF/53/70" # Base 0F
+  color15="FF/FF/FF" # Base 07 - Bright White
+else
+  color08="67/6E/95" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="FF/FF/FF" # Base 07 - Bright White
+  color16="F7/8C/6C" # Base 09
+  color17="FF/53/70" # Base 0F
+  color18="44/42/67" # Base 01
+  color19="32/37/4D" # Base 02
+  color20="87/96/B0" # Base 04
+  color21="95/9D/CB" # Base 06
+fi;
 color_foreground="95/9D/CB" # Base 05
 color_background="29/2D/3E" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-material-vivid.sh
+++ b/scripts/base16-material-vivid.sh
@@ -11,20 +11,31 @@ color04="21/96/f3" # Base 0D - Blue
 color05="67/3a/b7" # Base 0E - Magenta
 color06="00/bc/d4" # Base 0C - Cyan
 color07="80/86/8b" # Base 05 - White
-color08="44/46/4d" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="ff/98/00" # Base 09
-color17="8d/6e/63" # Base 0F
-color18="27/29/2c" # Base 01
-color19="32/36/39" # Base 02
-color20="67/6c/71" # Base 04
-color21="9e/9e/9e" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="44/46/4d" # Base 03 - Bright Black
+  color09="ff/98/00" # Base 09
+  color10="27/29/2c" # Base 01
+  color11="32/36/39" # Base 02
+  color12="67/6c/71" # Base 04
+  color13="9e/9e/9e" # Base 06
+  color14="8d/6e/63" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="44/46/4d" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="ff/98/00" # Base 09
+  color17="8d/6e/63" # Base 0F
+  color18="27/29/2c" # Base 01
+  color19="32/36/39" # Base 02
+  color20="67/6c/71" # Base 04
+  color21="9e/9e/9e" # Base 06
+fi;
 color_foreground="80/86/8b" # Base 05
 color_background="20/21/24" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-material.sh
+++ b/scripts/base16-material.sh
@@ -11,20 +11,31 @@ color04="82/AA/FF" # Base 0D - Blue
 color05="C7/92/EA" # Base 0E - Magenta
 color06="89/DD/FF" # Base 0C - Cyan
 color07="EE/FF/FF" # Base 05 - White
-color08="54/6E/7A" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="F7/8C/6C" # Base 09
-color17="FF/53/70" # Base 0F
-color18="2E/3C/43" # Base 01
-color19="31/45/49" # Base 02
-color20="B2/CC/D6" # Base 04
-color21="EE/FF/FF" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="54/6E/7A" # Base 03 - Bright Black
+  color09="F7/8C/6C" # Base 09
+  color10="2E/3C/43" # Base 01
+  color11="31/45/49" # Base 02
+  color12="B2/CC/D6" # Base 04
+  color13="EE/FF/FF" # Base 06
+  color14="FF/53/70" # Base 0F
+  color15="FF/FF/FF" # Base 07 - Bright White
+else
+  color08="54/6E/7A" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="FF/FF/FF" # Base 07 - Bright White
+  color16="F7/8C/6C" # Base 09
+  color17="FF/53/70" # Base 0F
+  color18="2E/3C/43" # Base 01
+  color19="31/45/49" # Base 02
+  color20="B2/CC/D6" # Base 04
+  color21="EE/FF/FF" # Base 06
+fi;
 color_foreground="EE/FF/FF" # Base 05
 color_background="26/32/38" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-mellow-purple.sh
+++ b/scripts/base16-mellow-purple.sh
@@ -11,20 +11,31 @@ color04="55/00/68" # Base 0D - Blue
 color05="89/91/bb" # Base 0E - Magenta
 color06="b9/00/b1" # Base 0C - Cyan
 color07="ff/ee/ff" # Base 05 - White
-color08="32/0f/55" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/c0/ff" # Base 07 - Bright White
-color16="aa/00/a3" # Base 09
-color17="4d/6f/ff" # Base 0F
-color18="1A/09/2D" # Base 01
-color19="33/13/54" # Base 02
-color20="87/35/82" # Base 04
-color21="ff/ee/ff" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="32/0f/55" # Base 03 - Bright Black
+  color09="aa/00/a3" # Base 09
+  color10="1A/09/2D" # Base 01
+  color11="33/13/54" # Base 02
+  color12="87/35/82" # Base 04
+  color13="ff/ee/ff" # Base 06
+  color14="4d/6f/ff" # Base 0F
+  color15="f8/c0/ff" # Base 07 - Bright White
+else
+  color08="32/0f/55" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f8/c0/ff" # Base 07 - Bright White
+  color16="aa/00/a3" # Base 09
+  color17="4d/6f/ff" # Base 0F
+  color18="1A/09/2D" # Base 01
+  color19="33/13/54" # Base 02
+  color20="87/35/82" # Base 04
+  color21="ff/ee/ff" # Base 06
+fi;
 color_foreground="ff/ee/ff" # Base 05
 color_background="1e/05/28" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-mexico-light.sh
+++ b/scripts/base16-mexico-light.sh
@@ -11,20 +11,31 @@ color04="7c/af/c2" # Base 0D - Blue
 color05="96/60/9e" # Base 0E - Magenta
 color06="4b/80/93" # Base 0C - Cyan
 color07="38/38/38" # Base 05 - White
-color08="b8/b8/b8" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="18/18/18" # Base 07 - Bright White
-color16="dc/96/56" # Base 09
-color17="a1/69/46" # Base 0F
-color18="e8/e8/e8" # Base 01
-color19="d8/d8/d8" # Base 02
-color20="58/58/58" # Base 04
-color21="28/28/28" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="b8/b8/b8" # Base 03 - Bright Black
+  color09="dc/96/56" # Base 09
+  color10="e8/e8/e8" # Base 01
+  color11="d8/d8/d8" # Base 02
+  color12="58/58/58" # Base 04
+  color13="28/28/28" # Base 06
+  color14="a1/69/46" # Base 0F
+  color15="18/18/18" # Base 07 - Bright White
+else
+  color08="b8/b8/b8" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="18/18/18" # Base 07 - Bright White
+  color16="dc/96/56" # Base 09
+  color17="a1/69/46" # Base 0F
+  color18="e8/e8/e8" # Base 01
+  color19="d8/d8/d8" # Base 02
+  color20="58/58/58" # Base 04
+  color21="28/28/28" # Base 06
+fi;
 color_foreground="38/38/38" # Base 05
 color_background="f8/f8/f8" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-mocha.sh
+++ b/scripts/base16-mocha.sh
@@ -11,20 +11,31 @@ color04="8a/b3/b5" # Base 0D - Blue
 color05="a8/9b/b9" # Base 0E - Magenta
 color06="7b/bd/a4" # Base 0C - Cyan
 color07="d0/c8/c6" # Base 05 - White
-color08="7e/70/5a" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f5/ee/eb" # Base 07 - Bright White
-color16="d2/8b/71" # Base 09
-color17="bb/95/84" # Base 0F
-color18="53/46/36" # Base 01
-color19="64/52/40" # Base 02
-color20="b8/af/ad" # Base 04
-color21="e9/e1/dd" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="7e/70/5a" # Base 03 - Bright Black
+  color09="d2/8b/71" # Base 09
+  color10="53/46/36" # Base 01
+  color11="64/52/40" # Base 02
+  color12="b8/af/ad" # Base 04
+  color13="e9/e1/dd" # Base 06
+  color14="bb/95/84" # Base 0F
+  color15="f5/ee/eb" # Base 07 - Bright White
+else
+  color08="7e/70/5a" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f5/ee/eb" # Base 07 - Bright White
+  color16="d2/8b/71" # Base 09
+  color17="bb/95/84" # Base 0F
+  color18="53/46/36" # Base 01
+  color19="64/52/40" # Base 02
+  color20="b8/af/ad" # Base 04
+  color21="e9/e1/dd" # Base 06
+fi;
 color_foreground="d0/c8/c6" # Base 05
 color_background="3B/32/28" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-monokai.sh
+++ b/scripts/base16-monokai.sh
@@ -11,20 +11,31 @@ color04="66/d9/ef" # Base 0D - Blue
 color05="ae/81/ff" # Base 0E - Magenta
 color06="a1/ef/e4" # Base 0C - Cyan
 color07="f8/f8/f2" # Base 05 - White
-color08="75/71/5e" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f9/f8/f5" # Base 07 - Bright White
-color16="fd/97/1f" # Base 09
-color17="cc/66/33" # Base 0F
-color18="38/38/30" # Base 01
-color19="49/48/3e" # Base 02
-color20="a5/9f/85" # Base 04
-color21="f5/f4/f1" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="75/71/5e" # Base 03 - Bright Black
+  color09="fd/97/1f" # Base 09
+  color10="38/38/30" # Base 01
+  color11="49/48/3e" # Base 02
+  color12="a5/9f/85" # Base 04
+  color13="f5/f4/f1" # Base 06
+  color14="cc/66/33" # Base 0F
+  color15="f9/f8/f5" # Base 07 - Bright White
+else
+  color08="75/71/5e" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f9/f8/f5" # Base 07 - Bright White
+  color16="fd/97/1f" # Base 09
+  color17="cc/66/33" # Base 0F
+  color18="38/38/30" # Base 01
+  color19="49/48/3e" # Base 02
+  color20="a5/9f/85" # Base 04
+  color21="f5/f4/f1" # Base 06
+fi;
 color_foreground="f8/f8/f2" # Base 05
 color_background="27/28/22" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-nord.sh
+++ b/scripts/base16-nord.sh
@@ -11,20 +11,31 @@ color04="EB/CB/8B" # Base 0D - Blue
 color05="A3/BE/8C" # Base 0E - Magenta
 color06="D0/87/70" # Base 0C - Cyan
 color07="E5/E9/F0" # Base 05 - White
-color08="4C/56/6A" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="8F/BC/BB" # Base 07 - Bright White
-color16="81/A1/C1" # Base 09
-color17="B4/8E/AD" # Base 0F
-color18="3B/42/52" # Base 01
-color19="43/4C/5E" # Base 02
-color20="D8/DE/E9" # Base 04
-color21="EC/EF/F4" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="4C/56/6A" # Base 03 - Bright Black
+  color09="81/A1/C1" # Base 09
+  color10="3B/42/52" # Base 01
+  color11="43/4C/5E" # Base 02
+  color12="D8/DE/E9" # Base 04
+  color13="EC/EF/F4" # Base 06
+  color14="B4/8E/AD" # Base 0F
+  color15="8F/BC/BB" # Base 07 - Bright White
+else
+  color08="4C/56/6A" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="8F/BC/BB" # Base 07 - Bright White
+  color16="81/A1/C1" # Base 09
+  color17="B4/8E/AD" # Base 0F
+  color18="3B/42/52" # Base 01
+  color19="43/4C/5E" # Base 02
+  color20="D8/DE/E9" # Base 04
+  color21="EC/EF/F4" # Base 06
+fi;
 color_foreground="E5/E9/F0" # Base 05
 color_background="2E/34/40" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-nova.sh
+++ b/scripts/base16-nova.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Nova scheme by George Essig (https://github.com/gessig), Trevor D. Miller (https://trevordmiller.com)
+
+color00="3C/4C/55" # Base 00 - Black
+color01="83/AF/E5" # Base 08 - Red
+color02="7F/C1/CA" # Base 0B - Green
+color03="A8/CE/93" # Base 0A - Yellow
+color04="83/AF/E5" # Base 0D - Blue
+color05="9A/93/E1" # Base 0E - Magenta
+color06="F2/C3/8F" # Base 0C - Cyan
+color07="C5/D4/DD" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="89/9B/A6" # Base 03 - Bright Black
+  color09="7F/C1/CA" # Base 09
+  color10="55/68/73" # Base 01
+  color11="6A/7D/89" # Base 02
+  color12="89/9B/A6" # Base 04
+  color13="89/9B/A6" # Base 06
+  color14="F2/C3/8F" # Base 0F
+  color15="55/68/73" # Base 07 - Bright White
+else
+  color08="89/9B/A6" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="55/68/73" # Base 07 - Bright White
+  color16="7F/C1/CA" # Base 09
+  color17="F2/C3/8F" # Base 0F
+  color18="55/68/73" # Base 01
+  color19="6A/7D/89" # Base 02
+  color20="89/9B/A6" # Base 04
+  color21="89/9B/A6" # Base 06
+fi;
+color_foreground="C5/D4/DD" # Base 05
+color_background="3C/4C/55" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg C5D4DD # foreground
+  put_template_custom Ph 3C4C55 # background
+  put_template_custom Pi C5D4DD # bold color
+  put_template_custom Pj 6A7D89 # selection color
+  put_template_custom Pk C5D4DD # selected text color
+  put_template_custom Pl C5D4DD # cursor
+  put_template_custom Pm 3C4C55 # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-ocean.sh
+++ b/scripts/base16-ocean.sh
@@ -11,20 +11,31 @@ color04="8f/a1/b3" # Base 0D - Blue
 color05="b4/8e/ad" # Base 0E - Magenta
 color06="96/b5/b4" # Base 0C - Cyan
 color07="c0/c5/ce" # Base 05 - White
-color08="65/73/7e" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ef/f1/f5" # Base 07 - Bright White
-color16="d0/87/70" # Base 09
-color17="ab/79/67" # Base 0F
-color18="34/3d/46" # Base 01
-color19="4f/5b/66" # Base 02
-color20="a7/ad/ba" # Base 04
-color21="df/e1/e8" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="65/73/7e" # Base 03 - Bright Black
+  color09="d0/87/70" # Base 09
+  color10="34/3d/46" # Base 01
+  color11="4f/5b/66" # Base 02
+  color12="a7/ad/ba" # Base 04
+  color13="df/e1/e8" # Base 06
+  color14="ab/79/67" # Base 0F
+  color15="ef/f1/f5" # Base 07 - Bright White
+else
+  color08="65/73/7e" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ef/f1/f5" # Base 07 - Bright White
+  color16="d0/87/70" # Base 09
+  color17="ab/79/67" # Base 0F
+  color18="34/3d/46" # Base 01
+  color19="4f/5b/66" # Base 02
+  color20="a7/ad/ba" # Base 04
+  color21="df/e1/e8" # Base 06
+fi;
 color_foreground="c0/c5/ce" # Base 05
 color_background="2b/30/3b" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-oceanicnext.sh
+++ b/scripts/base16-oceanicnext.sh
@@ -11,20 +11,31 @@ color04="66/99/CC" # Base 0D - Blue
 color05="C5/94/C5" # Base 0E - Magenta
 color06="5F/B3/B3" # Base 0C - Cyan
 color07="C0/C5/CE" # Base 05 - White
-color08="65/73/7E" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="D8/DE/E9" # Base 07 - Bright White
-color16="F9/91/57" # Base 09
-color17="AB/79/67" # Base 0F
-color18="34/3D/46" # Base 01
-color19="4F/5B/66" # Base 02
-color20="A7/AD/BA" # Base 04
-color21="CD/D3/DE" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="65/73/7E" # Base 03 - Bright Black
+  color09="F9/91/57" # Base 09
+  color10="34/3D/46" # Base 01
+  color11="4F/5B/66" # Base 02
+  color12="A7/AD/BA" # Base 04
+  color13="CD/D3/DE" # Base 06
+  color14="AB/79/67" # Base 0F
+  color15="D8/DE/E9" # Base 07 - Bright White
+else
+  color08="65/73/7E" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="D8/DE/E9" # Base 07 - Bright White
+  color16="F9/91/57" # Base 09
+  color17="AB/79/67" # Base 0F
+  color18="34/3D/46" # Base 01
+  color19="4F/5B/66" # Base 02
+  color20="A7/AD/BA" # Base 04
+  color21="CD/D3/DE" # Base 06
+fi;
 color_foreground="C0/C5/CE" # Base 05
 color_background="1B/2B/34" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-one-light.sh
+++ b/scripts/base16-one-light.sh
@@ -11,20 +11,31 @@ color04="40/78/f2" # Base 0D - Blue
 color05="a6/26/a4" # Base 0E - Magenta
 color06="01/84/bc" # Base 0C - Cyan
 color07="38/3a/42" # Base 05 - White
-color08="a0/a1/a7" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="09/0a/0b" # Base 07 - Bright White
-color16="d7/5f/00" # Base 09
-color17="98/68/01" # Base 0F
-color18="f0/f0/f1" # Base 01
-color19="e5/e5/e6" # Base 02
-color20="69/6c/77" # Base 04
-color21="20/22/27" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="a0/a1/a7" # Base 03 - Bright Black
+  color09="d7/5f/00" # Base 09
+  color10="f0/f0/f1" # Base 01
+  color11="e5/e5/e6" # Base 02
+  color12="69/6c/77" # Base 04
+  color13="20/22/27" # Base 06
+  color14="98/68/01" # Base 0F
+  color15="09/0a/0b" # Base 07 - Bright White
+else
+  color08="a0/a1/a7" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="09/0a/0b" # Base 07 - Bright White
+  color16="d7/5f/00" # Base 09
+  color17="98/68/01" # Base 0F
+  color18="f0/f0/f1" # Base 01
+  color19="e5/e5/e6" # Base 02
+  color20="69/6c/77" # Base 04
+  color21="20/22/27" # Base 06
+fi;
 color_foreground="38/3a/42" # Base 05
 color_background="fa/fa/fa" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-onedark.sh
+++ b/scripts/base16-onedark.sh
@@ -11,20 +11,31 @@ color04="61/af/ef" # Base 0D - Blue
 color05="c6/78/dd" # Base 0E - Magenta
 color06="56/b6/c2" # Base 0C - Cyan
 color07="ab/b2/bf" # Base 05 - White
-color08="54/58/62" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c8/cc/d4" # Base 07 - Bright White
-color16="d1/9a/66" # Base 09
-color17="be/50/46" # Base 0F
-color18="35/3b/45" # Base 01
-color19="3e/44/51" # Base 02
-color20="56/5c/64" # Base 04
-color21="b6/bd/ca" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="54/58/62" # Base 03 - Bright Black
+  color09="d1/9a/66" # Base 09
+  color10="35/3b/45" # Base 01
+  color11="3e/44/51" # Base 02
+  color12="56/5c/64" # Base 04
+  color13="b6/bd/ca" # Base 06
+  color14="be/50/46" # Base 0F
+  color15="c8/cc/d4" # Base 07 - Bright White
+else
+  color08="54/58/62" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="c8/cc/d4" # Base 07 - Bright White
+  color16="d1/9a/66" # Base 09
+  color17="be/50/46" # Base 0F
+  color18="35/3b/45" # Base 01
+  color19="3e/44/51" # Base 02
+  color20="56/5c/64" # Base 04
+  color21="b6/bd/ca" # Base 06
+fi;
 color_foreground="ab/b2/bf" # Base 05
 color_background="28/2c/34" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-outrun-dark.sh
+++ b/scripts/base16-outrun-dark.sh
@@ -11,20 +11,31 @@ color04="66/B0/FF" # Base 0D - Blue
 color05="F1/05/96" # Base 0E - Magenta
 color06="0E/F0/F0" # Base 0C - Cyan
 color07="D0/D0/FA" # Base 05 - White
-color08="50/50/7A" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="F5/F5/FF" # Base 07 - Bright White
-color16="FC/8D/28" # Base 09
-color17="F0/03/EF" # Base 0F
-color18="20/20/4A" # Base 01
-color19="30/30/5A" # Base 02
-color20="B0/B0/DA" # Base 04
-color21="E0/E0/FF" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="50/50/7A" # Base 03 - Bright Black
+  color09="FC/8D/28" # Base 09
+  color10="20/20/4A" # Base 01
+  color11="30/30/5A" # Base 02
+  color12="B0/B0/DA" # Base 04
+  color13="E0/E0/FF" # Base 06
+  color14="F0/03/EF" # Base 0F
+  color15="F5/F5/FF" # Base 07 - Bright White
+else
+  color08="50/50/7A" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="F5/F5/FF" # Base 07 - Bright White
+  color16="FC/8D/28" # Base 09
+  color17="F0/03/EF" # Base 0F
+  color18="20/20/4A" # Base 01
+  color19="30/30/5A" # Base 02
+  color20="B0/B0/DA" # Base 04
+  color21="E0/E0/FF" # Base 06
+fi;
 color_foreground="D0/D0/FA" # Base 05
 color_background="00/00/2A" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-papercolor-dark.sh
+++ b/scripts/base16-papercolor-dark.sh
@@ -11,20 +11,31 @@ color04="ff/5f/af" # Base 0D - Blue
 color05="00/af/af" # Base 0E - Magenta
 color06="ff/af/00" # Base 0C - Cyan
 color07="80/80/80" # Base 05 - White
-color08="d7/af/5f" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="d0/d0/d0" # Base 07 - Bright White
-color16="5f/af/5f" # Base 09
-color17="5f/87/87" # Base 0F
-color18="af/00/5f" # Base 01
-color19="5f/af/00" # Base 02
-color20="5f/af/d7" # Base 04
-color21="d7/87/5f" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="d7/af/5f" # Base 03 - Bright Black
+  color09="5f/af/5f" # Base 09
+  color10="af/00/5f" # Base 01
+  color11="5f/af/00" # Base 02
+  color12="5f/af/d7" # Base 04
+  color13="d7/87/5f" # Base 06
+  color14="5f/87/87" # Base 0F
+  color15="d0/d0/d0" # Base 07 - Bright White
+else
+  color08="d7/af/5f" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="d0/d0/d0" # Base 07 - Bright White
+  color16="5f/af/5f" # Base 09
+  color17="5f/87/87" # Base 0F
+  color18="af/00/5f" # Base 01
+  color19="5f/af/00" # Base 02
+  color20="5f/af/d7" # Base 04
+  color21="d7/87/5f" # Base 06
+fi;
 color_foreground="80/80/80" # Base 05
 color_background="1c/1c/1c" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-papercolor-light.sh
+++ b/scripts/base16-papercolor-light.sh
@@ -11,20 +11,31 @@ color04="d7/5f/00" # Base 0D - Blue
 color05="00/5f/af" # Base 0E - Magenta
 color06="d7/5f/00" # Base 0C - Cyan
 color07="87/87/87" # Base 05 - White
-color08="5f/87/00" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="44/44/44" # Base 07 - Bright White
-color16="d7/00/00" # Base 09
-color17="00/5f/87" # Base 0F
-color18="af/00/00" # Base 01
-color19="00/87/00" # Base 02
-color20="00/87/af" # Base 04
-color21="00/5f/87" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="5f/87/00" # Base 03 - Bright Black
+  color09="d7/00/00" # Base 09
+  color10="af/00/00" # Base 01
+  color11="00/87/00" # Base 02
+  color12="00/87/af" # Base 04
+  color13="00/5f/87" # Base 06
+  color14="00/5f/87" # Base 0F
+  color15="44/44/44" # Base 07 - Bright White
+else
+  color08="5f/87/00" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="44/44/44" # Base 07 - Bright White
+  color16="d7/00/00" # Base 09
+  color17="00/5f/87" # Base 0F
+  color18="af/00/00" # Base 01
+  color19="00/87/00" # Base 02
+  color20="00/87/af" # Base 04
+  color21="00/5f/87" # Base 06
+fi;
 color_foreground="87/87/87" # Base 05
 color_background="ee/ee/ee" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-paraiso.sh
+++ b/scripts/base16-paraiso.sh
@@ -11,20 +11,31 @@ color04="06/b6/ef" # Base 0D - Blue
 color05="81/5b/a4" # Base 0E - Magenta
 color06="5b/c4/bf" # Base 0C - Cyan
 color07="a3/9e/9b" # Base 05 - White
-color08="77/6e/71" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="e7/e9/db" # Base 07 - Bright White
-color16="f9/9b/15" # Base 09
-color17="e9/6b/a8" # Base 0F
-color18="41/32/3f" # Base 01
-color19="4f/42/4c" # Base 02
-color20="8d/86/87" # Base 04
-color21="b9/b6/b0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="77/6e/71" # Base 03 - Bright Black
+  color09="f9/9b/15" # Base 09
+  color10="41/32/3f" # Base 01
+  color11="4f/42/4c" # Base 02
+  color12="8d/86/87" # Base 04
+  color13="b9/b6/b0" # Base 06
+  color14="e9/6b/a8" # Base 0F
+  color15="e7/e9/db" # Base 07 - Bright White
+else
+  color08="77/6e/71" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="e7/e9/db" # Base 07 - Bright White
+  color16="f9/9b/15" # Base 09
+  color17="e9/6b/a8" # Base 0F
+  color18="41/32/3f" # Base 01
+  color19="4f/42/4c" # Base 02
+  color20="8d/86/87" # Base 04
+  color21="b9/b6/b0" # Base 06
+fi;
 color_foreground="a3/9e/9b" # Base 05
 color_background="2f/1e/2e" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-phd.sh
+++ b/scripts/base16-phd.sh
@@ -11,20 +11,31 @@ color04="52/99/bf" # Base 0D - Blue
 color05="99/89/cc" # Base 0E - Magenta
 color06="72/b9/bf" # Base 0C - Cyan
 color07="b8/bb/c2" # Base 05 - White
-color08="71/78/85" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="f0/a0/00" # Base 09
-color17="b0/80/60" # Base 0F
-color18="2a/34/48" # Base 01
-color19="4d/56/66" # Base 02
-color20="9a/99/a3" # Base 04
-color21="db/dd/e0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="71/78/85" # Base 03 - Bright Black
+  color09="f0/a0/00" # Base 09
+  color10="2a/34/48" # Base 01
+  color11="4d/56/66" # Base 02
+  color12="9a/99/a3" # Base 04
+  color13="db/dd/e0" # Base 06
+  color14="b0/80/60" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="71/78/85" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="f0/a0/00" # Base 09
+  color17="b0/80/60" # Base 0F
+  color18="2a/34/48" # Base 01
+  color19="4d/56/66" # Base 02
+  color20="9a/99/a3" # Base 04
+  color21="db/dd/e0" # Base 06
+fi;
 color_foreground="b8/bb/c2" # Base 05
 color_background="06/12/29" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-pico.sh
+++ b/scripts/base16-pico.sh
@@ -11,20 +11,31 @@ color04="83/76/9c" # Base 0D - Blue
 color05="ff/77/a8" # Base 0E - Magenta
 color06="29/ad/ff" # Base 0C - Cyan
 color07="5f/57/4f" # Base 05 - White
-color08="00/87/51" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/f1/e8" # Base 07 - Bright White
-color16="ff/a3/00" # Base 09
-color17="ff/cc/aa" # Base 0F
-color18="1d/2b/53" # Base 01
-color19="7e/25/53" # Base 02
-color20="ab/52/36" # Base 04
-color21="c2/c3/c7" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="00/87/51" # Base 03 - Bright Black
+  color09="ff/a3/00" # Base 09
+  color10="1d/2b/53" # Base 01
+  color11="7e/25/53" # Base 02
+  color12="ab/52/36" # Base 04
+  color13="c2/c3/c7" # Base 06
+  color14="ff/cc/aa" # Base 0F
+  color15="ff/f1/e8" # Base 07 - Bright White
+else
+  color08="00/87/51" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/f1/e8" # Base 07 - Bright White
+  color16="ff/a3/00" # Base 09
+  color17="ff/cc/aa" # Base 0F
+  color18="1d/2b/53" # Base 01
+  color19="7e/25/53" # Base 02
+  color20="ab/52/36" # Base 04
+  color21="c2/c3/c7" # Base 06
+fi;
 color_foreground="5f/57/4f" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-pop.sh
+++ b/scripts/base16-pop.sh
@@ -11,20 +11,31 @@ color04="0e/5a/94" # Base 0D - Blue
 color05="b3/1e/8d" # Base 0E - Magenta
 color06="00/aa/bb" # Base 0C - Cyan
 color07="d0/d0/d0" # Base 05 - White
-color08="50/50/50" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="f2/93/33" # Base 09
-color17="7a/2d/00" # Base 0F
-color18="20/20/20" # Base 01
-color19="30/30/30" # Base 02
-color20="b0/b0/b0" # Base 04
-color21="e0/e0/e0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="50/50/50" # Base 03 - Bright Black
+  color09="f2/93/33" # Base 09
+  color10="20/20/20" # Base 01
+  color11="30/30/30" # Base 02
+  color12="b0/b0/b0" # Base 04
+  color13="e0/e0/e0" # Base 06
+  color14="7a/2d/00" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="50/50/50" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="f2/93/33" # Base 09
+  color17="7a/2d/00" # Base 0F
+  color18="20/20/20" # Base 01
+  color19="30/30/30" # Base 02
+  color20="b0/b0/b0" # Base 04
+  color21="e0/e0/e0" # Base 06
+fi;
 color_foreground="d0/d0/d0" # Base 05
 color_background="00/00/00" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-porple.sh
+++ b/scripts/base16-porple.sh
@@ -11,20 +11,31 @@ color04="84/85/ce" # Base 0D - Blue
 color05="b7/49/89" # Base 0E - Magenta
 color06="64/87/8f" # Base 0C - Cyan
 color07="d8/d8/d8" # Base 05 - White
-color08="65/56/8a" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/f8/f8" # Base 07 - Bright White
-color16="d2/8e/5d" # Base 09
-color17="98/68/41" # Base 0F
-color18="33/33/44" # Base 01
-color19="47/41/60" # Base 02
-color20="b8/b8/b8" # Base 04
-color21="e8/e8/e8" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="65/56/8a" # Base 03 - Bright Black
+  color09="d2/8e/5d" # Base 09
+  color10="33/33/44" # Base 01
+  color11="47/41/60" # Base 02
+  color12="b8/b8/b8" # Base 04
+  color13="e8/e8/e8" # Base 06
+  color14="98/68/41" # Base 0F
+  color15="f8/f8/f8" # Base 07 - Bright White
+else
+  color08="65/56/8a" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f8/f8/f8" # Base 07 - Bright White
+  color16="d2/8e/5d" # Base 09
+  color17="98/68/41" # Base 0F
+  color18="33/33/44" # Base 01
+  color19="47/41/60" # Base 02
+  color20="b8/b8/b8" # Base 04
+  color21="e8/e8/e8" # Base 06
+fi;
 color_foreground="d8/d8/d8" # Base 05
 color_background="29/2c/36" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-railscasts.sh
+++ b/scripts/base16-railscasts.sh
@@ -11,20 +11,31 @@ color04="6d/9c/be" # Base 0D - Blue
 color05="b6/b3/eb" # Base 0E - Magenta
 color06="51/9f/50" # Base 0C - Cyan
 color07="e6/e1/dc" # Base 05 - White
-color08="5a/64/7e" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f9/f7/f3" # Base 07 - Bright White
-color16="cc/78/33" # Base 09
-color17="bc/94/58" # Base 0F
-color18="27/29/35" # Base 01
-color19="3a/40/55" # Base 02
-color20="d4/cf/c9" # Base 04
-color21="f4/f1/ed" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="5a/64/7e" # Base 03 - Bright Black
+  color09="cc/78/33" # Base 09
+  color10="27/29/35" # Base 01
+  color11="3a/40/55" # Base 02
+  color12="d4/cf/c9" # Base 04
+  color13="f4/f1/ed" # Base 06
+  color14="bc/94/58" # Base 0F
+  color15="f9/f7/f3" # Base 07 - Bright White
+else
+  color08="5a/64/7e" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f9/f7/f3" # Base 07 - Bright White
+  color16="cc/78/33" # Base 09
+  color17="bc/94/58" # Base 0F
+  color18="27/29/35" # Base 01
+  color19="3a/40/55" # Base 02
+  color20="d4/cf/c9" # Base 04
+  color21="f4/f1/ed" # Base 06
+fi;
 color_foreground="e6/e1/dc" # Base 05
 color_background="2b/2b/2b" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-rebecca.sh
+++ b/scripts/base16-rebecca.sh
@@ -11,20 +11,31 @@ color04="2d/e0/a7" # Base 0D - Blue
 color05="7a/a5/ff" # Base 0E - Magenta
 color06="8e/ae/e0" # Base 0C - Cyan
 color07="f1/ef/f8" # Base 05 - White
-color08="66/66/99" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="53/49/5d" # Base 07 - Bright White
-color16="ef/e4/a1" # Base 09
-color17="ff/79/c6" # Base 0F
-color18="66/33/99" # Base 01
-color19="38/3a/62" # Base 02
-color20="a0/a0/c5" # Base 04
-color21="cc/cc/ff" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="66/66/99" # Base 03 - Bright Black
+  color09="ef/e4/a1" # Base 09
+  color10="66/33/99" # Base 01
+  color11="38/3a/62" # Base 02
+  color12="a0/a0/c5" # Base 04
+  color13="cc/cc/ff" # Base 06
+  color14="ff/79/c6" # Base 0F
+  color15="53/49/5d" # Base 07 - Bright White
+else
+  color08="66/66/99" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="53/49/5d" # Base 07 - Bright White
+  color16="ef/e4/a1" # Base 09
+  color17="ff/79/c6" # Base 0F
+  color18="66/33/99" # Base 01
+  color19="38/3a/62" # Base 02
+  color20="a0/a0/c5" # Base 04
+  color21="cc/cc/ff" # Base 06
+fi;
 color_foreground="f1/ef/f8" # Base 05
 color_background="29/2a/44" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-sandcastle.sh
+++ b/scripts/base16-sandcastle.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# base16-shell (https://github.com/chriskempson/base16-shell)
+# Base16 Shell template by Chris Kempson (http://chriskempson.com)
+# Sandcastle scheme by George Essig (https://github.com/gessig)
+
+color00="28/2c/34" # Base 00 - Black
+color01="83/a5/98" # Base 08 - Red
+color02="52/8b/8b" # Base 0B - Green
+color03="a0/7e/3b" # Base 0A - Yellow
+color04="83/a5/98" # Base 0D - Blue
+color05="d7/5f/5f" # Base 0E - Magenta
+color06="83/a5/98" # Base 0C - Cyan
+color07="a8/99/84" # Base 05 - White
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="66/5c/54" # Base 03 - Bright Black
+  color09="a0/7e/3b" # Base 09
+  color10="2c/32/3b" # Base 01
+  color11="3e/44/51" # Base 02
+  color12="92/83/74" # Base 04
+  color13="d5/c4/a1" # Base 06
+  color14="a8/73/22" # Base 0F
+  color15="fd/f4/c1" # Base 07 - Bright White
+else
+  color08="66/5c/54" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="fd/f4/c1" # Base 07 - Bright White
+  color16="a0/7e/3b" # Base 09
+  color17="a8/73/22" # Base 0F
+  color18="2c/32/3b" # Base 01
+  color19="3e/44/51" # Base 02
+  color20="92/83/74" # Base 04
+  color21="d5/c4/a1" # Base 06
+fi;
+color_foreground="a8/99/84" # Base 05
+color_background="28/2c/34" # Base 00
+
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  $color00
+put_template 1  $color01
+put_template 2  $color02
+put_template 3  $color03
+put_template 4  $color04
+put_template 5  $color05
+put_template 6  $color06
+put_template 7  $color07
+put_template 8  $color08
+put_template 9  $color09
+put_template 10 $color10
+put_template 11 $color11
+put_template 12 $color12
+put_template 13 $color13
+put_template 14 $color14
+put_template 15 $color15
+
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
+
+# foreground / background / cursor color
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg a89984 # foreground
+  put_template_custom Ph 282c34 # background
+  put_template_custom Pi a89984 # bold color
+  put_template_custom Pj 3e4451 # selection color
+  put_template_custom Pk a89984 # selected text color
+  put_template_custom Pl a89984 # cursor
+  put_template_custom Pm 282c34 # cursor text
+else
+  put_template_var 10 $color_foreground
+  if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
+    put_template_var 11 $color_background
+    if [ "${TERM%%-*}" = "rxvt" ]; then
+      put_template_var 708 $color_background # internal border (rxvt)
+    fi
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+unset color00
+unset color01
+unset color02
+unset color03
+unset color04
+unset color05
+unset color06
+unset color07
+unset color08
+unset color09
+unset color10
+unset color11
+unset color12
+unset color13
+unset color14
+unset color15
+unset color16
+unset color17
+unset color18
+unset color19
+unset color20
+unset color21
+unset color_foreground
+unset color_background

--- a/scripts/base16-seti.sh
+++ b/scripts/base16-seti.sh
@@ -11,20 +11,31 @@ color04="55/b5/db" # Base 0D - Blue
 color05="a0/74/c4" # Base 0E - Magenta
 color06="55/db/be" # Base 0C - Cyan
 color07="d6/d6/d6" # Base 05 - White
-color08="41/53/5B" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="db/7b/55" # Base 09
-color17="8a/55/3f" # Base 0F
-color18="28/2a/2b" # Base 01
-color19="3B/75/8C" # Base 02
-color20="43/a5/d5" # Base 04
-color21="ee/ee/ee" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="41/53/5B" # Base 03 - Bright Black
+  color09="db/7b/55" # Base 09
+  color10="28/2a/2b" # Base 01
+  color11="3B/75/8C" # Base 02
+  color12="43/a5/d5" # Base 04
+  color13="ee/ee/ee" # Base 06
+  color14="8a/55/3f" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="41/53/5B" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="db/7b/55" # Base 09
+  color17="8a/55/3f" # Base 0F
+  color18="28/2a/2b" # Base 01
+  color19="3B/75/8C" # Base 02
+  color20="43/a5/d5" # Base 04
+  color21="ee/ee/ee" # Base 06
+fi;
 color_foreground="d6/d6/d6" # Base 05
 color_background="15/17/18" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-shapeshifter.sh
+++ b/scripts/base16-shapeshifter.sh
@@ -11,20 +11,31 @@ color04="3b/48/e3" # Base 0D - Blue
 color05="f9/96/e2" # Base 0E - Magenta
 color06="23/ed/da" # Base 0C - Cyan
 color07="10/20/15" # Base 05 - White
-color08="55/55/55" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="00/00/00" # Base 07 - Bright White
-color16="e0/94/48" # Base 09
-color17="69/54/2d" # Base 0F
-color18="e0/e0/e0" # Base 01
-color19="ab/ab/ab" # Base 02
-color20="34/34/34" # Base 04
-color21="04/04/04" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="55/55/55" # Base 03 - Bright Black
+  color09="e0/94/48" # Base 09
+  color10="e0/e0/e0" # Base 01
+  color11="ab/ab/ab" # Base 02
+  color12="34/34/34" # Base 04
+  color13="04/04/04" # Base 06
+  color14="69/54/2d" # Base 0F
+  color15="00/00/00" # Base 07 - Bright White
+else
+  color08="55/55/55" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="00/00/00" # Base 07 - Bright White
+  color16="e0/94/48" # Base 09
+  color17="69/54/2d" # Base 0F
+  color18="e0/e0/e0" # Base 01
+  color19="ab/ab/ab" # Base 02
+  color20="34/34/34" # Base 04
+  color21="04/04/04" # Base 06
+fi;
 color_foreground="10/20/15" # Base 05
 color_background="f9/f9/f9" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-snazzy.sh
+++ b/scripts/base16-snazzy.sh
@@ -11,20 +11,31 @@ color04="57/c7/ff" # Base 0D - Blue
 color05="ff/6a/c1" # Base 0E - Magenta
 color06="9a/ed/fe" # Base 0C - Cyan
 color07="e2/e4/e5" # Base 05 - White
-color08="78/78/7e" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f1/f1/f0" # Base 07 - Bright White
-color16="ff/9f/43" # Base 09
-color17="b2/64/3c" # Base 0F
-color18="34/35/3e" # Base 01
-color19="43/45/4f" # Base 02
-color20="a5/a5/a9" # Base 04
-color21="ef/f0/eb" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="78/78/7e" # Base 03 - Bright Black
+  color09="ff/9f/43" # Base 09
+  color10="34/35/3e" # Base 01
+  color11="43/45/4f" # Base 02
+  color12="a5/a5/a9" # Base 04
+  color13="ef/f0/eb" # Base 06
+  color14="b2/64/3c" # Base 0F
+  color15="f1/f1/f0" # Base 07 - Bright White
+else
+  color08="78/78/7e" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f1/f1/f0" # Base 07 - Bright White
+  color16="ff/9f/43" # Base 09
+  color17="b2/64/3c" # Base 0F
+  color18="34/35/3e" # Base 01
+  color19="43/45/4f" # Base 02
+  color20="a5/a5/a9" # Base 04
+  color21="ef/f0/eb" # Base 06
+fi;
 color_foreground="e2/e4/e5" # Base 05
 color_background="28/2a/36" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-solarflare.sh
+++ b/scripts/base16-solarflare.sh
@@ -11,20 +11,31 @@ color04="33/B5/E1" # Base 0D - Blue
 color05="A3/63/D5" # Base 0E - Magenta
 color06="52/CB/B0" # Base 0C - Cyan
 color07="A6/AF/B8" # Base 05 - White
-color08="66/75/81" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="F5/F7/FA" # Base 07 - Bright White
-color16="E6/6B/2B" # Base 09
-color17="D7/3C/9A" # Base 0F
-color18="22/2E/38" # Base 01
-color19="58/68/75" # Base 02
-color20="85/93/9E" # Base 04
-color21="E8/E9/ED" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="66/75/81" # Base 03 - Bright Black
+  color09="E6/6B/2B" # Base 09
+  color10="22/2E/38" # Base 01
+  color11="58/68/75" # Base 02
+  color12="85/93/9E" # Base 04
+  color13="E8/E9/ED" # Base 06
+  color14="D7/3C/9A" # Base 0F
+  color15="F5/F7/FA" # Base 07 - Bright White
+else
+  color08="66/75/81" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="F5/F7/FA" # Base 07 - Bright White
+  color16="E6/6B/2B" # Base 09
+  color17="D7/3C/9A" # Base 0F
+  color18="22/2E/38" # Base 01
+  color19="58/68/75" # Base 02
+  color20="85/93/9E" # Base 04
+  color21="E8/E9/ED" # Base 06
+fi;
 color_foreground="A6/AF/B8" # Base 05
 color_background="18/26/2F" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-solarized-dark.sh
+++ b/scripts/base16-solarized-dark.sh
@@ -11,20 +11,31 @@ color04="26/8b/d2" # Base 0D - Blue
 color05="6c/71/c4" # Base 0E - Magenta
 color06="2a/a1/98" # Base 0C - Cyan
 color07="93/a1/a1" # Base 05 - White
-color08="65/7b/83" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fd/f6/e3" # Base 07 - Bright White
-color16="cb/4b/16" # Base 09
-color17="d3/36/82" # Base 0F
-color18="07/36/42" # Base 01
-color19="58/6e/75" # Base 02
-color20="83/94/96" # Base 04
-color21="ee/e8/d5" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="65/7b/83" # Base 03 - Bright Black
+  color09="cb/4b/16" # Base 09
+  color10="07/36/42" # Base 01
+  color11="58/6e/75" # Base 02
+  color12="83/94/96" # Base 04
+  color13="ee/e8/d5" # Base 06
+  color14="d3/36/82" # Base 0F
+  color15="fd/f6/e3" # Base 07 - Bright White
+else
+  color08="65/7b/83" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="fd/f6/e3" # Base 07 - Bright White
+  color16="cb/4b/16" # Base 09
+  color17="d3/36/82" # Base 0F
+  color18="07/36/42" # Base 01
+  color19="58/6e/75" # Base 02
+  color20="83/94/96" # Base 04
+  color21="ee/e8/d5" # Base 06
+fi;
 color_foreground="93/a1/a1" # Base 05
 color_background="00/2b/36" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-solarized-light.sh
+++ b/scripts/base16-solarized-light.sh
@@ -11,20 +11,31 @@ color04="26/8b/d2" # Base 0D - Blue
 color05="6c/71/c4" # Base 0E - Magenta
 color06="2a/a1/98" # Base 0C - Cyan
 color07="58/6e/75" # Base 05 - White
-color08="83/94/96" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="00/2b/36" # Base 07 - Bright White
-color16="cb/4b/16" # Base 09
-color17="d3/36/82" # Base 0F
-color18="ee/e8/d5" # Base 01
-color19="93/a1/a1" # Base 02
-color20="65/7b/83" # Base 04
-color21="07/36/42" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="83/94/96" # Base 03 - Bright Black
+  color09="cb/4b/16" # Base 09
+  color10="ee/e8/d5" # Base 01
+  color11="93/a1/a1" # Base 02
+  color12="65/7b/83" # Base 04
+  color13="07/36/42" # Base 06
+  color14="d3/36/82" # Base 0F
+  color15="00/2b/36" # Base 07 - Bright White
+else
+  color08="83/94/96" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="00/2b/36" # Base 07 - Bright White
+  color16="cb/4b/16" # Base 09
+  color17="d3/36/82" # Base 0F
+  color18="ee/e8/d5" # Base 01
+  color19="93/a1/a1" # Base 02
+  color20="65/7b/83" # Base 04
+  color21="07/36/42" # Base 06
+fi;
 color_foreground="58/6e/75" # Base 05
 color_background="fd/f6/e3" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-spacemacs.sh
+++ b/scripts/base16-spacemacs.sh
@@ -11,20 +11,31 @@ color04="4f/97/d7" # Base 0D - Blue
 color05="a3/1d/b1" # Base 0E - Magenta
 color06="2d/95/74" # Base 0C - Cyan
 color07="a3/a3/a3" # Base 05 - White
-color08="58/58/58" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/f8/f8" # Base 07 - Bright White
-color16="ff/a5/00" # Base 09
-color17="b0/30/60" # Base 0F
-color18="28/28/28" # Base 01
-color19="44/41/55" # Base 02
-color20="b8/b8/b8" # Base 04
-color21="e8/e8/e8" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="58/58/58" # Base 03 - Bright Black
+  color09="ff/a5/00" # Base 09
+  color10="28/28/28" # Base 01
+  color11="44/41/55" # Base 02
+  color12="b8/b8/b8" # Base 04
+  color13="e8/e8/e8" # Base 06
+  color14="b0/30/60" # Base 0F
+  color15="f8/f8/f8" # Base 07 - Bright White
+else
+  color08="58/58/58" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f8/f8/f8" # Base 07 - Bright White
+  color16="ff/a5/00" # Base 09
+  color17="b0/30/60" # Base 0F
+  color18="28/28/28" # Base 01
+  color19="44/41/55" # Base 02
+  color20="b8/b8/b8" # Base 04
+  color21="e8/e8/e8" # Base 06
+fi;
 color_foreground="a3/a3/a3" # Base 05
 color_background="1f/20/22" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-summerfruit-dark.sh
+++ b/scripts/base16-summerfruit-dark.sh
@@ -11,20 +11,31 @@ color04="37/77/E6" # Base 0D - Blue
 color05="AD/00/A1" # Base 0E - Magenta
 color06="1F/AA/AA" # Base 0C - Cyan
 color07="D0/D0/D0" # Base 05 - White
-color08="50/50/50" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="FD/89/00" # Base 09
-color17="CC/66/33" # Base 0F
-color18="20/20/20" # Base 01
-color19="30/30/30" # Base 02
-color20="B0/B0/B0" # Base 04
-color21="E0/E0/E0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="50/50/50" # Base 03 - Bright Black
+  color09="FD/89/00" # Base 09
+  color10="20/20/20" # Base 01
+  color11="30/30/30" # Base 02
+  color12="B0/B0/B0" # Base 04
+  color13="E0/E0/E0" # Base 06
+  color14="CC/66/33" # Base 0F
+  color15="FF/FF/FF" # Base 07 - Bright White
+else
+  color08="50/50/50" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="FF/FF/FF" # Base 07 - Bright White
+  color16="FD/89/00" # Base 09
+  color17="CC/66/33" # Base 0F
+  color18="20/20/20" # Base 01
+  color19="30/30/30" # Base 02
+  color20="B0/B0/B0" # Base 04
+  color21="E0/E0/E0" # Base 06
+fi;
 color_foreground="D0/D0/D0" # Base 05
 color_background="15/15/15" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-summerfruit-light.sh
+++ b/scripts/base16-summerfruit-light.sh
@@ -11,20 +11,31 @@ color04="37/77/E6" # Base 0D - Blue
 color05="AD/00/A1" # Base 0E - Magenta
 color06="1F/AA/AA" # Base 0C - Cyan
 color07="10/10/10" # Base 05 - White
-color08="B0/B0/B0" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="20/20/20" # Base 07 - Bright White
-color16="FD/89/00" # Base 09
-color17="CC/66/33" # Base 0F
-color18="E0/E0/E0" # Base 01
-color19="D0/D0/D0" # Base 02
-color20="00/00/00" # Base 04
-color21="15/15/15" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="B0/B0/B0" # Base 03 - Bright Black
+  color09="FD/89/00" # Base 09
+  color10="E0/E0/E0" # Base 01
+  color11="D0/D0/D0" # Base 02
+  color12="00/00/00" # Base 04
+  color13="15/15/15" # Base 06
+  color14="CC/66/33" # Base 0F
+  color15="20/20/20" # Base 07 - Bright White
+else
+  color08="B0/B0/B0" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="20/20/20" # Base 07 - Bright White
+  color16="FD/89/00" # Base 09
+  color17="CC/66/33" # Base 0F
+  color18="E0/E0/E0" # Base 01
+  color19="D0/D0/D0" # Base 02
+  color20="00/00/00" # Base 04
+  color21="15/15/15" # Base 06
+fi;
 color_foreground="10/10/10" # Base 05
 color_background="FF/FF/FF" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-synth-midnight-dark.sh
+++ b/scripts/base16-synth-midnight-dark.sh
@@ -11,20 +11,31 @@ color04="03/AE/FF" # Base 0D - Blue
 color05="EA/5C/E2" # Base 0E - Magenta
 color06="7C/ED/E9" # Base 0C - Cyan
 color07="DF/DB/DF" # Base 05 - White
-color08="61/50/7A" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FB/FF" # Base 07 - Bright White
-color16="E4/60/0E" # Base 09
-color17="9D/4D/0E" # Base 0F
-color18="14/14/14" # Base 01
-color19="24/24/24" # Base 02
-color20="BF/BB/BF" # Base 04
-color21="EF/EB/EF" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="61/50/7A" # Base 03 - Bright Black
+  color09="E4/60/0E" # Base 09
+  color10="14/14/14" # Base 01
+  color11="24/24/24" # Base 02
+  color12="BF/BB/BF" # Base 04
+  color13="EF/EB/EF" # Base 06
+  color14="9D/4D/0E" # Base 0F
+  color15="FF/FB/FF" # Base 07 - Bright White
+else
+  color08="61/50/7A" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="FF/FB/FF" # Base 07 - Bright White
+  color16="E4/60/0E" # Base 09
+  color17="9D/4D/0E" # Base 0F
+  color18="14/14/14" # Base 01
+  color19="24/24/24" # Base 02
+  color20="BF/BB/BF" # Base 04
+  color21="EF/EB/EF" # Base 06
+fi;
 color_foreground="DF/DB/DF" # Base 05
 color_background="04/04/04" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-tomorrow-night-eighties.sh
+++ b/scripts/base16-tomorrow-night-eighties.sh
@@ -11,20 +11,31 @@ color04="66/99/cc" # Base 0D - Blue
 color05="cc/99/cc" # Base 0E - Magenta
 color06="66/cc/cc" # Base 0C - Cyan
 color07="cc/cc/cc" # Base 05 - White
-color08="99/99/99" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="f9/91/57" # Base 09
-color17="a3/68/5a" # Base 0F
-color18="39/39/39" # Base 01
-color19="51/51/51" # Base 02
-color20="b4/b7/b4" # Base 04
-color21="e0/e0/e0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="99/99/99" # Base 03 - Bright Black
+  color09="f9/91/57" # Base 09
+  color10="39/39/39" # Base 01
+  color11="51/51/51" # Base 02
+  color12="b4/b7/b4" # Base 04
+  color13="e0/e0/e0" # Base 06
+  color14="a3/68/5a" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="99/99/99" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="f9/91/57" # Base 09
+  color17="a3/68/5a" # Base 0F
+  color18="39/39/39" # Base 01
+  color19="51/51/51" # Base 02
+  color20="b4/b7/b4" # Base 04
+  color21="e0/e0/e0" # Base 06
+fi;
 color_foreground="cc/cc/cc" # Base 05
 color_background="2d/2d/2d" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-tomorrow-night.sh
+++ b/scripts/base16-tomorrow-night.sh
@@ -11,20 +11,31 @@ color04="81/a2/be" # Base 0D - Blue
 color05="b2/94/bb" # Base 0E - Magenta
 color06="8a/be/b7" # Base 0C - Cyan
 color07="c5/c8/c6" # Base 05 - White
-color08="96/98/96" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="de/93/5f" # Base 09
-color17="a3/68/5a" # Base 0F
-color18="28/2a/2e" # Base 01
-color19="37/3b/41" # Base 02
-color20="b4/b7/b4" # Base 04
-color21="e0/e0/e0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="96/98/96" # Base 03 - Bright Black
+  color09="de/93/5f" # Base 09
+  color10="28/2a/2e" # Base 01
+  color11="37/3b/41" # Base 02
+  color12="b4/b7/b4" # Base 04
+  color13="e0/e0/e0" # Base 06
+  color14="a3/68/5a" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="96/98/96" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="de/93/5f" # Base 09
+  color17="a3/68/5a" # Base 0F
+  color18="28/2a/2e" # Base 01
+  color19="37/3b/41" # Base 02
+  color20="b4/b7/b4" # Base 04
+  color21="e0/e0/e0" # Base 06
+fi;
 color_foreground="c5/c8/c6" # Base 05
 color_background="1d/1f/21" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-tomorrow.sh
+++ b/scripts/base16-tomorrow.sh
@@ -11,20 +11,31 @@ color04="42/71/ae" # Base 0D - Blue
 color05="89/59/a8" # Base 0E - Magenta
 color06="3e/99/9f" # Base 0C - Cyan
 color07="4d/4d/4c" # Base 05 - White
-color08="8e/90/8c" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="1d/1f/21" # Base 07 - Bright White
-color16="f5/87/1f" # Base 09
-color17="a3/68/5a" # Base 0F
-color18="e0/e0/e0" # Base 01
-color19="d6/d6/d6" # Base 02
-color20="96/98/96" # Base 04
-color21="28/2a/2e" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="8e/90/8c" # Base 03 - Bright Black
+  color09="f5/87/1f" # Base 09
+  color10="e0/e0/e0" # Base 01
+  color11="d6/d6/d6" # Base 02
+  color12="96/98/96" # Base 04
+  color13="28/2a/2e" # Base 06
+  color14="a3/68/5a" # Base 0F
+  color15="1d/1f/21" # Base 07 - Bright White
+else
+  color08="8e/90/8c" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="1d/1f/21" # Base 07 - Bright White
+  color16="f5/87/1f" # Base 09
+  color17="a3/68/5a" # Base 0F
+  color18="e0/e0/e0" # Base 01
+  color19="d6/d6/d6" # Base 02
+  color20="96/98/96" # Base 04
+  color21="28/2a/2e" # Base 06
+fi;
 color_foreground="4d/4d/4c" # Base 05
 color_background="ff/ff/ff" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-tube.sh
+++ b/scripts/base16-tube.sh
@@ -11,20 +11,31 @@ color04="00/9d/dc" # Base 0D - Blue
 color05="98/00/5d" # Base 0E - Magenta
 color06="85/ce/bc" # Base 0C - Cyan
 color07="d9/d8/d8" # Base 05 - White
-color08="73/71/71" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="f3/86/a1" # Base 09
-color17="b0/61/10" # Base 0F
-color18="1c/3f/95" # Base 01
-color19="5a/57/58" # Base 02
-color20="95/9c/a1" # Base 04
-color21="e7/e7/e8" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="73/71/71" # Base 03 - Bright Black
+  color09="f3/86/a1" # Base 09
+  color10="1c/3f/95" # Base 01
+  color11="5a/57/58" # Base 02
+  color12="95/9c/a1" # Base 04
+  color13="e7/e7/e8" # Base 06
+  color14="b0/61/10" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="73/71/71" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="f3/86/a1" # Base 09
+  color17="b0/61/10" # Base 0F
+  color18="1c/3f/95" # Base 01
+  color19="5a/57/58" # Base 02
+  color20="95/9c/a1" # Base 04
+  color21="e7/e7/e8" # Base 06
+fi;
 color_foreground="d9/d8/d8" # Base 05
 color_background="23/1f/20" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-twilight.sh
+++ b/scripts/base16-twilight.sh
@@ -11,20 +11,31 @@ color04="75/87/a6" # Base 0D - Blue
 color05="9b/85/9d" # Base 0E - Magenta
 color06="af/c4/db" # Base 0C - Cyan
 color07="a7/a7/a7" # Base 05 - White
-color08="5f/5a/60" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="cd/a8/69" # Base 09
-color17="9b/70/3f" # Base 0F
-color18="32/35/37" # Base 01
-color19="46/4b/50" # Base 02
-color20="83/81/84" # Base 04
-color21="c3/c3/c3" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="5f/5a/60" # Base 03 - Bright Black
+  color09="cd/a8/69" # Base 09
+  color10="32/35/37" # Base 01
+  color11="46/4b/50" # Base 02
+  color12="83/81/84" # Base 04
+  color13="c3/c3/c3" # Base 06
+  color14="9b/70/3f" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="5f/5a/60" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="cd/a8/69" # Base 09
+  color17="9b/70/3f" # Base 0F
+  color18="32/35/37" # Base 01
+  color19="46/4b/50" # Base 02
+  color20="83/81/84" # Base 04
+  color21="c3/c3/c3" # Base 06
+fi;
 color_foreground="a7/a7/a7" # Base 05
 color_background="1e/1e/1e" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-unikitty-dark.sh
+++ b/scripts/base16-unikitty-dark.sh
@@ -11,20 +11,31 @@ color04="79/6a/f5" # Base 0D - Blue
 color05="bb/60/ea" # Base 0E - Magenta
 color06="14/9b/da" # Base 0C - Cyan
 color07="bc/ba/be" # Base 05 - White
-color08="83/80/85" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f5/f4/f7" # Base 07 - Bright White
-color16="d6/54/07" # Base 09
-color17="c7/20/ca" # Base 0F
-color18="4a/46/4d" # Base 01
-color19="66/63/69" # Base 02
-color20="9f/9d/a2" # Base 04
-color21="d8/d7/da" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="83/80/85" # Base 03 - Bright Black
+  color09="d6/54/07" # Base 09
+  color10="4a/46/4d" # Base 01
+  color11="66/63/69" # Base 02
+  color12="9f/9d/a2" # Base 04
+  color13="d8/d7/da" # Base 06
+  color14="c7/20/ca" # Base 0F
+  color15="f5/f4/f7" # Base 07 - Bright White
+else
+  color08="83/80/85" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="f5/f4/f7" # Base 07 - Bright White
+  color16="d6/54/07" # Base 09
+  color17="c7/20/ca" # Base 0F
+  color18="4a/46/4d" # Base 01
+  color19="66/63/69" # Base 02
+  color20="9f/9d/a2" # Base 04
+  color21="d8/d7/da" # Base 06
+fi;
 color_foreground="bc/ba/be" # Base 05
 color_background="2e/2a/31" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-unikitty-light.sh
+++ b/scripts/base16-unikitty-light.sh
@@ -11,20 +11,31 @@ color04="77/5d/ff" # Base 0D - Blue
 color05="aa/17/e6" # Base 0E - Magenta
 color06="14/9b/da" # Base 0C - Cyan
 color07="6c/69/6e" # Base 05 - White
-color08="a7/a5/a8" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="32/2d/34" # Base 07 - Bright White
-color16="d6/54/07" # Base 09
-color17="e0/13/d0" # Base 0F
-color18="e1/e1/e2" # Base 01
-color19="c4/c3/c5" # Base 02
-color20="89/87/8b" # Base 04
-color21="4f/4b/51" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="a7/a5/a8" # Base 03 - Bright Black
+  color09="d6/54/07" # Base 09
+  color10="e1/e1/e2" # Base 01
+  color11="c4/c3/c5" # Base 02
+  color12="89/87/8b" # Base 04
+  color13="4f/4b/51" # Base 06
+  color14="e0/13/d0" # Base 0F
+  color15="32/2d/34" # Base 07 - Bright White
+else
+  color08="a7/a5/a8" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="32/2d/34" # Base 07 - Bright White
+  color16="d6/54/07" # Base 09
+  color17="e0/13/d0" # Base 0F
+  color18="e1/e1/e2" # Base 01
+  color19="c4/c3/c5" # Base 02
+  color20="89/87/8b" # Base 04
+  color21="4f/4b/51" # Base 06
+fi;
 color_foreground="6c/69/6e" # Base 05
 color_background="ff/ff/ff" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-woodland.sh
+++ b/scripts/base16-woodland.sh
@@ -11,20 +11,31 @@ color04="88/a4/d3" # Base 0D - Blue
 color05="bb/90/e2" # Base 0E - Magenta
 color06="6e/b9/58" # Base 0C - Cyan
 color07="ca/bc/b1" # Base 05 - White
-color08="9d/8b/70" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="e4/d4/c8" # Base 07 - Bright White
-color16="ca/7f/32" # Base 09
-color17="b4/93/68" # Base 0F
-color18="30/2b/25" # Base 01
-color19="48/41/3a" # Base 02
-color20="b4/a4/90" # Base 04
-color21="d7/c8/bc" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="9d/8b/70" # Base 03 - Bright Black
+  color09="ca/7f/32" # Base 09
+  color10="30/2b/25" # Base 01
+  color11="48/41/3a" # Base 02
+  color12="b4/a4/90" # Base 04
+  color13="d7/c8/bc" # Base 06
+  color14="b4/93/68" # Base 0F
+  color15="e4/d4/c8" # Base 07 - Bright White
+else
+  color08="9d/8b/70" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="e4/d4/c8" # Base 07 - Bright White
+  color16="ca/7f/32" # Base 09
+  color17="b4/93/68" # Base 0F
+  color18="30/2b/25" # Base 01
+  color19="48/41/3a" # Base 02
+  color20="b4/a4/90" # Base 04
+  color21="d7/c8/bc" # Base 06
+fi;
 color_foreground="ca/bc/b1" # Base 05
 color_background="23/1e/18" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-xcode-dusk.sh
+++ b/scripts/base16-xcode-dusk.sh
@@ -11,20 +11,31 @@ color04="79/0E/AD" # Base 0D - Blue
 color05="B2/18/89" # Base 0E - Magenta
 color06="00/A0/BE" # Base 0C - Cyan
 color07="93/95/99" # Base 05 - White
-color08="68/6A/71" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="BE/BF/C2" # Base 07 - Bright White
-color16="78/6D/C5" # Base 09
-color17="C7/7C/48" # Base 0F
-color18="3D/40/48" # Base 01
-color19="53/55/5D" # Base 02
-color20="7E/80/86" # Base 04
-color21="A9/AA/AE" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="68/6A/71" # Base 03 - Bright Black
+  color09="78/6D/C5" # Base 09
+  color10="3D/40/48" # Base 01
+  color11="53/55/5D" # Base 02
+  color12="7E/80/86" # Base 04
+  color13="A9/AA/AE" # Base 06
+  color14="C7/7C/48" # Base 0F
+  color15="BE/BF/C2" # Base 07 - Bright White
+else
+  color08="68/6A/71" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="BE/BF/C2" # Base 07 - Bright White
+  color16="78/6D/C5" # Base 09
+  color17="C7/7C/48" # Base 0F
+  color18="3D/40/48" # Base 01
+  color19="53/55/5D" # Base 02
+  color20="7E/80/86" # Base 04
+  color21="A9/AA/AE" # Base 06
+fi;
 color_foreground="93/95/99" # Base 05
 color_background="28/2B/35" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/scripts/base16-zenburn.sh
+++ b/scripts/base16-zenburn.sh
@@ -11,20 +11,31 @@ color04="7c/b8/bb" # Base 0D - Blue
 color05="dc/8c/c3" # Base 0E - Magenta
 color06="93/e0/e3" # Base 0C - Cyan
 color07="dc/dc/cc" # Base 05 - White
-color08="6f/6f/6f" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="df/af/8f" # Base 09
-color17="00/00/00" # Base 0F
-color18="40/40/40" # Base 01
-color19="60/60/60" # Base 02
-color20="80/80/80" # Base 04
-color21="c0/c0/c0" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="6f/6f/6f" # Base 03 - Bright Black
+  color09="df/af/8f" # Base 09
+  color10="40/40/40" # Base 01
+  color11="60/60/60" # Base 02
+  color12="80/80/80" # Base 04
+  color13="c0/c0/c0" # Base 06
+  color14="00/00/00" # Base 0F
+  color15="ff/ff/ff" # Base 07 - Bright White
+else
+  color08="6f/6f/6f" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="ff/ff/ff" # Base 07 - Bright White
+  color16="df/af/8f" # Base 09
+  color17="00/00/00" # Base 0F
+  color18="40/40/40" # Base 01
+  color19="60/60/60" # Base 02
+  color20="80/80/80" # Base 04
+  color21="c0/c0/c0" # Base 06
+fi;
 color_foreground="dc/dc/cc" # Base 05
 color_background="38/38/38" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -11,20 +11,31 @@ color04="{{base0D-hex-r}}/{{base0D-hex-g}}/{{base0D-hex-b}}" # Base 0D - Blue
 color05="{{base0E-hex-r}}/{{base0E-hex-g}}/{{base0E-hex-b}}" # Base 0E - Magenta
 color06="{{base0C-hex-r}}/{{base0C-hex-g}}/{{base0C-hex-b}}" # Base 0C - Cyan
 color07="{{base05-hex-r}}/{{base05-hex-g}}/{{base05-hex-b}}" # Base 05 - White
-color08="{{base03-hex-r}}/{{base03-hex-g}}/{{base03-hex-b}}" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="{{base07-hex-r}}/{{base07-hex-g}}/{{base07-hex-b}}" # Base 07 - Bright White
-color16="{{base09-hex-r}}/{{base09-hex-g}}/{{base09-hex-b}}" # Base 09
-color17="{{base0F-hex-r}}/{{base0F-hex-g}}/{{base0F-hex-b}}" # Base 0F
-color18="{{base01-hex-r}}/{{base01-hex-g}}/{{base01-hex-b}}" # Base 01
-color19="{{base02-hex-r}}/{{base02-hex-g}}/{{base02-hex-b}}" # Base 02
-color20="{{base04-hex-r}}/{{base04-hex-g}}/{{base04-hex-b}}" # Base 04
-color21="{{base06-hex-r}}/{{base06-hex-g}}/{{base06-hex-b}}" # Base 06
+if [ -n "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  color08="{{base03-hex-r}}/{{base03-hex-g}}/{{base03-hex-b}}" # Base 03 - Bright Black
+  color09="{{base09-hex-r}}/{{base09-hex-g}}/{{base09-hex-b}}" # Base 09
+  color10="{{base01-hex-r}}/{{base01-hex-g}}/{{base01-hex-b}}" # Base 01
+  color11="{{base02-hex-r}}/{{base02-hex-g}}/{{base02-hex-b}}" # Base 02
+  color12="{{base04-hex-r}}/{{base04-hex-g}}/{{base04-hex-b}}" # Base 04
+  color13="{{base06-hex-r}}/{{base06-hex-g}}/{{base06-hex-b}}" # Base 06
+  color14="{{base0F-hex-r}}/{{base0F-hex-g}}/{{base0F-hex-b}}" # Base 0F
+  color15="{{base07-hex-r}}/{{base07-hex-g}}/{{base07-hex-b}}" # Base 07 - Bright White
+else
+  color08="{{base03-hex-r}}/{{base03-hex-g}}/{{base03-hex-b}}" # Base 03 - Bright Black
+  color09=$color01 # Base 08 - Bright Red
+  color10=$color02 # Base 0B - Bright Green
+  color11=$color03 # Base 0A - Bright Yellow
+  color12=$color04 # Base 0D - Bright Blue
+  color13=$color05 # Base 0E - Bright Magenta
+  color14=$color06 # Base 0C - Bright Cyan
+  color15="{{base07-hex-r}}/{{base07-hex-g}}/{{base07-hex-b}}" # Base 07 - Bright White
+  color16="{{base09-hex-r}}/{{base09-hex-g}}/{{base09-hex-b}}" # Base 09
+  color17="{{base0F-hex-r}}/{{base0F-hex-g}}/{{base0F-hex-b}}" # Base 0F
+  color18="{{base01-hex-r}}/{{base01-hex-g}}/{{base01-hex-b}}" # Base 01
+  color19="{{base02-hex-r}}/{{base02-hex-g}}/{{base02-hex-b}}" # Base 02
+  color20="{{base04-hex-r}}/{{base04-hex-g}}/{{base04-hex-b}}" # Base 04
+  color21="{{base06-hex-r}}/{{base06-hex-g}}/{{base06-hex-b}}" # Base 06
+fi;
 color_foreground="{{base05-hex-r}}/{{base05-hex-g}}/{{base05-hex-b}}" # Base 05
 color_background="{{base00-hex-r}}/{{base00-hex-g}}/{{base00-hex-b}}" # Base 00
 
@@ -67,13 +78,15 @@ put_template 13 $color13
 put_template 14 $color14
 put_template 15 $color15
 
-# 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+if [ -z "$BASE16_SHELL_DEFAULT_VARIANT" ]; then
+  # 256 color space
+  put_template 16 $color16
+  put_template 17 $color17
+  put_template 18 $color18
+  put_template 19 $color19
+  put_template 20 $color20
+  put_template 21 $color21
+fi
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then


### PR DESCRIPTION
# Why

I'm on MacOS, using base16 since a long time using the [iTerm2](https://github.com/martinlindhe/base16-iterm2), [Vim](https://github.com/chriskempson/base16-vim) and [fzf](https://github.com/nicodebo/base16-fzf) templates.

I'm now using other terminal emulators and more and more Linux. Then I wanted to switch to this [base16-shell](https://github.com/chriskempson/base16-shell) template, in order to have all of my config depending on my shell config, instead of having having to handle some terminal emulators templates on one side, and the rest inside config files.

But, this [base16-shell](https://github.com/chriskempson/base16-shell) template only provids the 256 version, which is different from other templates. Then, I propose to implement the default behavior, in addition to the original 256 version.

# How

I propose to add a `$BASE16_SHELL_DEFAULT_VARIANT` variable in order to switch to the 16 colors version. It is built not to break the current users configuration: unless this variable is set, the template acts exactly as it already does:

<img width="1112" alt="Capture d’écran 2020-03-06 à 20 32 16" src="https://user-images.githubusercontent.com/2766032/76116100-a6485b80-5fe9-11ea-85b0-fbb12f289d50.png">

# What

- [x] Upgrade `templates/default.mustache` in order to change different colors depending on the `$BASE16_SHELL_DEFAULT_VARIANT` variable state
- [x] Upgrade `README.md` to reflect new behavior
- [x] Build the whole set of `scripts/base16-*.sh`, using the very last version of [Base 16 Builder Python](https://github.com/InspectorMustache/base16-builder-python)
- [x] Adapt the `colortest` script to the new template