### PR TITLE
Make colour variables environment variables instead of unsetting them.

### DIFF
--- a/scripts/base16-3024.sh
+++ b/scripts/base16-3024.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # 3024 scheme by Jan T. Sott (http://github.com/idleberg)
 
-color00="09/03/00" # Base 00 - Black
-color01="db/2d/20" # Base 08 - Red
-color02="01/a2/52" # Base 0B - Green
-color03="fd/ed/02" # Base 0A - Yellow
-color04="01/a0/e4" # Base 0D - Blue
-color05="a1/6a/94" # Base 0E - Magenta
-color06="b5/e4/f4" # Base 0C - Cyan
-color07="a5/a2/a2" # Base 05 - White
-color08="5c/58/55" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f7/f7" # Base 07 - Bright White
-color16="e8/bb/d0" # Base 09
-color17="cd/ab/53" # Base 0F
-color18="3a/34/32" # Base 01
-color19="4a/45/43" # Base 02
-color20="80/7d/7c" # Base 04
-color21="d6/d5/d4" # Base 06
-color_foreground="a5/a2/a2" # Base 05
-color_background="09/03/00" # Base 00
+base16_color00="09/03/00" # Base 00 - Black
+base16_color01="db/2d/20" # Base 08 - Red
+base16_color02="01/a2/52" # Base 0B - Green
+base16_color03="fd/ed/02" # Base 0A - Yellow
+base16_color04="01/a0/e4" # Base 0D - Blue
+base16_color05="a1/6a/94" # Base 0E - Magenta
+base16_color06="b5/e4/f4" # Base 0C - Cyan
+base16_color07="a5/a2/a2" # Base 05 - White
+base16_color08="5c/58/55" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f7/f7/f7" # Base 07 - Bright White
+base16_color16="e8/bb/d0" # Base 09
+base16_color17="cd/ab/53" # Base 0F
+base16_color18="3a/34/32" # Base 01
+base16_color19="4a/45/43" # Base 02
+base16_color20="80/7d/7c" # Base 04
+base16_color21="d6/d5/d4" # Base 06
+base16_color_foreground="a5/a2/a2" # Base 05
+base16_color_background="09/03/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl a5a2a2 # cursor
   put_template_custom Pm 090300 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-3024.sh
+++ b/scripts/base16-3024.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # 3024 scheme by Jan T. Sott (http://github.com/idleberg)
 
-base16_color00="09/03/00" # Base 00 - Black
-base16_color01="db/2d/20" # Base 08 - Red
-base16_color02="01/a2/52" # Base 0B - Green
-base16_color03="fd/ed/02" # Base 0A - Yellow
-base16_color04="01/a0/e4" # Base 0D - Blue
-base16_color05="a1/6a/94" # Base 0E - Magenta
-base16_color06="b5/e4/f4" # Base 0C - Cyan
-base16_color07="a5/a2/a2" # Base 05 - White
-base16_color08="5c/58/55" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f7/f7/f7" # Base 07 - Bright White
-base16_color16="e8/bb/d0" # Base 09
-base16_color17="cd/ab/53" # Base 0F
-base16_color18="3a/34/32" # Base 01
-base16_color19="4a/45/43" # Base 02
-base16_color20="80/7d/7c" # Base 04
-base16_color21="d6/d5/d4" # Base 06
-base16_color_foreground="a5/a2/a2" # Base 05
-base16_color_background="09/03/00" # Base 00
+export base16_color00="09/03/00" # Base 00 - Black
+export base16_color01="db/2d/20" # Base 08 - Red
+export base16_color02="01/a2/52" # Base 0B - Green
+export base16_color03="fd/ed/02" # Base 0A - Yellow
+export base16_color04="01/a0/e4" # Base 0D - Blue
+export base16_color05="a1/6a/94" # Base 0E - Magenta
+export base16_color06="b5/e4/f4" # Base 0C - Cyan
+export base16_color07="a5/a2/a2" # Base 05 - White
+export base16_color08="5c/58/55" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f7/f7/f7" # Base 07 - Bright White
+export base16_color16="e8/bb/d0" # Base 09
+export base16_color17="cd/ab/53" # Base 0F
+export base16_color18="3a/34/32" # Base 01
+export base16_color19="4a/45/43" # Base 02
+export base16_color20="80/7d/7c" # Base 04
+export base16_color21="d6/d5/d4" # Base 06
+export base16_color_foreground="a5/a2/a2" # Base 05
+export base16_color_background="09/03/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-apathy.sh
+++ b/scripts/base16-apathy.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Apathy scheme by Jannik Siebert (https://github.com/janniks)
 
-base16_color00="03/1A/16" # Base 00 - Black
-base16_color01="3E/96/88" # Base 08 - Red
-base16_color02="88/3E/96" # Base 0B - Green
-base16_color03="3E/4C/96" # Base 0A - Yellow
-base16_color04="96/88/3E" # Base 0D - Blue
-base16_color05="4C/96/3E" # Base 0E - Magenta
-base16_color06="96/3E/4C" # Base 0C - Cyan
-base16_color07="81/B5/AC" # Base 05 - White
-base16_color08="2B/68/5E" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="D2/E7/E4" # Base 07 - Bright White
-base16_color16="3E/79/96" # Base 09
-base16_color17="3E/96/5B" # Base 0F
-base16_color18="0B/34/2D" # Base 01
-base16_color19="18/4E/45" # Base 02
-base16_color20="5F/9C/92" # Base 04
-base16_color21="A7/CE/C8" # Base 06
-base16_color_foreground="81/B5/AC" # Base 05
-base16_color_background="03/1A/16" # Base 00
+export base16_color00="03/1A/16" # Base 00 - Black
+export base16_color01="3E/96/88" # Base 08 - Red
+export base16_color02="88/3E/96" # Base 0B - Green
+export base16_color03="3E/4C/96" # Base 0A - Yellow
+export base16_color04="96/88/3E" # Base 0D - Blue
+export base16_color05="4C/96/3E" # Base 0E - Magenta
+export base16_color06="96/3E/4C" # Base 0C - Cyan
+export base16_color07="81/B5/AC" # Base 05 - White
+export base16_color08="2B/68/5E" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="D2/E7/E4" # Base 07 - Bright White
+export base16_color16="3E/79/96" # Base 09
+export base16_color17="3E/96/5B" # Base 0F
+export base16_color18="0B/34/2D" # Base 01
+export base16_color19="18/4E/45" # Base 02
+export base16_color20="5F/9C/92" # Base 04
+export base16_color21="A7/CE/C8" # Base 06
+export base16_color_foreground="81/B5/AC" # Base 05
+export base16_color_background="03/1A/16" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-apathy.sh
+++ b/scripts/base16-apathy.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Apathy scheme by Jannik Siebert (https://github.com/janniks)
 
-color00="03/1A/16" # Base 00 - Black
-color01="3E/96/88" # Base 08 - Red
-color02="88/3E/96" # Base 0B - Green
-color03="3E/4C/96" # Base 0A - Yellow
-color04="96/88/3E" # Base 0D - Blue
-color05="4C/96/3E" # Base 0E - Magenta
-color06="96/3E/4C" # Base 0C - Cyan
-color07="81/B5/AC" # Base 05 - White
-color08="2B/68/5E" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="D2/E7/E4" # Base 07 - Bright White
-color16="3E/79/96" # Base 09
-color17="3E/96/5B" # Base 0F
-color18="0B/34/2D" # Base 01
-color19="18/4E/45" # Base 02
-color20="5F/9C/92" # Base 04
-color21="A7/CE/C8" # Base 06
-color_foreground="81/B5/AC" # Base 05
-color_background="03/1A/16" # Base 00
+base16_color00="03/1A/16" # Base 00 - Black
+base16_color01="3E/96/88" # Base 08 - Red
+base16_color02="88/3E/96" # Base 0B - Green
+base16_color03="3E/4C/96" # Base 0A - Yellow
+base16_color04="96/88/3E" # Base 0D - Blue
+base16_color05="4C/96/3E" # Base 0E - Magenta
+base16_color06="96/3E/4C" # Base 0C - Cyan
+base16_color07="81/B5/AC" # Base 05 - White
+base16_color08="2B/68/5E" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="D2/E7/E4" # Base 07 - Bright White
+base16_color16="3E/79/96" # Base 09
+base16_color17="3E/96/5B" # Base 0F
+base16_color18="0B/34/2D" # Base 01
+base16_color19="18/4E/45" # Base 02
+base16_color20="5F/9C/92" # Base 04
+base16_color21="A7/CE/C8" # Base 06
+base16_color_foreground="81/B5/AC" # Base 05
+base16_color_background="03/1A/16" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 81B5AC # cursor
   put_template_custom Pm 031A16 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-ashes.sh
+++ b/scripts/base16-ashes.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Ashes scheme by Jannik Siebert (https://github.com/janniks)
 
-base16_color00="1C/20/23" # Base 00 - Black
-base16_color01="C7/AE/95" # Base 08 - Red
-base16_color02="95/C7/AE" # Base 0B - Green
-base16_color03="AE/C7/95" # Base 0A - Yellow
-base16_color04="AE/95/C7" # Base 0D - Blue
-base16_color05="C7/95/AE" # Base 0E - Magenta
-base16_color06="95/AE/C7" # Base 0C - Cyan
-base16_color07="C7/CC/D1" # Base 05 - White
-base16_color08="74/7C/84" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="F3/F4/F5" # Base 07 - Bright White
-base16_color16="C7/C7/95" # Base 09
-base16_color17="C7/95/95" # Base 0F
-base16_color18="39/3F/45" # Base 01
-base16_color19="56/5E/65" # Base 02
-base16_color20="AD/B3/BA" # Base 04
-base16_color21="DF/E2/E5" # Base 06
-base16_color_foreground="C7/CC/D1" # Base 05
-base16_color_background="1C/20/23" # Base 00
+export base16_color00="1C/20/23" # Base 00 - Black
+export base16_color01="C7/AE/95" # Base 08 - Red
+export base16_color02="95/C7/AE" # Base 0B - Green
+export base16_color03="AE/C7/95" # Base 0A - Yellow
+export base16_color04="AE/95/C7" # Base 0D - Blue
+export base16_color05="C7/95/AE" # Base 0E - Magenta
+export base16_color06="95/AE/C7" # Base 0C - Cyan
+export base16_color07="C7/CC/D1" # Base 05 - White
+export base16_color08="74/7C/84" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="F3/F4/F5" # Base 07 - Bright White
+export base16_color16="C7/C7/95" # Base 09
+export base16_color17="C7/95/95" # Base 0F
+export base16_color18="39/3F/45" # Base 01
+export base16_color19="56/5E/65" # Base 02
+export base16_color20="AD/B3/BA" # Base 04
+export base16_color21="DF/E2/E5" # Base 06
+export base16_color_foreground="C7/CC/D1" # Base 05
+export base16_color_background="1C/20/23" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-ashes.sh
+++ b/scripts/base16-ashes.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Ashes scheme by Jannik Siebert (https://github.com/janniks)
 
-color00="1C/20/23" # Base 00 - Black
-color01="C7/AE/95" # Base 08 - Red
-color02="95/C7/AE" # Base 0B - Green
-color03="AE/C7/95" # Base 0A - Yellow
-color04="AE/95/C7" # Base 0D - Blue
-color05="C7/95/AE" # Base 0E - Magenta
-color06="95/AE/C7" # Base 0C - Cyan
-color07="C7/CC/D1" # Base 05 - White
-color08="74/7C/84" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="F3/F4/F5" # Base 07 - Bright White
-color16="C7/C7/95" # Base 09
-color17="C7/95/95" # Base 0F
-color18="39/3F/45" # Base 01
-color19="56/5E/65" # Base 02
-color20="AD/B3/BA" # Base 04
-color21="DF/E2/E5" # Base 06
-color_foreground="C7/CC/D1" # Base 05
-color_background="1C/20/23" # Base 00
+base16_color00="1C/20/23" # Base 00 - Black
+base16_color01="C7/AE/95" # Base 08 - Red
+base16_color02="95/C7/AE" # Base 0B - Green
+base16_color03="AE/C7/95" # Base 0A - Yellow
+base16_color04="AE/95/C7" # Base 0D - Blue
+base16_color05="C7/95/AE" # Base 0E - Magenta
+base16_color06="95/AE/C7" # Base 0C - Cyan
+base16_color07="C7/CC/D1" # Base 05 - White
+base16_color08="74/7C/84" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="F3/F4/F5" # Base 07 - Bright White
+base16_color16="C7/C7/95" # Base 09
+base16_color17="C7/95/95" # Base 0F
+base16_color18="39/3F/45" # Base 01
+base16_color19="56/5E/65" # Base 02
+base16_color20="AD/B3/BA" # Base 04
+base16_color21="DF/E2/E5" # Base 06
+base16_color_foreground="C7/CC/D1" # Base 05
+base16_color_background="1C/20/23" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl C7CCD1 # cursor
   put_template_custom Pm 1C2023 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-cave-light.sh
+++ b/scripts/base16-atelier-cave-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Cave Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="ef/ec/f4" # Base 00 - Black
-base16_color01="be/46/78" # Base 08 - Red
-base16_color02="2a/92/92" # Base 0B - Green
-base16_color03="a0/6e/3b" # Base 0A - Yellow
-base16_color04="57/6d/db" # Base 0D - Blue
-base16_color05="95/5a/e7" # Base 0E - Magenta
-base16_color06="39/8b/c6" # Base 0C - Cyan
-base16_color07="58/52/60" # Base 05 - White
-base16_color08="7e/78/87" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="19/17/1c" # Base 07 - Bright White
-base16_color16="aa/57/3c" # Base 09
-base16_color17="bf/40/bf" # Base 0F
-base16_color18="e2/df/e7" # Base 01
-base16_color19="8b/87/92" # Base 02
-base16_color20="65/5f/6d" # Base 04
-base16_color21="26/23/2a" # Base 06
-base16_color_foreground="58/52/60" # Base 05
-base16_color_background="ef/ec/f4" # Base 00
+export base16_color00="ef/ec/f4" # Base 00 - Black
+export base16_color01="be/46/78" # Base 08 - Red
+export base16_color02="2a/92/92" # Base 0B - Green
+export base16_color03="a0/6e/3b" # Base 0A - Yellow
+export base16_color04="57/6d/db" # Base 0D - Blue
+export base16_color05="95/5a/e7" # Base 0E - Magenta
+export base16_color06="39/8b/c6" # Base 0C - Cyan
+export base16_color07="58/52/60" # Base 05 - White
+export base16_color08="7e/78/87" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="19/17/1c" # Base 07 - Bright White
+export base16_color16="aa/57/3c" # Base 09
+export base16_color17="bf/40/bf" # Base 0F
+export base16_color18="e2/df/e7" # Base 01
+export base16_color19="8b/87/92" # Base 02
+export base16_color20="65/5f/6d" # Base 04
+export base16_color21="26/23/2a" # Base 06
+export base16_color_foreground="58/52/60" # Base 05
+export base16_color_background="ef/ec/f4" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-cave-light.sh
+++ b/scripts/base16-atelier-cave-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Cave Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="ef/ec/f4" # Base 00 - Black
-color01="be/46/78" # Base 08 - Red
-color02="2a/92/92" # Base 0B - Green
-color03="a0/6e/3b" # Base 0A - Yellow
-color04="57/6d/db" # Base 0D - Blue
-color05="95/5a/e7" # Base 0E - Magenta
-color06="39/8b/c6" # Base 0C - Cyan
-color07="58/52/60" # Base 05 - White
-color08="7e/78/87" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="19/17/1c" # Base 07 - Bright White
-color16="aa/57/3c" # Base 09
-color17="bf/40/bf" # Base 0F
-color18="e2/df/e7" # Base 01
-color19="8b/87/92" # Base 02
-color20="65/5f/6d" # Base 04
-color21="26/23/2a" # Base 06
-color_foreground="58/52/60" # Base 05
-color_background="ef/ec/f4" # Base 00
+base16_color00="ef/ec/f4" # Base 00 - Black
+base16_color01="be/46/78" # Base 08 - Red
+base16_color02="2a/92/92" # Base 0B - Green
+base16_color03="a0/6e/3b" # Base 0A - Yellow
+base16_color04="57/6d/db" # Base 0D - Blue
+base16_color05="95/5a/e7" # Base 0E - Magenta
+base16_color06="39/8b/c6" # Base 0C - Cyan
+base16_color07="58/52/60" # Base 05 - White
+base16_color08="7e/78/87" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="19/17/1c" # Base 07 - Bright White
+base16_color16="aa/57/3c" # Base 09
+base16_color17="bf/40/bf" # Base 0F
+base16_color18="e2/df/e7" # Base 01
+base16_color19="8b/87/92" # Base 02
+base16_color20="65/5f/6d" # Base 04
+base16_color21="26/23/2a" # Base 06
+base16_color_foreground="58/52/60" # Base 05
+base16_color_background="ef/ec/f4" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 585260 # cursor
   put_template_custom Pm efecf4 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-cave.sh
+++ b/scripts/base16-atelier-cave.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Cave scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="19/17/1c" # Base 00 - Black
-base16_color01="be/46/78" # Base 08 - Red
-base16_color02="2a/92/92" # Base 0B - Green
-base16_color03="a0/6e/3b" # Base 0A - Yellow
-base16_color04="57/6d/db" # Base 0D - Blue
-base16_color05="95/5a/e7" # Base 0E - Magenta
-base16_color06="39/8b/c6" # Base 0C - Cyan
-base16_color07="8b/87/92" # Base 05 - White
-base16_color08="65/5f/6d" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ef/ec/f4" # Base 07 - Bright White
-base16_color16="aa/57/3c" # Base 09
-base16_color17="bf/40/bf" # Base 0F
-base16_color18="26/23/2a" # Base 01
-base16_color19="58/52/60" # Base 02
-base16_color20="7e/78/87" # Base 04
-base16_color21="e2/df/e7" # Base 06
-base16_color_foreground="8b/87/92" # Base 05
-base16_color_background="19/17/1c" # Base 00
+export base16_color00="19/17/1c" # Base 00 - Black
+export base16_color01="be/46/78" # Base 08 - Red
+export base16_color02="2a/92/92" # Base 0B - Green
+export base16_color03="a0/6e/3b" # Base 0A - Yellow
+export base16_color04="57/6d/db" # Base 0D - Blue
+export base16_color05="95/5a/e7" # Base 0E - Magenta
+export base16_color06="39/8b/c6" # Base 0C - Cyan
+export base16_color07="8b/87/92" # Base 05 - White
+export base16_color08="65/5f/6d" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ef/ec/f4" # Base 07 - Bright White
+export base16_color16="aa/57/3c" # Base 09
+export base16_color17="bf/40/bf" # Base 0F
+export base16_color18="26/23/2a" # Base 01
+export base16_color19="58/52/60" # Base 02
+export base16_color20="7e/78/87" # Base 04
+export base16_color21="e2/df/e7" # Base 06
+export base16_color_foreground="8b/87/92" # Base 05
+export base16_color_background="19/17/1c" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-cave.sh
+++ b/scripts/base16-atelier-cave.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Cave scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="19/17/1c" # Base 00 - Black
-color01="be/46/78" # Base 08 - Red
-color02="2a/92/92" # Base 0B - Green
-color03="a0/6e/3b" # Base 0A - Yellow
-color04="57/6d/db" # Base 0D - Blue
-color05="95/5a/e7" # Base 0E - Magenta
-color06="39/8b/c6" # Base 0C - Cyan
-color07="8b/87/92" # Base 05 - White
-color08="65/5f/6d" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ef/ec/f4" # Base 07 - Bright White
-color16="aa/57/3c" # Base 09
-color17="bf/40/bf" # Base 0F
-color18="26/23/2a" # Base 01
-color19="58/52/60" # Base 02
-color20="7e/78/87" # Base 04
-color21="e2/df/e7" # Base 06
-color_foreground="8b/87/92" # Base 05
-color_background="19/17/1c" # Base 00
+base16_color00="19/17/1c" # Base 00 - Black
+base16_color01="be/46/78" # Base 08 - Red
+base16_color02="2a/92/92" # Base 0B - Green
+base16_color03="a0/6e/3b" # Base 0A - Yellow
+base16_color04="57/6d/db" # Base 0D - Blue
+base16_color05="95/5a/e7" # Base 0E - Magenta
+base16_color06="39/8b/c6" # Base 0C - Cyan
+base16_color07="8b/87/92" # Base 05 - White
+base16_color08="65/5f/6d" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ef/ec/f4" # Base 07 - Bright White
+base16_color16="aa/57/3c" # Base 09
+base16_color17="bf/40/bf" # Base 0F
+base16_color18="26/23/2a" # Base 01
+base16_color19="58/52/60" # Base 02
+base16_color20="7e/78/87" # Base 04
+base16_color21="e2/df/e7" # Base 06
+base16_color_foreground="8b/87/92" # Base 05
+base16_color_background="19/17/1c" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 8b8792 # cursor
   put_template_custom Pm 19171c # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-dune-light.sh
+++ b/scripts/base16-atelier-dune-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Dune Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="fe/fb/ec" # Base 00 - Black
-color01="d7/37/37" # Base 08 - Red
-color02="60/ac/39" # Base 0B - Green
-color03="ae/95/13" # Base 0A - Yellow
-color04="66/84/e1" # Base 0D - Blue
-color05="b8/54/d4" # Base 0E - Magenta
-color06="1f/ad/83" # Base 0C - Cyan
-color07="6e/6b/5e" # Base 05 - White
-color08="99/95/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="20/20/1d" # Base 07 - Bright White
-color16="b6/56/11" # Base 09
-color17="d4/35/52" # Base 0F
-color18="e8/e4/cf" # Base 01
-color19="a6/a2/8c" # Base 02
-color20="7d/7a/68" # Base 04
-color21="29/28/24" # Base 06
-color_foreground="6e/6b/5e" # Base 05
-color_background="fe/fb/ec" # Base 00
+base16_color00="fe/fb/ec" # Base 00 - Black
+base16_color01="d7/37/37" # Base 08 - Red
+base16_color02="60/ac/39" # Base 0B - Green
+base16_color03="ae/95/13" # Base 0A - Yellow
+base16_color04="66/84/e1" # Base 0D - Blue
+base16_color05="b8/54/d4" # Base 0E - Magenta
+base16_color06="1f/ad/83" # Base 0C - Cyan
+base16_color07="6e/6b/5e" # Base 05 - White
+base16_color08="99/95/80" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="20/20/1d" # Base 07 - Bright White
+base16_color16="b6/56/11" # Base 09
+base16_color17="d4/35/52" # Base 0F
+base16_color18="e8/e4/cf" # Base 01
+base16_color19="a6/a2/8c" # Base 02
+base16_color20="7d/7a/68" # Base 04
+base16_color21="29/28/24" # Base 06
+base16_color_foreground="6e/6b/5e" # Base 05
+base16_color_background="fe/fb/ec" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 6e6b5e # cursor
   put_template_custom Pm fefbec # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-dune-light.sh
+++ b/scripts/base16-atelier-dune-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Dune Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="fe/fb/ec" # Base 00 - Black
-base16_color01="d7/37/37" # Base 08 - Red
-base16_color02="60/ac/39" # Base 0B - Green
-base16_color03="ae/95/13" # Base 0A - Yellow
-base16_color04="66/84/e1" # Base 0D - Blue
-base16_color05="b8/54/d4" # Base 0E - Magenta
-base16_color06="1f/ad/83" # Base 0C - Cyan
-base16_color07="6e/6b/5e" # Base 05 - White
-base16_color08="99/95/80" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="20/20/1d" # Base 07 - Bright White
-base16_color16="b6/56/11" # Base 09
-base16_color17="d4/35/52" # Base 0F
-base16_color18="e8/e4/cf" # Base 01
-base16_color19="a6/a2/8c" # Base 02
-base16_color20="7d/7a/68" # Base 04
-base16_color21="29/28/24" # Base 06
-base16_color_foreground="6e/6b/5e" # Base 05
-base16_color_background="fe/fb/ec" # Base 00
+export base16_color00="fe/fb/ec" # Base 00 - Black
+export base16_color01="d7/37/37" # Base 08 - Red
+export base16_color02="60/ac/39" # Base 0B - Green
+export base16_color03="ae/95/13" # Base 0A - Yellow
+export base16_color04="66/84/e1" # Base 0D - Blue
+export base16_color05="b8/54/d4" # Base 0E - Magenta
+export base16_color06="1f/ad/83" # Base 0C - Cyan
+export base16_color07="6e/6b/5e" # Base 05 - White
+export base16_color08="99/95/80" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="20/20/1d" # Base 07 - Bright White
+export base16_color16="b6/56/11" # Base 09
+export base16_color17="d4/35/52" # Base 0F
+export base16_color18="e8/e4/cf" # Base 01
+export base16_color19="a6/a2/8c" # Base 02
+export base16_color20="7d/7a/68" # Base 04
+export base16_color21="29/28/24" # Base 06
+export base16_color_foreground="6e/6b/5e" # Base 05
+export base16_color_background="fe/fb/ec" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-dune.sh
+++ b/scripts/base16-atelier-dune.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Dune scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="20/20/1d" # Base 00 - Black
-base16_color01="d7/37/37" # Base 08 - Red
-base16_color02="60/ac/39" # Base 0B - Green
-base16_color03="ae/95/13" # Base 0A - Yellow
-base16_color04="66/84/e1" # Base 0D - Blue
-base16_color05="b8/54/d4" # Base 0E - Magenta
-base16_color06="1f/ad/83" # Base 0C - Cyan
-base16_color07="a6/a2/8c" # Base 05 - White
-base16_color08="7d/7a/68" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="fe/fb/ec" # Base 07 - Bright White
-base16_color16="b6/56/11" # Base 09
-base16_color17="d4/35/52" # Base 0F
-base16_color18="29/28/24" # Base 01
-base16_color19="6e/6b/5e" # Base 02
-base16_color20="99/95/80" # Base 04
-base16_color21="e8/e4/cf" # Base 06
-base16_color_foreground="a6/a2/8c" # Base 05
-base16_color_background="20/20/1d" # Base 00
+export base16_color00="20/20/1d" # Base 00 - Black
+export base16_color01="d7/37/37" # Base 08 - Red
+export base16_color02="60/ac/39" # Base 0B - Green
+export base16_color03="ae/95/13" # Base 0A - Yellow
+export base16_color04="66/84/e1" # Base 0D - Blue
+export base16_color05="b8/54/d4" # Base 0E - Magenta
+export base16_color06="1f/ad/83" # Base 0C - Cyan
+export base16_color07="a6/a2/8c" # Base 05 - White
+export base16_color08="7d/7a/68" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="fe/fb/ec" # Base 07 - Bright White
+export base16_color16="b6/56/11" # Base 09
+export base16_color17="d4/35/52" # Base 0F
+export base16_color18="29/28/24" # Base 01
+export base16_color19="6e/6b/5e" # Base 02
+export base16_color20="99/95/80" # Base 04
+export base16_color21="e8/e4/cf" # Base 06
+export base16_color_foreground="a6/a2/8c" # Base 05
+export base16_color_background="20/20/1d" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-dune.sh
+++ b/scripts/base16-atelier-dune.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Dune scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="20/20/1d" # Base 00 - Black
-color01="d7/37/37" # Base 08 - Red
-color02="60/ac/39" # Base 0B - Green
-color03="ae/95/13" # Base 0A - Yellow
-color04="66/84/e1" # Base 0D - Blue
-color05="b8/54/d4" # Base 0E - Magenta
-color06="1f/ad/83" # Base 0C - Cyan
-color07="a6/a2/8c" # Base 05 - White
-color08="7d/7a/68" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fe/fb/ec" # Base 07 - Bright White
-color16="b6/56/11" # Base 09
-color17="d4/35/52" # Base 0F
-color18="29/28/24" # Base 01
-color19="6e/6b/5e" # Base 02
-color20="99/95/80" # Base 04
-color21="e8/e4/cf" # Base 06
-color_foreground="a6/a2/8c" # Base 05
-color_background="20/20/1d" # Base 00
+base16_color00="20/20/1d" # Base 00 - Black
+base16_color01="d7/37/37" # Base 08 - Red
+base16_color02="60/ac/39" # Base 0B - Green
+base16_color03="ae/95/13" # Base 0A - Yellow
+base16_color04="66/84/e1" # Base 0D - Blue
+base16_color05="b8/54/d4" # Base 0E - Magenta
+base16_color06="1f/ad/83" # Base 0C - Cyan
+base16_color07="a6/a2/8c" # Base 05 - White
+base16_color08="7d/7a/68" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="fe/fb/ec" # Base 07 - Bright White
+base16_color16="b6/56/11" # Base 09
+base16_color17="d4/35/52" # Base 0F
+base16_color18="29/28/24" # Base 01
+base16_color19="6e/6b/5e" # Base 02
+base16_color20="99/95/80" # Base 04
+base16_color21="e8/e4/cf" # Base 06
+base16_color_foreground="a6/a2/8c" # Base 05
+base16_color_background="20/20/1d" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl a6a28c # cursor
   put_template_custom Pm 20201d # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-estuary-light.sh
+++ b/scripts/base16-atelier-estuary-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Estuary Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="f4/f3/ec" # Base 00 - Black
-base16_color01="ba/62/36" # Base 08 - Red
-base16_color02="7d/97/26" # Base 0B - Green
-base16_color03="a5/98/0d" # Base 0A - Yellow
-base16_color04="36/a1/66" # Base 0D - Blue
-base16_color05="5f/91/82" # Base 0E - Magenta
-base16_color06="5b/9d/48" # Base 0C - Cyan
-base16_color07="5f/5e/4e" # Base 05 - White
-base16_color08="87/85/73" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="22/22/1b" # Base 07 - Bright White
-base16_color16="ae/73/13" # Base 09
-base16_color17="9d/6c/7c" # Base 0F
-base16_color18="e7/e6/df" # Base 01
-base16_color19="92/91/81" # Base 02
-base16_color20="6c/6b/5a" # Base 04
-base16_color21="30/2f/27" # Base 06
-base16_color_foreground="5f/5e/4e" # Base 05
-base16_color_background="f4/f3/ec" # Base 00
+export base16_color00="f4/f3/ec" # Base 00 - Black
+export base16_color01="ba/62/36" # Base 08 - Red
+export base16_color02="7d/97/26" # Base 0B - Green
+export base16_color03="a5/98/0d" # Base 0A - Yellow
+export base16_color04="36/a1/66" # Base 0D - Blue
+export base16_color05="5f/91/82" # Base 0E - Magenta
+export base16_color06="5b/9d/48" # Base 0C - Cyan
+export base16_color07="5f/5e/4e" # Base 05 - White
+export base16_color08="87/85/73" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="22/22/1b" # Base 07 - Bright White
+export base16_color16="ae/73/13" # Base 09
+export base16_color17="9d/6c/7c" # Base 0F
+export base16_color18="e7/e6/df" # Base 01
+export base16_color19="92/91/81" # Base 02
+export base16_color20="6c/6b/5a" # Base 04
+export base16_color21="30/2f/27" # Base 06
+export base16_color_foreground="5f/5e/4e" # Base 05
+export base16_color_background="f4/f3/ec" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-estuary-light.sh
+++ b/scripts/base16-atelier-estuary-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Estuary Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="f4/f3/ec" # Base 00 - Black
-color01="ba/62/36" # Base 08 - Red
-color02="7d/97/26" # Base 0B - Green
-color03="a5/98/0d" # Base 0A - Yellow
-color04="36/a1/66" # Base 0D - Blue
-color05="5f/91/82" # Base 0E - Magenta
-color06="5b/9d/48" # Base 0C - Cyan
-color07="5f/5e/4e" # Base 05 - White
-color08="87/85/73" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="22/22/1b" # Base 07 - Bright White
-color16="ae/73/13" # Base 09
-color17="9d/6c/7c" # Base 0F
-color18="e7/e6/df" # Base 01
-color19="92/91/81" # Base 02
-color20="6c/6b/5a" # Base 04
-color21="30/2f/27" # Base 06
-color_foreground="5f/5e/4e" # Base 05
-color_background="f4/f3/ec" # Base 00
+base16_color00="f4/f3/ec" # Base 00 - Black
+base16_color01="ba/62/36" # Base 08 - Red
+base16_color02="7d/97/26" # Base 0B - Green
+base16_color03="a5/98/0d" # Base 0A - Yellow
+base16_color04="36/a1/66" # Base 0D - Blue
+base16_color05="5f/91/82" # Base 0E - Magenta
+base16_color06="5b/9d/48" # Base 0C - Cyan
+base16_color07="5f/5e/4e" # Base 05 - White
+base16_color08="87/85/73" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="22/22/1b" # Base 07 - Bright White
+base16_color16="ae/73/13" # Base 09
+base16_color17="9d/6c/7c" # Base 0F
+base16_color18="e7/e6/df" # Base 01
+base16_color19="92/91/81" # Base 02
+base16_color20="6c/6b/5a" # Base 04
+base16_color21="30/2f/27" # Base 06
+base16_color_foreground="5f/5e/4e" # Base 05
+base16_color_background="f4/f3/ec" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 5f5e4e # cursor
   put_template_custom Pm f4f3ec # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-estuary.sh
+++ b/scripts/base16-atelier-estuary.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Estuary scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="22/22/1b" # Base 00 - Black
-color01="ba/62/36" # Base 08 - Red
-color02="7d/97/26" # Base 0B - Green
-color03="a5/98/0d" # Base 0A - Yellow
-color04="36/a1/66" # Base 0D - Blue
-color05="5f/91/82" # Base 0E - Magenta
-color06="5b/9d/48" # Base 0C - Cyan
-color07="92/91/81" # Base 05 - White
-color08="6c/6b/5a" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f4/f3/ec" # Base 07 - Bright White
-color16="ae/73/13" # Base 09
-color17="9d/6c/7c" # Base 0F
-color18="30/2f/27" # Base 01
-color19="5f/5e/4e" # Base 02
-color20="87/85/73" # Base 04
-color21="e7/e6/df" # Base 06
-color_foreground="92/91/81" # Base 05
-color_background="22/22/1b" # Base 00
+base16_color00="22/22/1b" # Base 00 - Black
+base16_color01="ba/62/36" # Base 08 - Red
+base16_color02="7d/97/26" # Base 0B - Green
+base16_color03="a5/98/0d" # Base 0A - Yellow
+base16_color04="36/a1/66" # Base 0D - Blue
+base16_color05="5f/91/82" # Base 0E - Magenta
+base16_color06="5b/9d/48" # Base 0C - Cyan
+base16_color07="92/91/81" # Base 05 - White
+base16_color08="6c/6b/5a" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f4/f3/ec" # Base 07 - Bright White
+base16_color16="ae/73/13" # Base 09
+base16_color17="9d/6c/7c" # Base 0F
+base16_color18="30/2f/27" # Base 01
+base16_color19="5f/5e/4e" # Base 02
+base16_color20="87/85/73" # Base 04
+base16_color21="e7/e6/df" # Base 06
+base16_color_foreground="92/91/81" # Base 05
+base16_color_background="22/22/1b" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 929181 # cursor
   put_template_custom Pm 22221b # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-estuary.sh
+++ b/scripts/base16-atelier-estuary.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Estuary scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="22/22/1b" # Base 00 - Black
-base16_color01="ba/62/36" # Base 08 - Red
-base16_color02="7d/97/26" # Base 0B - Green
-base16_color03="a5/98/0d" # Base 0A - Yellow
-base16_color04="36/a1/66" # Base 0D - Blue
-base16_color05="5f/91/82" # Base 0E - Magenta
-base16_color06="5b/9d/48" # Base 0C - Cyan
-base16_color07="92/91/81" # Base 05 - White
-base16_color08="6c/6b/5a" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f4/f3/ec" # Base 07 - Bright White
-base16_color16="ae/73/13" # Base 09
-base16_color17="9d/6c/7c" # Base 0F
-base16_color18="30/2f/27" # Base 01
-base16_color19="5f/5e/4e" # Base 02
-base16_color20="87/85/73" # Base 04
-base16_color21="e7/e6/df" # Base 06
-base16_color_foreground="92/91/81" # Base 05
-base16_color_background="22/22/1b" # Base 00
+export base16_color00="22/22/1b" # Base 00 - Black
+export base16_color01="ba/62/36" # Base 08 - Red
+export base16_color02="7d/97/26" # Base 0B - Green
+export base16_color03="a5/98/0d" # Base 0A - Yellow
+export base16_color04="36/a1/66" # Base 0D - Blue
+export base16_color05="5f/91/82" # Base 0E - Magenta
+export base16_color06="5b/9d/48" # Base 0C - Cyan
+export base16_color07="92/91/81" # Base 05 - White
+export base16_color08="6c/6b/5a" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f4/f3/ec" # Base 07 - Bright White
+export base16_color16="ae/73/13" # Base 09
+export base16_color17="9d/6c/7c" # Base 0F
+export base16_color18="30/2f/27" # Base 01
+export base16_color19="5f/5e/4e" # Base 02
+export base16_color20="87/85/73" # Base 04
+export base16_color21="e7/e6/df" # Base 06
+export base16_color_foreground="92/91/81" # Base 05
+export base16_color_background="22/22/1b" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-forest-light.sh
+++ b/scripts/base16-atelier-forest-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Forest Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="f1/ef/ee" # Base 00 - Black
-color01="f2/2c/40" # Base 08 - Red
-color02="7b/97/26" # Base 0B - Green
-color03="c3/84/18" # Base 0A - Yellow
-color04="40/7e/e7" # Base 0D - Blue
-color05="66/66/ea" # Base 0E - Magenta
-color06="3d/97/b8" # Base 0C - Cyan
-color07="68/61/5e" # Base 05 - White
-color08="9c/94/91" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="1b/19/18" # Base 07 - Bright White
-color16="df/53/20" # Base 09
-color17="c3/3f/f3" # Base 0F
-color18="e6/e2/e0" # Base 01
-color19="a8/a1/9f" # Base 02
-color20="76/6e/6b" # Base 04
-color21="2c/24/21" # Base 06
-color_foreground="68/61/5e" # Base 05
-color_background="f1/ef/ee" # Base 00
+base16_color00="f1/ef/ee" # Base 00 - Black
+base16_color01="f2/2c/40" # Base 08 - Red
+base16_color02="7b/97/26" # Base 0B - Green
+base16_color03="c3/84/18" # Base 0A - Yellow
+base16_color04="40/7e/e7" # Base 0D - Blue
+base16_color05="66/66/ea" # Base 0E - Magenta
+base16_color06="3d/97/b8" # Base 0C - Cyan
+base16_color07="68/61/5e" # Base 05 - White
+base16_color08="9c/94/91" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="1b/19/18" # Base 07 - Bright White
+base16_color16="df/53/20" # Base 09
+base16_color17="c3/3f/f3" # Base 0F
+base16_color18="e6/e2/e0" # Base 01
+base16_color19="a8/a1/9f" # Base 02
+base16_color20="76/6e/6b" # Base 04
+base16_color21="2c/24/21" # Base 06
+base16_color_foreground="68/61/5e" # Base 05
+base16_color_background="f1/ef/ee" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 68615e # cursor
   put_template_custom Pm f1efee # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-forest-light.sh
+++ b/scripts/base16-atelier-forest-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Forest Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="f1/ef/ee" # Base 00 - Black
-base16_color01="f2/2c/40" # Base 08 - Red
-base16_color02="7b/97/26" # Base 0B - Green
-base16_color03="c3/84/18" # Base 0A - Yellow
-base16_color04="40/7e/e7" # Base 0D - Blue
-base16_color05="66/66/ea" # Base 0E - Magenta
-base16_color06="3d/97/b8" # Base 0C - Cyan
-base16_color07="68/61/5e" # Base 05 - White
-base16_color08="9c/94/91" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="1b/19/18" # Base 07 - Bright White
-base16_color16="df/53/20" # Base 09
-base16_color17="c3/3f/f3" # Base 0F
-base16_color18="e6/e2/e0" # Base 01
-base16_color19="a8/a1/9f" # Base 02
-base16_color20="76/6e/6b" # Base 04
-base16_color21="2c/24/21" # Base 06
-base16_color_foreground="68/61/5e" # Base 05
-base16_color_background="f1/ef/ee" # Base 00
+export base16_color00="f1/ef/ee" # Base 00 - Black
+export base16_color01="f2/2c/40" # Base 08 - Red
+export base16_color02="7b/97/26" # Base 0B - Green
+export base16_color03="c3/84/18" # Base 0A - Yellow
+export base16_color04="40/7e/e7" # Base 0D - Blue
+export base16_color05="66/66/ea" # Base 0E - Magenta
+export base16_color06="3d/97/b8" # Base 0C - Cyan
+export base16_color07="68/61/5e" # Base 05 - White
+export base16_color08="9c/94/91" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="1b/19/18" # Base 07 - Bright White
+export base16_color16="df/53/20" # Base 09
+export base16_color17="c3/3f/f3" # Base 0F
+export base16_color18="e6/e2/e0" # Base 01
+export base16_color19="a8/a1/9f" # Base 02
+export base16_color20="76/6e/6b" # Base 04
+export base16_color21="2c/24/21" # Base 06
+export base16_color_foreground="68/61/5e" # Base 05
+export base16_color_background="f1/ef/ee" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-forest.sh
+++ b/scripts/base16-atelier-forest.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Forest scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="1b/19/18" # Base 00 - Black
-color01="f2/2c/40" # Base 08 - Red
-color02="7b/97/26" # Base 0B - Green
-color03="c3/84/18" # Base 0A - Yellow
-color04="40/7e/e7" # Base 0D - Blue
-color05="66/66/ea" # Base 0E - Magenta
-color06="3d/97/b8" # Base 0C - Cyan
-color07="a8/a1/9f" # Base 05 - White
-color08="76/6e/6b" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f1/ef/ee" # Base 07 - Bright White
-color16="df/53/20" # Base 09
-color17="c3/3f/f3" # Base 0F
-color18="2c/24/21" # Base 01
-color19="68/61/5e" # Base 02
-color20="9c/94/91" # Base 04
-color21="e6/e2/e0" # Base 06
-color_foreground="a8/a1/9f" # Base 05
-color_background="1b/19/18" # Base 00
+base16_color00="1b/19/18" # Base 00 - Black
+base16_color01="f2/2c/40" # Base 08 - Red
+base16_color02="7b/97/26" # Base 0B - Green
+base16_color03="c3/84/18" # Base 0A - Yellow
+base16_color04="40/7e/e7" # Base 0D - Blue
+base16_color05="66/66/ea" # Base 0E - Magenta
+base16_color06="3d/97/b8" # Base 0C - Cyan
+base16_color07="a8/a1/9f" # Base 05 - White
+base16_color08="76/6e/6b" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f1/ef/ee" # Base 07 - Bright White
+base16_color16="df/53/20" # Base 09
+base16_color17="c3/3f/f3" # Base 0F
+base16_color18="2c/24/21" # Base 01
+base16_color19="68/61/5e" # Base 02
+base16_color20="9c/94/91" # Base 04
+base16_color21="e6/e2/e0" # Base 06
+base16_color_foreground="a8/a1/9f" # Base 05
+base16_color_background="1b/19/18" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl a8a19f # cursor
   put_template_custom Pm 1b1918 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-forest.sh
+++ b/scripts/base16-atelier-forest.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Forest scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="1b/19/18" # Base 00 - Black
-base16_color01="f2/2c/40" # Base 08 - Red
-base16_color02="7b/97/26" # Base 0B - Green
-base16_color03="c3/84/18" # Base 0A - Yellow
-base16_color04="40/7e/e7" # Base 0D - Blue
-base16_color05="66/66/ea" # Base 0E - Magenta
-base16_color06="3d/97/b8" # Base 0C - Cyan
-base16_color07="a8/a1/9f" # Base 05 - White
-base16_color08="76/6e/6b" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f1/ef/ee" # Base 07 - Bright White
-base16_color16="df/53/20" # Base 09
-base16_color17="c3/3f/f3" # Base 0F
-base16_color18="2c/24/21" # Base 01
-base16_color19="68/61/5e" # Base 02
-base16_color20="9c/94/91" # Base 04
-base16_color21="e6/e2/e0" # Base 06
-base16_color_foreground="a8/a1/9f" # Base 05
-base16_color_background="1b/19/18" # Base 00
+export base16_color00="1b/19/18" # Base 00 - Black
+export base16_color01="f2/2c/40" # Base 08 - Red
+export base16_color02="7b/97/26" # Base 0B - Green
+export base16_color03="c3/84/18" # Base 0A - Yellow
+export base16_color04="40/7e/e7" # Base 0D - Blue
+export base16_color05="66/66/ea" # Base 0E - Magenta
+export base16_color06="3d/97/b8" # Base 0C - Cyan
+export base16_color07="a8/a1/9f" # Base 05 - White
+export base16_color08="76/6e/6b" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f1/ef/ee" # Base 07 - Bright White
+export base16_color16="df/53/20" # Base 09
+export base16_color17="c3/3f/f3" # Base 0F
+export base16_color18="2c/24/21" # Base 01
+export base16_color19="68/61/5e" # Base 02
+export base16_color20="9c/94/91" # Base 04
+export base16_color21="e6/e2/e0" # Base 06
+export base16_color_foreground="a8/a1/9f" # Base 05
+export base16_color_background="1b/19/18" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-heath-light.sh
+++ b/scripts/base16-atelier-heath-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Heath Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="f7/f3/f7" # Base 00 - Black
-color01="ca/40/2b" # Base 08 - Red
-color02="91/8b/3b" # Base 0B - Green
-color03="bb/8a/35" # Base 0A - Yellow
-color04="51/6a/ec" # Base 0D - Blue
-color05="7b/59/c0" # Base 0E - Magenta
-color06="15/93/93" # Base 0C - Cyan
-color07="69/5d/69" # Base 05 - White
-color08="9e/8f/9e" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="1b/18/1b" # Base 07 - Bright White
-color16="a6/59/26" # Base 09
-color17="cc/33/cc" # Base 0F
-color18="d8/ca/d8" # Base 01
-color19="ab/9b/ab" # Base 02
-color20="77/69/77" # Base 04
-color21="29/23/29" # Base 06
-color_foreground="69/5d/69" # Base 05
-color_background="f7/f3/f7" # Base 00
+base16_color00="f7/f3/f7" # Base 00 - Black
+base16_color01="ca/40/2b" # Base 08 - Red
+base16_color02="91/8b/3b" # Base 0B - Green
+base16_color03="bb/8a/35" # Base 0A - Yellow
+base16_color04="51/6a/ec" # Base 0D - Blue
+base16_color05="7b/59/c0" # Base 0E - Magenta
+base16_color06="15/93/93" # Base 0C - Cyan
+base16_color07="69/5d/69" # Base 05 - White
+base16_color08="9e/8f/9e" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="1b/18/1b" # Base 07 - Bright White
+base16_color16="a6/59/26" # Base 09
+base16_color17="cc/33/cc" # Base 0F
+base16_color18="d8/ca/d8" # Base 01
+base16_color19="ab/9b/ab" # Base 02
+base16_color20="77/69/77" # Base 04
+base16_color21="29/23/29" # Base 06
+base16_color_foreground="69/5d/69" # Base 05
+base16_color_background="f7/f3/f7" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 695d69 # cursor
   put_template_custom Pm f7f3f7 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-heath-light.sh
+++ b/scripts/base16-atelier-heath-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Heath Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="f7/f3/f7" # Base 00 - Black
-base16_color01="ca/40/2b" # Base 08 - Red
-base16_color02="91/8b/3b" # Base 0B - Green
-base16_color03="bb/8a/35" # Base 0A - Yellow
-base16_color04="51/6a/ec" # Base 0D - Blue
-base16_color05="7b/59/c0" # Base 0E - Magenta
-base16_color06="15/93/93" # Base 0C - Cyan
-base16_color07="69/5d/69" # Base 05 - White
-base16_color08="9e/8f/9e" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="1b/18/1b" # Base 07 - Bright White
-base16_color16="a6/59/26" # Base 09
-base16_color17="cc/33/cc" # Base 0F
-base16_color18="d8/ca/d8" # Base 01
-base16_color19="ab/9b/ab" # Base 02
-base16_color20="77/69/77" # Base 04
-base16_color21="29/23/29" # Base 06
-base16_color_foreground="69/5d/69" # Base 05
-base16_color_background="f7/f3/f7" # Base 00
+export base16_color00="f7/f3/f7" # Base 00 - Black
+export base16_color01="ca/40/2b" # Base 08 - Red
+export base16_color02="91/8b/3b" # Base 0B - Green
+export base16_color03="bb/8a/35" # Base 0A - Yellow
+export base16_color04="51/6a/ec" # Base 0D - Blue
+export base16_color05="7b/59/c0" # Base 0E - Magenta
+export base16_color06="15/93/93" # Base 0C - Cyan
+export base16_color07="69/5d/69" # Base 05 - White
+export base16_color08="9e/8f/9e" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="1b/18/1b" # Base 07 - Bright White
+export base16_color16="a6/59/26" # Base 09
+export base16_color17="cc/33/cc" # Base 0F
+export base16_color18="d8/ca/d8" # Base 01
+export base16_color19="ab/9b/ab" # Base 02
+export base16_color20="77/69/77" # Base 04
+export base16_color21="29/23/29" # Base 06
+export base16_color_foreground="69/5d/69" # Base 05
+export base16_color_background="f7/f3/f7" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-heath.sh
+++ b/scripts/base16-atelier-heath.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Heath scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="1b/18/1b" # Base 00 - Black
-color01="ca/40/2b" # Base 08 - Red
-color02="91/8b/3b" # Base 0B - Green
-color03="bb/8a/35" # Base 0A - Yellow
-color04="51/6a/ec" # Base 0D - Blue
-color05="7b/59/c0" # Base 0E - Magenta
-color06="15/93/93" # Base 0C - Cyan
-color07="ab/9b/ab" # Base 05 - White
-color08="77/69/77" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f3/f7" # Base 07 - Bright White
-color16="a6/59/26" # Base 09
-color17="cc/33/cc" # Base 0F
-color18="29/23/29" # Base 01
-color19="69/5d/69" # Base 02
-color20="9e/8f/9e" # Base 04
-color21="d8/ca/d8" # Base 06
-color_foreground="ab/9b/ab" # Base 05
-color_background="1b/18/1b" # Base 00
+base16_color00="1b/18/1b" # Base 00 - Black
+base16_color01="ca/40/2b" # Base 08 - Red
+base16_color02="91/8b/3b" # Base 0B - Green
+base16_color03="bb/8a/35" # Base 0A - Yellow
+base16_color04="51/6a/ec" # Base 0D - Blue
+base16_color05="7b/59/c0" # Base 0E - Magenta
+base16_color06="15/93/93" # Base 0C - Cyan
+base16_color07="ab/9b/ab" # Base 05 - White
+base16_color08="77/69/77" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f7/f3/f7" # Base 07 - Bright White
+base16_color16="a6/59/26" # Base 09
+base16_color17="cc/33/cc" # Base 0F
+base16_color18="29/23/29" # Base 01
+base16_color19="69/5d/69" # Base 02
+base16_color20="9e/8f/9e" # Base 04
+base16_color21="d8/ca/d8" # Base 06
+base16_color_foreground="ab/9b/ab" # Base 05
+base16_color_background="1b/18/1b" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl ab9bab # cursor
   put_template_custom Pm 1b181b # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-heath.sh
+++ b/scripts/base16-atelier-heath.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Heath scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="1b/18/1b" # Base 00 - Black
-base16_color01="ca/40/2b" # Base 08 - Red
-base16_color02="91/8b/3b" # Base 0B - Green
-base16_color03="bb/8a/35" # Base 0A - Yellow
-base16_color04="51/6a/ec" # Base 0D - Blue
-base16_color05="7b/59/c0" # Base 0E - Magenta
-base16_color06="15/93/93" # Base 0C - Cyan
-base16_color07="ab/9b/ab" # Base 05 - White
-base16_color08="77/69/77" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f7/f3/f7" # Base 07 - Bright White
-base16_color16="a6/59/26" # Base 09
-base16_color17="cc/33/cc" # Base 0F
-base16_color18="29/23/29" # Base 01
-base16_color19="69/5d/69" # Base 02
-base16_color20="9e/8f/9e" # Base 04
-base16_color21="d8/ca/d8" # Base 06
-base16_color_foreground="ab/9b/ab" # Base 05
-base16_color_background="1b/18/1b" # Base 00
+export base16_color00="1b/18/1b" # Base 00 - Black
+export base16_color01="ca/40/2b" # Base 08 - Red
+export base16_color02="91/8b/3b" # Base 0B - Green
+export base16_color03="bb/8a/35" # Base 0A - Yellow
+export base16_color04="51/6a/ec" # Base 0D - Blue
+export base16_color05="7b/59/c0" # Base 0E - Magenta
+export base16_color06="15/93/93" # Base 0C - Cyan
+export base16_color07="ab/9b/ab" # Base 05 - White
+export base16_color08="77/69/77" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f7/f3/f7" # Base 07 - Bright White
+export base16_color16="a6/59/26" # Base 09
+export base16_color17="cc/33/cc" # Base 0F
+export base16_color18="29/23/29" # Base 01
+export base16_color19="69/5d/69" # Base 02
+export base16_color20="9e/8f/9e" # Base 04
+export base16_color21="d8/ca/d8" # Base 06
+export base16_color_foreground="ab/9b/ab" # Base 05
+export base16_color_background="1b/18/1b" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-lakeside-light.sh
+++ b/scripts/base16-atelier-lakeside-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Lakeside Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="eb/f8/ff" # Base 00 - Black
-base16_color01="d2/2d/72" # Base 08 - Red
-base16_color02="56/8c/3b" # Base 0B - Green
-base16_color03="8a/8a/0f" # Base 0A - Yellow
-base16_color04="25/7f/ad" # Base 0D - Blue
-base16_color05="6b/6b/b8" # Base 0E - Magenta
-base16_color06="2d/8f/6f" # Base 0C - Cyan
-base16_color07="51/6d/7b" # Base 05 - White
-base16_color08="71/95/a8" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="16/1b/1d" # Base 07 - Bright White
-base16_color16="93/5c/25" # Base 09
-base16_color17="b7/2d/d2" # Base 0F
-base16_color18="c1/e4/f6" # Base 01
-base16_color19="7e/a2/b4" # Base 02
-base16_color20="5a/7b/8c" # Base 04
-base16_color21="1f/29/2e" # Base 06
-base16_color_foreground="51/6d/7b" # Base 05
-base16_color_background="eb/f8/ff" # Base 00
+export base16_color00="eb/f8/ff" # Base 00 - Black
+export base16_color01="d2/2d/72" # Base 08 - Red
+export base16_color02="56/8c/3b" # Base 0B - Green
+export base16_color03="8a/8a/0f" # Base 0A - Yellow
+export base16_color04="25/7f/ad" # Base 0D - Blue
+export base16_color05="6b/6b/b8" # Base 0E - Magenta
+export base16_color06="2d/8f/6f" # Base 0C - Cyan
+export base16_color07="51/6d/7b" # Base 05 - White
+export base16_color08="71/95/a8" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="16/1b/1d" # Base 07 - Bright White
+export base16_color16="93/5c/25" # Base 09
+export base16_color17="b7/2d/d2" # Base 0F
+export base16_color18="c1/e4/f6" # Base 01
+export base16_color19="7e/a2/b4" # Base 02
+export base16_color20="5a/7b/8c" # Base 04
+export base16_color21="1f/29/2e" # Base 06
+export base16_color_foreground="51/6d/7b" # Base 05
+export base16_color_background="eb/f8/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-lakeside-light.sh
+++ b/scripts/base16-atelier-lakeside-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Lakeside Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="eb/f8/ff" # Base 00 - Black
-color01="d2/2d/72" # Base 08 - Red
-color02="56/8c/3b" # Base 0B - Green
-color03="8a/8a/0f" # Base 0A - Yellow
-color04="25/7f/ad" # Base 0D - Blue
-color05="6b/6b/b8" # Base 0E - Magenta
-color06="2d/8f/6f" # Base 0C - Cyan
-color07="51/6d/7b" # Base 05 - White
-color08="71/95/a8" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="16/1b/1d" # Base 07 - Bright White
-color16="93/5c/25" # Base 09
-color17="b7/2d/d2" # Base 0F
-color18="c1/e4/f6" # Base 01
-color19="7e/a2/b4" # Base 02
-color20="5a/7b/8c" # Base 04
-color21="1f/29/2e" # Base 06
-color_foreground="51/6d/7b" # Base 05
-color_background="eb/f8/ff" # Base 00
+base16_color00="eb/f8/ff" # Base 00 - Black
+base16_color01="d2/2d/72" # Base 08 - Red
+base16_color02="56/8c/3b" # Base 0B - Green
+base16_color03="8a/8a/0f" # Base 0A - Yellow
+base16_color04="25/7f/ad" # Base 0D - Blue
+base16_color05="6b/6b/b8" # Base 0E - Magenta
+base16_color06="2d/8f/6f" # Base 0C - Cyan
+base16_color07="51/6d/7b" # Base 05 - White
+base16_color08="71/95/a8" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="16/1b/1d" # Base 07 - Bright White
+base16_color16="93/5c/25" # Base 09
+base16_color17="b7/2d/d2" # Base 0F
+base16_color18="c1/e4/f6" # Base 01
+base16_color19="7e/a2/b4" # Base 02
+base16_color20="5a/7b/8c" # Base 04
+base16_color21="1f/29/2e" # Base 06
+base16_color_foreground="51/6d/7b" # Base 05
+base16_color_background="eb/f8/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 516d7b # cursor
   put_template_custom Pm ebf8ff # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-lakeside.sh
+++ b/scripts/base16-atelier-lakeside.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Lakeside scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="16/1b/1d" # Base 00 - Black
-base16_color01="d2/2d/72" # Base 08 - Red
-base16_color02="56/8c/3b" # Base 0B - Green
-base16_color03="8a/8a/0f" # Base 0A - Yellow
-base16_color04="25/7f/ad" # Base 0D - Blue
-base16_color05="6b/6b/b8" # Base 0E - Magenta
-base16_color06="2d/8f/6f" # Base 0C - Cyan
-base16_color07="7e/a2/b4" # Base 05 - White
-base16_color08="5a/7b/8c" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="eb/f8/ff" # Base 07 - Bright White
-base16_color16="93/5c/25" # Base 09
-base16_color17="b7/2d/d2" # Base 0F
-base16_color18="1f/29/2e" # Base 01
-base16_color19="51/6d/7b" # Base 02
-base16_color20="71/95/a8" # Base 04
-base16_color21="c1/e4/f6" # Base 06
-base16_color_foreground="7e/a2/b4" # Base 05
-base16_color_background="16/1b/1d" # Base 00
+export base16_color00="16/1b/1d" # Base 00 - Black
+export base16_color01="d2/2d/72" # Base 08 - Red
+export base16_color02="56/8c/3b" # Base 0B - Green
+export base16_color03="8a/8a/0f" # Base 0A - Yellow
+export base16_color04="25/7f/ad" # Base 0D - Blue
+export base16_color05="6b/6b/b8" # Base 0E - Magenta
+export base16_color06="2d/8f/6f" # Base 0C - Cyan
+export base16_color07="7e/a2/b4" # Base 05 - White
+export base16_color08="5a/7b/8c" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="eb/f8/ff" # Base 07 - Bright White
+export base16_color16="93/5c/25" # Base 09
+export base16_color17="b7/2d/d2" # Base 0F
+export base16_color18="1f/29/2e" # Base 01
+export base16_color19="51/6d/7b" # Base 02
+export base16_color20="71/95/a8" # Base 04
+export base16_color21="c1/e4/f6" # Base 06
+export base16_color_foreground="7e/a2/b4" # Base 05
+export base16_color_background="16/1b/1d" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-lakeside.sh
+++ b/scripts/base16-atelier-lakeside.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Lakeside scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="16/1b/1d" # Base 00 - Black
-color01="d2/2d/72" # Base 08 - Red
-color02="56/8c/3b" # Base 0B - Green
-color03="8a/8a/0f" # Base 0A - Yellow
-color04="25/7f/ad" # Base 0D - Blue
-color05="6b/6b/b8" # Base 0E - Magenta
-color06="2d/8f/6f" # Base 0C - Cyan
-color07="7e/a2/b4" # Base 05 - White
-color08="5a/7b/8c" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="eb/f8/ff" # Base 07 - Bright White
-color16="93/5c/25" # Base 09
-color17="b7/2d/d2" # Base 0F
-color18="1f/29/2e" # Base 01
-color19="51/6d/7b" # Base 02
-color20="71/95/a8" # Base 04
-color21="c1/e4/f6" # Base 06
-color_foreground="7e/a2/b4" # Base 05
-color_background="16/1b/1d" # Base 00
+base16_color00="16/1b/1d" # Base 00 - Black
+base16_color01="d2/2d/72" # Base 08 - Red
+base16_color02="56/8c/3b" # Base 0B - Green
+base16_color03="8a/8a/0f" # Base 0A - Yellow
+base16_color04="25/7f/ad" # Base 0D - Blue
+base16_color05="6b/6b/b8" # Base 0E - Magenta
+base16_color06="2d/8f/6f" # Base 0C - Cyan
+base16_color07="7e/a2/b4" # Base 05 - White
+base16_color08="5a/7b/8c" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="eb/f8/ff" # Base 07 - Bright White
+base16_color16="93/5c/25" # Base 09
+base16_color17="b7/2d/d2" # Base 0F
+base16_color18="1f/29/2e" # Base 01
+base16_color19="51/6d/7b" # Base 02
+base16_color20="71/95/a8" # Base 04
+base16_color21="c1/e4/f6" # Base 06
+base16_color_foreground="7e/a2/b4" # Base 05
+base16_color_background="16/1b/1d" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 7ea2b4 # cursor
   put_template_custom Pm 161b1d # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-plateau-light.sh
+++ b/scripts/base16-atelier-plateau-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Plateau Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="f4/ec/ec" # Base 00 - Black
-base16_color01="ca/49/49" # Base 08 - Red
-base16_color02="4b/8b/8b" # Base 0B - Green
-base16_color03="a0/6e/3b" # Base 0A - Yellow
-base16_color04="72/72/ca" # Base 0D - Blue
-base16_color05="84/64/c4" # Base 0E - Magenta
-base16_color06="54/85/b6" # Base 0C - Cyan
-base16_color07="58/50/50" # Base 05 - White
-base16_color08="7e/77/77" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="1b/18/18" # Base 07 - Bright White
-base16_color16="b4/5a/3c" # Base 09
-base16_color17="bd/51/87" # Base 0F
-base16_color18="e7/df/df" # Base 01
-base16_color19="8a/85/85" # Base 02
-base16_color20="65/5d/5d" # Base 04
-base16_color21="29/24/24" # Base 06
-base16_color_foreground="58/50/50" # Base 05
-base16_color_background="f4/ec/ec" # Base 00
+export base16_color00="f4/ec/ec" # Base 00 - Black
+export base16_color01="ca/49/49" # Base 08 - Red
+export base16_color02="4b/8b/8b" # Base 0B - Green
+export base16_color03="a0/6e/3b" # Base 0A - Yellow
+export base16_color04="72/72/ca" # Base 0D - Blue
+export base16_color05="84/64/c4" # Base 0E - Magenta
+export base16_color06="54/85/b6" # Base 0C - Cyan
+export base16_color07="58/50/50" # Base 05 - White
+export base16_color08="7e/77/77" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="1b/18/18" # Base 07 - Bright White
+export base16_color16="b4/5a/3c" # Base 09
+export base16_color17="bd/51/87" # Base 0F
+export base16_color18="e7/df/df" # Base 01
+export base16_color19="8a/85/85" # Base 02
+export base16_color20="65/5d/5d" # Base 04
+export base16_color21="29/24/24" # Base 06
+export base16_color_foreground="58/50/50" # Base 05
+export base16_color_background="f4/ec/ec" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-plateau-light.sh
+++ b/scripts/base16-atelier-plateau-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Plateau Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="f4/ec/ec" # Base 00 - Black
-color01="ca/49/49" # Base 08 - Red
-color02="4b/8b/8b" # Base 0B - Green
-color03="a0/6e/3b" # Base 0A - Yellow
-color04="72/72/ca" # Base 0D - Blue
-color05="84/64/c4" # Base 0E - Magenta
-color06="54/85/b6" # Base 0C - Cyan
-color07="58/50/50" # Base 05 - White
-color08="7e/77/77" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="1b/18/18" # Base 07 - Bright White
-color16="b4/5a/3c" # Base 09
-color17="bd/51/87" # Base 0F
-color18="e7/df/df" # Base 01
-color19="8a/85/85" # Base 02
-color20="65/5d/5d" # Base 04
-color21="29/24/24" # Base 06
-color_foreground="58/50/50" # Base 05
-color_background="f4/ec/ec" # Base 00
+base16_color00="f4/ec/ec" # Base 00 - Black
+base16_color01="ca/49/49" # Base 08 - Red
+base16_color02="4b/8b/8b" # Base 0B - Green
+base16_color03="a0/6e/3b" # Base 0A - Yellow
+base16_color04="72/72/ca" # Base 0D - Blue
+base16_color05="84/64/c4" # Base 0E - Magenta
+base16_color06="54/85/b6" # Base 0C - Cyan
+base16_color07="58/50/50" # Base 05 - White
+base16_color08="7e/77/77" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="1b/18/18" # Base 07 - Bright White
+base16_color16="b4/5a/3c" # Base 09
+base16_color17="bd/51/87" # Base 0F
+base16_color18="e7/df/df" # Base 01
+base16_color19="8a/85/85" # Base 02
+base16_color20="65/5d/5d" # Base 04
+base16_color21="29/24/24" # Base 06
+base16_color_foreground="58/50/50" # Base 05
+base16_color_background="f4/ec/ec" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 585050 # cursor
   put_template_custom Pm f4ecec # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-plateau.sh
+++ b/scripts/base16-atelier-plateau.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Plateau scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="1b/18/18" # Base 00 - Black
-color01="ca/49/49" # Base 08 - Red
-color02="4b/8b/8b" # Base 0B - Green
-color03="a0/6e/3b" # Base 0A - Yellow
-color04="72/72/ca" # Base 0D - Blue
-color05="84/64/c4" # Base 0E - Magenta
-color06="54/85/b6" # Base 0C - Cyan
-color07="8a/85/85" # Base 05 - White
-color08="65/5d/5d" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f4/ec/ec" # Base 07 - Bright White
-color16="b4/5a/3c" # Base 09
-color17="bd/51/87" # Base 0F
-color18="29/24/24" # Base 01
-color19="58/50/50" # Base 02
-color20="7e/77/77" # Base 04
-color21="e7/df/df" # Base 06
-color_foreground="8a/85/85" # Base 05
-color_background="1b/18/18" # Base 00
+base16_color00="1b/18/18" # Base 00 - Black
+base16_color01="ca/49/49" # Base 08 - Red
+base16_color02="4b/8b/8b" # Base 0B - Green
+base16_color03="a0/6e/3b" # Base 0A - Yellow
+base16_color04="72/72/ca" # Base 0D - Blue
+base16_color05="84/64/c4" # Base 0E - Magenta
+base16_color06="54/85/b6" # Base 0C - Cyan
+base16_color07="8a/85/85" # Base 05 - White
+base16_color08="65/5d/5d" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f4/ec/ec" # Base 07 - Bright White
+base16_color16="b4/5a/3c" # Base 09
+base16_color17="bd/51/87" # Base 0F
+base16_color18="29/24/24" # Base 01
+base16_color19="58/50/50" # Base 02
+base16_color20="7e/77/77" # Base 04
+base16_color21="e7/df/df" # Base 06
+base16_color_foreground="8a/85/85" # Base 05
+base16_color_background="1b/18/18" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 8a8585 # cursor
   put_template_custom Pm 1b1818 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-plateau.sh
+++ b/scripts/base16-atelier-plateau.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Plateau scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="1b/18/18" # Base 00 - Black
-base16_color01="ca/49/49" # Base 08 - Red
-base16_color02="4b/8b/8b" # Base 0B - Green
-base16_color03="a0/6e/3b" # Base 0A - Yellow
-base16_color04="72/72/ca" # Base 0D - Blue
-base16_color05="84/64/c4" # Base 0E - Magenta
-base16_color06="54/85/b6" # Base 0C - Cyan
-base16_color07="8a/85/85" # Base 05 - White
-base16_color08="65/5d/5d" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f4/ec/ec" # Base 07 - Bright White
-base16_color16="b4/5a/3c" # Base 09
-base16_color17="bd/51/87" # Base 0F
-base16_color18="29/24/24" # Base 01
-base16_color19="58/50/50" # Base 02
-base16_color20="7e/77/77" # Base 04
-base16_color21="e7/df/df" # Base 06
-base16_color_foreground="8a/85/85" # Base 05
-base16_color_background="1b/18/18" # Base 00
+export base16_color00="1b/18/18" # Base 00 - Black
+export base16_color01="ca/49/49" # Base 08 - Red
+export base16_color02="4b/8b/8b" # Base 0B - Green
+export base16_color03="a0/6e/3b" # Base 0A - Yellow
+export base16_color04="72/72/ca" # Base 0D - Blue
+export base16_color05="84/64/c4" # Base 0E - Magenta
+export base16_color06="54/85/b6" # Base 0C - Cyan
+export base16_color07="8a/85/85" # Base 05 - White
+export base16_color08="65/5d/5d" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f4/ec/ec" # Base 07 - Bright White
+export base16_color16="b4/5a/3c" # Base 09
+export base16_color17="bd/51/87" # Base 0F
+export base16_color18="29/24/24" # Base 01
+export base16_color19="58/50/50" # Base 02
+export base16_color20="7e/77/77" # Base 04
+export base16_color21="e7/df/df" # Base 06
+export base16_color_foreground="8a/85/85" # Base 05
+export base16_color_background="1b/18/18" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-savanna-light.sh
+++ b/scripts/base16-atelier-savanna-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Savanna Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="ec/f4/ee" # Base 00 - Black
-color01="b1/61/39" # Base 08 - Red
-color02="48/99/63" # Base 0B - Green
-color03="a0/7e/3b" # Base 0A - Yellow
-color04="47/8c/90" # Base 0D - Blue
-color05="55/85/9b" # Base 0E - Magenta
-color06="1c/9a/a0" # Base 0C - Cyan
-color07="52/60/57" # Base 05 - White
-color08="78/87/7d" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="17/1c/19" # Base 07 - Bright White
-color16="9f/71/3c" # Base 09
-color17="86/74/69" # Base 0F
-color18="df/e7/e2" # Base 01
-color19="87/92/8a" # Base 02
-color20="5f/6d/64" # Base 04
-color21="23/2a/25" # Base 06
-color_foreground="52/60/57" # Base 05
-color_background="ec/f4/ee" # Base 00
+base16_color00="ec/f4/ee" # Base 00 - Black
+base16_color01="b1/61/39" # Base 08 - Red
+base16_color02="48/99/63" # Base 0B - Green
+base16_color03="a0/7e/3b" # Base 0A - Yellow
+base16_color04="47/8c/90" # Base 0D - Blue
+base16_color05="55/85/9b" # Base 0E - Magenta
+base16_color06="1c/9a/a0" # Base 0C - Cyan
+base16_color07="52/60/57" # Base 05 - White
+base16_color08="78/87/7d" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="17/1c/19" # Base 07 - Bright White
+base16_color16="9f/71/3c" # Base 09
+base16_color17="86/74/69" # Base 0F
+base16_color18="df/e7/e2" # Base 01
+base16_color19="87/92/8a" # Base 02
+base16_color20="5f/6d/64" # Base 04
+base16_color21="23/2a/25" # Base 06
+base16_color_foreground="52/60/57" # Base 05
+base16_color_background="ec/f4/ee" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 526057 # cursor
   put_template_custom Pm ecf4ee # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-savanna-light.sh
+++ b/scripts/base16-atelier-savanna-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Savanna Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="ec/f4/ee" # Base 00 - Black
-base16_color01="b1/61/39" # Base 08 - Red
-base16_color02="48/99/63" # Base 0B - Green
-base16_color03="a0/7e/3b" # Base 0A - Yellow
-base16_color04="47/8c/90" # Base 0D - Blue
-base16_color05="55/85/9b" # Base 0E - Magenta
-base16_color06="1c/9a/a0" # Base 0C - Cyan
-base16_color07="52/60/57" # Base 05 - White
-base16_color08="78/87/7d" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="17/1c/19" # Base 07 - Bright White
-base16_color16="9f/71/3c" # Base 09
-base16_color17="86/74/69" # Base 0F
-base16_color18="df/e7/e2" # Base 01
-base16_color19="87/92/8a" # Base 02
-base16_color20="5f/6d/64" # Base 04
-base16_color21="23/2a/25" # Base 06
-base16_color_foreground="52/60/57" # Base 05
-base16_color_background="ec/f4/ee" # Base 00
+export base16_color00="ec/f4/ee" # Base 00 - Black
+export base16_color01="b1/61/39" # Base 08 - Red
+export base16_color02="48/99/63" # Base 0B - Green
+export base16_color03="a0/7e/3b" # Base 0A - Yellow
+export base16_color04="47/8c/90" # Base 0D - Blue
+export base16_color05="55/85/9b" # Base 0E - Magenta
+export base16_color06="1c/9a/a0" # Base 0C - Cyan
+export base16_color07="52/60/57" # Base 05 - White
+export base16_color08="78/87/7d" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="17/1c/19" # Base 07 - Bright White
+export base16_color16="9f/71/3c" # Base 09
+export base16_color17="86/74/69" # Base 0F
+export base16_color18="df/e7/e2" # Base 01
+export base16_color19="87/92/8a" # Base 02
+export base16_color20="5f/6d/64" # Base 04
+export base16_color21="23/2a/25" # Base 06
+export base16_color_foreground="52/60/57" # Base 05
+export base16_color_background="ec/f4/ee" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-savanna.sh
+++ b/scripts/base16-atelier-savanna.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Savanna scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="17/1c/19" # Base 00 - Black
-base16_color01="b1/61/39" # Base 08 - Red
-base16_color02="48/99/63" # Base 0B - Green
-base16_color03="a0/7e/3b" # Base 0A - Yellow
-base16_color04="47/8c/90" # Base 0D - Blue
-base16_color05="55/85/9b" # Base 0E - Magenta
-base16_color06="1c/9a/a0" # Base 0C - Cyan
-base16_color07="87/92/8a" # Base 05 - White
-base16_color08="5f/6d/64" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ec/f4/ee" # Base 07 - Bright White
-base16_color16="9f/71/3c" # Base 09
-base16_color17="86/74/69" # Base 0F
-base16_color18="23/2a/25" # Base 01
-base16_color19="52/60/57" # Base 02
-base16_color20="78/87/7d" # Base 04
-base16_color21="df/e7/e2" # Base 06
-base16_color_foreground="87/92/8a" # Base 05
-base16_color_background="17/1c/19" # Base 00
+export base16_color00="17/1c/19" # Base 00 - Black
+export base16_color01="b1/61/39" # Base 08 - Red
+export base16_color02="48/99/63" # Base 0B - Green
+export base16_color03="a0/7e/3b" # Base 0A - Yellow
+export base16_color04="47/8c/90" # Base 0D - Blue
+export base16_color05="55/85/9b" # Base 0E - Magenta
+export base16_color06="1c/9a/a0" # Base 0C - Cyan
+export base16_color07="87/92/8a" # Base 05 - White
+export base16_color08="5f/6d/64" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ec/f4/ee" # Base 07 - Bright White
+export base16_color16="9f/71/3c" # Base 09
+export base16_color17="86/74/69" # Base 0F
+export base16_color18="23/2a/25" # Base 01
+export base16_color19="52/60/57" # Base 02
+export base16_color20="78/87/7d" # Base 04
+export base16_color21="df/e7/e2" # Base 06
+export base16_color_foreground="87/92/8a" # Base 05
+export base16_color_background="17/1c/19" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-savanna.sh
+++ b/scripts/base16-atelier-savanna.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Savanna scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="17/1c/19" # Base 00 - Black
-color01="b1/61/39" # Base 08 - Red
-color02="48/99/63" # Base 0B - Green
-color03="a0/7e/3b" # Base 0A - Yellow
-color04="47/8c/90" # Base 0D - Blue
-color05="55/85/9b" # Base 0E - Magenta
-color06="1c/9a/a0" # Base 0C - Cyan
-color07="87/92/8a" # Base 05 - White
-color08="5f/6d/64" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ec/f4/ee" # Base 07 - Bright White
-color16="9f/71/3c" # Base 09
-color17="86/74/69" # Base 0F
-color18="23/2a/25" # Base 01
-color19="52/60/57" # Base 02
-color20="78/87/7d" # Base 04
-color21="df/e7/e2" # Base 06
-color_foreground="87/92/8a" # Base 05
-color_background="17/1c/19" # Base 00
+base16_color00="17/1c/19" # Base 00 - Black
+base16_color01="b1/61/39" # Base 08 - Red
+base16_color02="48/99/63" # Base 0B - Green
+base16_color03="a0/7e/3b" # Base 0A - Yellow
+base16_color04="47/8c/90" # Base 0D - Blue
+base16_color05="55/85/9b" # Base 0E - Magenta
+base16_color06="1c/9a/a0" # Base 0C - Cyan
+base16_color07="87/92/8a" # Base 05 - White
+base16_color08="5f/6d/64" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ec/f4/ee" # Base 07 - Bright White
+base16_color16="9f/71/3c" # Base 09
+base16_color17="86/74/69" # Base 0F
+base16_color18="23/2a/25" # Base 01
+base16_color19="52/60/57" # Base 02
+base16_color20="78/87/7d" # Base 04
+base16_color21="df/e7/e2" # Base 06
+base16_color_foreground="87/92/8a" # Base 05
+base16_color_background="17/1c/19" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 87928a # cursor
   put_template_custom Pm 171c19 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-seaside-light.sh
+++ b/scripts/base16-atelier-seaside-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Seaside Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="f4/fb/f4" # Base 00 - Black
-color01="e6/19/3c" # Base 08 - Red
-color02="29/a3/29" # Base 0B - Green
-color03="98/98/1b" # Base 0A - Yellow
-color04="3d/62/f5" # Base 0D - Blue
-color05="ad/2b/ee" # Base 0E - Magenta
-color06="19/99/b3" # Base 0C - Cyan
-color07="5e/6e/5e" # Base 05 - White
-color08="80/99/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="13/15/13" # Base 07 - Bright White
-color16="87/71/1d" # Base 09
-color17="e6/19/c3" # Base 0F
-color18="cf/e8/cf" # Base 01
-color19="8c/a6/8c" # Base 02
-color20="68/7d/68" # Base 04
-color21="24/29/24" # Base 06
-color_foreground="5e/6e/5e" # Base 05
-color_background="f4/fb/f4" # Base 00
+base16_color00="f4/fb/f4" # Base 00 - Black
+base16_color01="e6/19/3c" # Base 08 - Red
+base16_color02="29/a3/29" # Base 0B - Green
+base16_color03="98/98/1b" # Base 0A - Yellow
+base16_color04="3d/62/f5" # Base 0D - Blue
+base16_color05="ad/2b/ee" # Base 0E - Magenta
+base16_color06="19/99/b3" # Base 0C - Cyan
+base16_color07="5e/6e/5e" # Base 05 - White
+base16_color08="80/99/80" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="13/15/13" # Base 07 - Bright White
+base16_color16="87/71/1d" # Base 09
+base16_color17="e6/19/c3" # Base 0F
+base16_color18="cf/e8/cf" # Base 01
+base16_color19="8c/a6/8c" # Base 02
+base16_color20="68/7d/68" # Base 04
+base16_color21="24/29/24" # Base 06
+base16_color_foreground="5e/6e/5e" # Base 05
+base16_color_background="f4/fb/f4" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 5e6e5e # cursor
   put_template_custom Pm f4fbf4 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-seaside-light.sh
+++ b/scripts/base16-atelier-seaside-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Seaside Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="f4/fb/f4" # Base 00 - Black
-base16_color01="e6/19/3c" # Base 08 - Red
-base16_color02="29/a3/29" # Base 0B - Green
-base16_color03="98/98/1b" # Base 0A - Yellow
-base16_color04="3d/62/f5" # Base 0D - Blue
-base16_color05="ad/2b/ee" # Base 0E - Magenta
-base16_color06="19/99/b3" # Base 0C - Cyan
-base16_color07="5e/6e/5e" # Base 05 - White
-base16_color08="80/99/80" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="13/15/13" # Base 07 - Bright White
-base16_color16="87/71/1d" # Base 09
-base16_color17="e6/19/c3" # Base 0F
-base16_color18="cf/e8/cf" # Base 01
-base16_color19="8c/a6/8c" # Base 02
-base16_color20="68/7d/68" # Base 04
-base16_color21="24/29/24" # Base 06
-base16_color_foreground="5e/6e/5e" # Base 05
-base16_color_background="f4/fb/f4" # Base 00
+export base16_color00="f4/fb/f4" # Base 00 - Black
+export base16_color01="e6/19/3c" # Base 08 - Red
+export base16_color02="29/a3/29" # Base 0B - Green
+export base16_color03="98/98/1b" # Base 0A - Yellow
+export base16_color04="3d/62/f5" # Base 0D - Blue
+export base16_color05="ad/2b/ee" # Base 0E - Magenta
+export base16_color06="19/99/b3" # Base 0C - Cyan
+export base16_color07="5e/6e/5e" # Base 05 - White
+export base16_color08="80/99/80" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="13/15/13" # Base 07 - Bright White
+export base16_color16="87/71/1d" # Base 09
+export base16_color17="e6/19/c3" # Base 0F
+export base16_color18="cf/e8/cf" # Base 01
+export base16_color19="8c/a6/8c" # Base 02
+export base16_color20="68/7d/68" # Base 04
+export base16_color21="24/29/24" # Base 06
+export base16_color_foreground="5e/6e/5e" # Base 05
+export base16_color_background="f4/fb/f4" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-seaside.sh
+++ b/scripts/base16-atelier-seaside.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Seaside scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="13/15/13" # Base 00 - Black
-base16_color01="e6/19/3c" # Base 08 - Red
-base16_color02="29/a3/29" # Base 0B - Green
-base16_color03="98/98/1b" # Base 0A - Yellow
-base16_color04="3d/62/f5" # Base 0D - Blue
-base16_color05="ad/2b/ee" # Base 0E - Magenta
-base16_color06="19/99/b3" # Base 0C - Cyan
-base16_color07="8c/a6/8c" # Base 05 - White
-base16_color08="68/7d/68" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f4/fb/f4" # Base 07 - Bright White
-base16_color16="87/71/1d" # Base 09
-base16_color17="e6/19/c3" # Base 0F
-base16_color18="24/29/24" # Base 01
-base16_color19="5e/6e/5e" # Base 02
-base16_color20="80/99/80" # Base 04
-base16_color21="cf/e8/cf" # Base 06
-base16_color_foreground="8c/a6/8c" # Base 05
-base16_color_background="13/15/13" # Base 00
+export base16_color00="13/15/13" # Base 00 - Black
+export base16_color01="e6/19/3c" # Base 08 - Red
+export base16_color02="29/a3/29" # Base 0B - Green
+export base16_color03="98/98/1b" # Base 0A - Yellow
+export base16_color04="3d/62/f5" # Base 0D - Blue
+export base16_color05="ad/2b/ee" # Base 0E - Magenta
+export base16_color06="19/99/b3" # Base 0C - Cyan
+export base16_color07="8c/a6/8c" # Base 05 - White
+export base16_color08="68/7d/68" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f4/fb/f4" # Base 07 - Bright White
+export base16_color16="87/71/1d" # Base 09
+export base16_color17="e6/19/c3" # Base 0F
+export base16_color18="24/29/24" # Base 01
+export base16_color19="5e/6e/5e" # Base 02
+export base16_color20="80/99/80" # Base 04
+export base16_color21="cf/e8/cf" # Base 06
+export base16_color_foreground="8c/a6/8c" # Base 05
+export base16_color_background="13/15/13" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-seaside.sh
+++ b/scripts/base16-atelier-seaside.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Seaside scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="13/15/13" # Base 00 - Black
-color01="e6/19/3c" # Base 08 - Red
-color02="29/a3/29" # Base 0B - Green
-color03="98/98/1b" # Base 0A - Yellow
-color04="3d/62/f5" # Base 0D - Blue
-color05="ad/2b/ee" # Base 0E - Magenta
-color06="19/99/b3" # Base 0C - Cyan
-color07="8c/a6/8c" # Base 05 - White
-color08="68/7d/68" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f4/fb/f4" # Base 07 - Bright White
-color16="87/71/1d" # Base 09
-color17="e6/19/c3" # Base 0F
-color18="24/29/24" # Base 01
-color19="5e/6e/5e" # Base 02
-color20="80/99/80" # Base 04
-color21="cf/e8/cf" # Base 06
-color_foreground="8c/a6/8c" # Base 05
-color_background="13/15/13" # Base 00
+base16_color00="13/15/13" # Base 00 - Black
+base16_color01="e6/19/3c" # Base 08 - Red
+base16_color02="29/a3/29" # Base 0B - Green
+base16_color03="98/98/1b" # Base 0A - Yellow
+base16_color04="3d/62/f5" # Base 0D - Blue
+base16_color05="ad/2b/ee" # Base 0E - Magenta
+base16_color06="19/99/b3" # Base 0C - Cyan
+base16_color07="8c/a6/8c" # Base 05 - White
+base16_color08="68/7d/68" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f4/fb/f4" # Base 07 - Bright White
+base16_color16="87/71/1d" # Base 09
+base16_color17="e6/19/c3" # Base 0F
+base16_color18="24/29/24" # Base 01
+base16_color19="5e/6e/5e" # Base 02
+base16_color20="80/99/80" # Base 04
+base16_color21="cf/e8/cf" # Base 06
+base16_color_foreground="8c/a6/8c" # Base 05
+base16_color_background="13/15/13" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 8ca68c # cursor
   put_template_custom Pm 131513 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-sulphurpool-light.sh
+++ b/scripts/base16-atelier-sulphurpool-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Sulphurpool Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="f5/f7/ff" # Base 00 - Black
-color01="c9/49/22" # Base 08 - Red
-color02="ac/97/39" # Base 0B - Green
-color03="c0/8b/30" # Base 0A - Yellow
-color04="3d/8f/d1" # Base 0D - Blue
-color05="66/79/cc" # Base 0E - Magenta
-color06="22/a2/c9" # Base 0C - Cyan
-color07="5e/66/87" # Base 05 - White
-color08="89/8e/a4" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="20/27/46" # Base 07 - Bright White
-color16="c7/6b/29" # Base 09
-color17="9c/63/7a" # Base 0F
-color18="df/e2/f1" # Base 01
-color19="97/9d/b4" # Base 02
-color20="6b/73/94" # Base 04
-color21="29/32/56" # Base 06
-color_foreground="5e/66/87" # Base 05
-color_background="f5/f7/ff" # Base 00
+base16_color00="f5/f7/ff" # Base 00 - Black
+base16_color01="c9/49/22" # Base 08 - Red
+base16_color02="ac/97/39" # Base 0B - Green
+base16_color03="c0/8b/30" # Base 0A - Yellow
+base16_color04="3d/8f/d1" # Base 0D - Blue
+base16_color05="66/79/cc" # Base 0E - Magenta
+base16_color06="22/a2/c9" # Base 0C - Cyan
+base16_color07="5e/66/87" # Base 05 - White
+base16_color08="89/8e/a4" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="20/27/46" # Base 07 - Bright White
+base16_color16="c7/6b/29" # Base 09
+base16_color17="9c/63/7a" # Base 0F
+base16_color18="df/e2/f1" # Base 01
+base16_color19="97/9d/b4" # Base 02
+base16_color20="6b/73/94" # Base 04
+base16_color21="29/32/56" # Base 06
+base16_color_foreground="5e/66/87" # Base 05
+base16_color_background="f5/f7/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 5e6687 # cursor
   put_template_custom Pm f5f7ff # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atelier-sulphurpool-light.sh
+++ b/scripts/base16-atelier-sulphurpool-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Sulphurpool Light scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="f5/f7/ff" # Base 00 - Black
-base16_color01="c9/49/22" # Base 08 - Red
-base16_color02="ac/97/39" # Base 0B - Green
-base16_color03="c0/8b/30" # Base 0A - Yellow
-base16_color04="3d/8f/d1" # Base 0D - Blue
-base16_color05="66/79/cc" # Base 0E - Magenta
-base16_color06="22/a2/c9" # Base 0C - Cyan
-base16_color07="5e/66/87" # Base 05 - White
-base16_color08="89/8e/a4" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="20/27/46" # Base 07 - Bright White
-base16_color16="c7/6b/29" # Base 09
-base16_color17="9c/63/7a" # Base 0F
-base16_color18="df/e2/f1" # Base 01
-base16_color19="97/9d/b4" # Base 02
-base16_color20="6b/73/94" # Base 04
-base16_color21="29/32/56" # Base 06
-base16_color_foreground="5e/66/87" # Base 05
-base16_color_background="f5/f7/ff" # Base 00
+export base16_color00="f5/f7/ff" # Base 00 - Black
+export base16_color01="c9/49/22" # Base 08 - Red
+export base16_color02="ac/97/39" # Base 0B - Green
+export base16_color03="c0/8b/30" # Base 0A - Yellow
+export base16_color04="3d/8f/d1" # Base 0D - Blue
+export base16_color05="66/79/cc" # Base 0E - Magenta
+export base16_color06="22/a2/c9" # Base 0C - Cyan
+export base16_color07="5e/66/87" # Base 05 - White
+export base16_color08="89/8e/a4" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="20/27/46" # Base 07 - Bright White
+export base16_color16="c7/6b/29" # Base 09
+export base16_color17="9c/63/7a" # Base 0F
+export base16_color18="df/e2/f1" # Base 01
+export base16_color19="97/9d/b4" # Base 02
+export base16_color20="6b/73/94" # Base 04
+export base16_color21="29/32/56" # Base 06
+export base16_color_foreground="5e/66/87" # Base 05
+export base16_color_background="f5/f7/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-sulphurpool.sh
+++ b/scripts/base16-atelier-sulphurpool.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Sulphurpool scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-base16_color00="20/27/46" # Base 00 - Black
-base16_color01="c9/49/22" # Base 08 - Red
-base16_color02="ac/97/39" # Base 0B - Green
-base16_color03="c0/8b/30" # Base 0A - Yellow
-base16_color04="3d/8f/d1" # Base 0D - Blue
-base16_color05="66/79/cc" # Base 0E - Magenta
-base16_color06="22/a2/c9" # Base 0C - Cyan
-base16_color07="97/9d/b4" # Base 05 - White
-base16_color08="6b/73/94" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f5/f7/ff" # Base 07 - Bright White
-base16_color16="c7/6b/29" # Base 09
-base16_color17="9c/63/7a" # Base 0F
-base16_color18="29/32/56" # Base 01
-base16_color19="5e/66/87" # Base 02
-base16_color20="89/8e/a4" # Base 04
-base16_color21="df/e2/f1" # Base 06
-base16_color_foreground="97/9d/b4" # Base 05
-base16_color_background="20/27/46" # Base 00
+export base16_color00="20/27/46" # Base 00 - Black
+export base16_color01="c9/49/22" # Base 08 - Red
+export base16_color02="ac/97/39" # Base 0B - Green
+export base16_color03="c0/8b/30" # Base 0A - Yellow
+export base16_color04="3d/8f/d1" # Base 0D - Blue
+export base16_color05="66/79/cc" # Base 0E - Magenta
+export base16_color06="22/a2/c9" # Base 0C - Cyan
+export base16_color07="97/9d/b4" # Base 05 - White
+export base16_color08="6b/73/94" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f5/f7/ff" # Base 07 - Bright White
+export base16_color16="c7/6b/29" # Base 09
+export base16_color17="9c/63/7a" # Base 0F
+export base16_color18="29/32/56" # Base 01
+export base16_color19="5e/66/87" # Base 02
+export base16_color20="89/8e/a4" # Base 04
+export base16_color21="df/e2/f1" # Base 06
+export base16_color_foreground="97/9d/b4" # Base 05
+export base16_color_background="20/27/46" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-atelier-sulphurpool.sh
+++ b/scripts/base16-atelier-sulphurpool.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atelier Sulphurpool scheme by Bram de Haan (http://atelierbramdehaan.nl)
 
-color00="20/27/46" # Base 00 - Black
-color01="c9/49/22" # Base 08 - Red
-color02="ac/97/39" # Base 0B - Green
-color03="c0/8b/30" # Base 0A - Yellow
-color04="3d/8f/d1" # Base 0D - Blue
-color05="66/79/cc" # Base 0E - Magenta
-color06="22/a2/c9" # Base 0C - Cyan
-color07="97/9d/b4" # Base 05 - White
-color08="6b/73/94" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f5/f7/ff" # Base 07 - Bright White
-color16="c7/6b/29" # Base 09
-color17="9c/63/7a" # Base 0F
-color18="29/32/56" # Base 01
-color19="5e/66/87" # Base 02
-color20="89/8e/a4" # Base 04
-color21="df/e2/f1" # Base 06
-color_foreground="97/9d/b4" # Base 05
-color_background="20/27/46" # Base 00
+base16_color00="20/27/46" # Base 00 - Black
+base16_color01="c9/49/22" # Base 08 - Red
+base16_color02="ac/97/39" # Base 0B - Green
+base16_color03="c0/8b/30" # Base 0A - Yellow
+base16_color04="3d/8f/d1" # Base 0D - Blue
+base16_color05="66/79/cc" # Base 0E - Magenta
+base16_color06="22/a2/c9" # Base 0C - Cyan
+base16_color07="97/9d/b4" # Base 05 - White
+base16_color08="6b/73/94" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f5/f7/ff" # Base 07 - Bright White
+base16_color16="c7/6b/29" # Base 09
+base16_color17="9c/63/7a" # Base 0F
+base16_color18="29/32/56" # Base 01
+base16_color19="5e/66/87" # Base 02
+base16_color20="89/8e/a4" # Base 04
+base16_color21="df/e2/f1" # Base 06
+base16_color_foreground="97/9d/b4" # Base 05
+base16_color_background="20/27/46" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 979db4 # cursor
   put_template_custom Pm 202746 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atlas.sh
+++ b/scripts/base16-atlas.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atlas scheme by Alex Lende (https://ajlende.com)
 
-color00="00/26/35" # Base 00 - Black
-color01="ff/5a/67" # Base 08 - Red
-color02="7f/c0/6e" # Base 0B - Green
-color03="ff/cc/1b" # Base 0A - Yellow
-color04="5d/d7/b9" # Base 0D - Blue
-color05="9a/70/a4" # Base 0E - Magenta
-color06="14/74/7e" # Base 0C - Cyan
-color07="a1/a1/9a" # Base 05 - White
-color08="6C/8B/91" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fa/fa/f8" # Base 07 - Bright White
-color16="f0/8e/48" # Base 09
-color17="c4/30/60" # Base 0F
-color18="00/38/4d" # Base 01
-color19="51/7F/8D" # Base 02
-color20="86/96/96" # Base 04
-color21="e6/e6/dc" # Base 06
-color_foreground="a1/a1/9a" # Base 05
-color_background="00/26/35" # Base 00
+base16_color00="00/26/35" # Base 00 - Black
+base16_color01="ff/5a/67" # Base 08 - Red
+base16_color02="7f/c0/6e" # Base 0B - Green
+base16_color03="ff/cc/1b" # Base 0A - Yellow
+base16_color04="5d/d7/b9" # Base 0D - Blue
+base16_color05="9a/70/a4" # Base 0E - Magenta
+base16_color06="14/74/7e" # Base 0C - Cyan
+base16_color07="a1/a1/9a" # Base 05 - White
+base16_color08="6C/8B/91" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="fa/fa/f8" # Base 07 - Bright White
+base16_color16="f0/8e/48" # Base 09
+base16_color17="c4/30/60" # Base 0F
+base16_color18="00/38/4d" # Base 01
+base16_color19="51/7F/8D" # Base 02
+base16_color20="86/96/96" # Base 04
+base16_color21="e6/e6/dc" # Base 06
+base16_color_foreground="a1/a1/9a" # Base 05
+base16_color_background="00/26/35" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl a1a19a # cursor
   put_template_custom Pm 002635 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-atlas.sh
+++ b/scripts/base16-atlas.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Atlas scheme by Alex Lende (https://ajlende.com)
 
-base16_color00="00/26/35" # Base 00 - Black
-base16_color01="ff/5a/67" # Base 08 - Red
-base16_color02="7f/c0/6e" # Base 0B - Green
-base16_color03="ff/cc/1b" # Base 0A - Yellow
-base16_color04="5d/d7/b9" # Base 0D - Blue
-base16_color05="9a/70/a4" # Base 0E - Magenta
-base16_color06="14/74/7e" # Base 0C - Cyan
-base16_color07="a1/a1/9a" # Base 05 - White
-base16_color08="6C/8B/91" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="fa/fa/f8" # Base 07 - Bright White
-base16_color16="f0/8e/48" # Base 09
-base16_color17="c4/30/60" # Base 0F
-base16_color18="00/38/4d" # Base 01
-base16_color19="51/7F/8D" # Base 02
-base16_color20="86/96/96" # Base 04
-base16_color21="e6/e6/dc" # Base 06
-base16_color_foreground="a1/a1/9a" # Base 05
-base16_color_background="00/26/35" # Base 00
+export base16_color00="00/26/35" # Base 00 - Black
+export base16_color01="ff/5a/67" # Base 08 - Red
+export base16_color02="7f/c0/6e" # Base 0B - Green
+export base16_color03="ff/cc/1b" # Base 0A - Yellow
+export base16_color04="5d/d7/b9" # Base 0D - Blue
+export base16_color05="9a/70/a4" # Base 0E - Magenta
+export base16_color06="14/74/7e" # Base 0C - Cyan
+export base16_color07="a1/a1/9a" # Base 05 - White
+export base16_color08="6C/8B/91" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="fa/fa/f8" # Base 07 - Bright White
+export base16_color16="f0/8e/48" # Base 09
+export base16_color17="c4/30/60" # Base 0F
+export base16_color18="00/38/4d" # Base 01
+export base16_color19="51/7F/8D" # Base 02
+export base16_color20="86/96/96" # Base 04
+export base16_color21="e6/e6/dc" # Base 06
+export base16_color_foreground="a1/a1/9a" # Base 05
+export base16_color_background="00/26/35" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-bespin.sh
+++ b/scripts/base16-bespin.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Bespin scheme by Jan T. Sott
 
-color00="28/21/1c" # Base 00 - Black
-color01="cf/6a/4c" # Base 08 - Red
-color02="54/be/0d" # Base 0B - Green
-color03="f9/ee/98" # Base 0A - Yellow
-color04="5e/a6/ea" # Base 0D - Blue
-color05="9b/85/9d" # Base 0E - Magenta
-color06="af/c4/db" # Base 0C - Cyan
-color07="8a/89/86" # Base 05 - White
-color08="66/66/66" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ba/ae/9e" # Base 07 - Bright White
-color16="cf/7d/34" # Base 09
-color17="93/71/21" # Base 0F
-color18="36/31/2e" # Base 01
-color19="5e/5d/5c" # Base 02
-color20="79/79/77" # Base 04
-color21="9d/9b/97" # Base 06
-color_foreground="8a/89/86" # Base 05
-color_background="28/21/1c" # Base 00
+base16_color00="28/21/1c" # Base 00 - Black
+base16_color01="cf/6a/4c" # Base 08 - Red
+base16_color02="54/be/0d" # Base 0B - Green
+base16_color03="f9/ee/98" # Base 0A - Yellow
+base16_color04="5e/a6/ea" # Base 0D - Blue
+base16_color05="9b/85/9d" # Base 0E - Magenta
+base16_color06="af/c4/db" # Base 0C - Cyan
+base16_color07="8a/89/86" # Base 05 - White
+base16_color08="66/66/66" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ba/ae/9e" # Base 07 - Bright White
+base16_color16="cf/7d/34" # Base 09
+base16_color17="93/71/21" # Base 0F
+base16_color18="36/31/2e" # Base 01
+base16_color19="5e/5d/5c" # Base 02
+base16_color20="79/79/77" # Base 04
+base16_color21="9d/9b/97" # Base 06
+base16_color_foreground="8a/89/86" # Base 05
+base16_color_background="28/21/1c" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 8a8986 # cursor
   put_template_custom Pm 28211c # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-bespin.sh
+++ b/scripts/base16-bespin.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Bespin scheme by Jan T. Sott
 
-base16_color00="28/21/1c" # Base 00 - Black
-base16_color01="cf/6a/4c" # Base 08 - Red
-base16_color02="54/be/0d" # Base 0B - Green
-base16_color03="f9/ee/98" # Base 0A - Yellow
-base16_color04="5e/a6/ea" # Base 0D - Blue
-base16_color05="9b/85/9d" # Base 0E - Magenta
-base16_color06="af/c4/db" # Base 0C - Cyan
-base16_color07="8a/89/86" # Base 05 - White
-base16_color08="66/66/66" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ba/ae/9e" # Base 07 - Bright White
-base16_color16="cf/7d/34" # Base 09
-base16_color17="93/71/21" # Base 0F
-base16_color18="36/31/2e" # Base 01
-base16_color19="5e/5d/5c" # Base 02
-base16_color20="79/79/77" # Base 04
-base16_color21="9d/9b/97" # Base 06
-base16_color_foreground="8a/89/86" # Base 05
-base16_color_background="28/21/1c" # Base 00
+export base16_color00="28/21/1c" # Base 00 - Black
+export base16_color01="cf/6a/4c" # Base 08 - Red
+export base16_color02="54/be/0d" # Base 0B - Green
+export base16_color03="f9/ee/98" # Base 0A - Yellow
+export base16_color04="5e/a6/ea" # Base 0D - Blue
+export base16_color05="9b/85/9d" # Base 0E - Magenta
+export base16_color06="af/c4/db" # Base 0C - Cyan
+export base16_color07="8a/89/86" # Base 05 - White
+export base16_color08="66/66/66" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ba/ae/9e" # Base 07 - Bright White
+export base16_color16="cf/7d/34" # Base 09
+export base16_color17="93/71/21" # Base 0F
+export base16_color18="36/31/2e" # Base 01
+export base16_color19="5e/5d/5c" # Base 02
+export base16_color20="79/79/77" # Base 04
+export base16_color21="9d/9b/97" # Base 06
+export base16_color_foreground="8a/89/86" # Base 05
+export base16_color_background="28/21/1c" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-bathory.sh
+++ b/scripts/base16-black-metal-bathory.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Bathory) scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="fb/cb/97" # Base 0B - Green
-color03="e7/8a/53" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="fb/cb/97" # Base 0B - Green
+base16_color03="e7/8a/53" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal-bathory.sh
+++ b/scripts/base16-black-metal-bathory.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Bathory) scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="fb/cb/97" # Base 0B - Green
-base16_color03="e7/8a/53" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="fb/cb/97" # Base 0B - Green
+export base16_color03="e7/8a/53" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-burzum.sh
+++ b/scripts/base16-black-metal-burzum.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Burzum) scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="dd/ee/cc" # Base 0B - Green
-color03="99/bb/aa" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="dd/ee/cc" # Base 0B - Green
+base16_color03="99/bb/aa" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal-burzum.sh
+++ b/scripts/base16-black-metal-burzum.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Burzum) scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="dd/ee/cc" # Base 0B - Green
-base16_color03="99/bb/aa" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="dd/ee/cc" # Base 0B - Green
+export base16_color03="99/bb/aa" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-dark-funeral.sh
+++ b/scripts/base16-black-metal-dark-funeral.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Dark Funeral) scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="d0/df/ee" # Base 0B - Green
-base16_color03="5f/81/a5" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="d0/df/ee" # Base 0B - Green
+export base16_color03="5f/81/a5" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-dark-funeral.sh
+++ b/scripts/base16-black-metal-dark-funeral.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Dark Funeral) scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="d0/df/ee" # Base 0B - Green
-color03="5f/81/a5" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="d0/df/ee" # Base 0B - Green
+base16_color03="5f/81/a5" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal-gorgoroth.sh
+++ b/scripts/base16-black-metal-gorgoroth.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Gorgoroth) scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="9b/8d/7f" # Base 0B - Green
-color03="8c/7f/70" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="9b/8d/7f" # Base 0B - Green
+base16_color03="8c/7f/70" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal-gorgoroth.sh
+++ b/scripts/base16-black-metal-gorgoroth.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Gorgoroth) scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="9b/8d/7f" # Base 0B - Green
-base16_color03="8c/7f/70" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="9b/8d/7f" # Base 0B - Green
+export base16_color03="8c/7f/70" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-immortal.sh
+++ b/scripts/base16-black-metal-immortal.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Immortal) scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="77/99/bb" # Base 0B - Green
-base16_color03="55/66/77" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="77/99/bb" # Base 0B - Green
+export base16_color03="55/66/77" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-immortal.sh
+++ b/scripts/base16-black-metal-immortal.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Immortal) scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="77/99/bb" # Base 0B - Green
-color03="55/66/77" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="77/99/bb" # Base 0B - Green
+base16_color03="55/66/77" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal-khold.sh
+++ b/scripts/base16-black-metal-khold.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Khold) scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="ec/ee/e3" # Base 0B - Green
-color03="97/4b/46" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="ec/ee/e3" # Base 0B - Green
+base16_color03="97/4b/46" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal-khold.sh
+++ b/scripts/base16-black-metal-khold.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Khold) scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="ec/ee/e3" # Base 0B - Green
-base16_color03="97/4b/46" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="ec/ee/e3" # Base 0B - Green
+export base16_color03="97/4b/46" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-marduk.sh
+++ b/scripts/base16-black-metal-marduk.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Marduk) scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="a5/aa/a7" # Base 0B - Green
-base16_color03="62/6b/67" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="a5/aa/a7" # Base 0B - Green
+export base16_color03="62/6b/67" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-marduk.sh
+++ b/scripts/base16-black-metal-marduk.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Marduk) scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="a5/aa/a7" # Base 0B - Green
-color03="62/6b/67" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="a5/aa/a7" # Base 0B - Green
+base16_color03="62/6b/67" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal-mayhem.sh
+++ b/scripts/base16-black-metal-mayhem.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Mayhem) scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="f3/ec/d4" # Base 0B - Green
-color03="ee/cc/6c" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="f3/ec/d4" # Base 0B - Green
+base16_color03="ee/cc/6c" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal-mayhem.sh
+++ b/scripts/base16-black-metal-mayhem.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Mayhem) scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="f3/ec/d4" # Base 0B - Green
-base16_color03="ee/cc/6c" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="f3/ec/d4" # Base 0B - Green
+export base16_color03="ee/cc/6c" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-nile.sh
+++ b/scripts/base16-black-metal-nile.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Nile) scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="aa/99/88" # Base 0B - Green
-color03="77/77/55" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="aa/99/88" # Base 0B - Green
+base16_color03="77/77/55" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal-nile.sh
+++ b/scripts/base16-black-metal-nile.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Nile) scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="aa/99/88" # Base 0B - Green
-base16_color03="77/77/55" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="aa/99/88" # Base 0B - Green
+export base16_color03="77/77/55" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-venom.sh
+++ b/scripts/base16-black-metal-venom.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Venom) scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="f8/f7/f2" # Base 0B - Green
-base16_color03="79/24/1f" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="f8/f7/f2" # Base 0B - Green
+export base16_color03="79/24/1f" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-black-metal-venom.sh
+++ b/scripts/base16-black-metal-venom.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal (Venom) scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="f8/f7/f2" # Base 0B - Green
-color03="79/24/1f" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="f8/f7/f2" # Base 0B - Green
+base16_color03="79/24/1f" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal.sh
+++ b/scripts/base16-black-metal.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal scheme by metalelf0 (https://github.com/metalelf0)
 
-color00="00/00/00" # Base 00 - Black
-color01="5f/87/87" # Base 08 - Red
-color02="dd/99/99" # Base 0B - Green
-color03="a0/66/66" # Base 0A - Yellow
-color04="88/88/88" # Base 0D - Blue
-color05="99/99/99" # Base 0E - Magenta
-color06="aa/aa/aa" # Base 0C - Cyan
-color07="c1/c1/c1" # Base 05 - White
-color08="33/33/33" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c1/c1/c1" # Base 07 - Bright White
-color16="aa/aa/aa" # Base 09
-color17="44/44/44" # Base 0F
-color18="12/12/12" # Base 01
-color19="22/22/22" # Base 02
-color20="99/99/99" # Base 04
-color21="99/99/99" # Base 06
-color_foreground="c1/c1/c1" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="5f/87/87" # Base 08 - Red
+base16_color02="dd/99/99" # Base 0B - Green
+base16_color03="a0/66/66" # Base 0A - Yellow
+base16_color04="88/88/88" # Base 0D - Blue
+base16_color05="99/99/99" # Base 0E - Magenta
+base16_color06="aa/aa/aa" # Base 0C - Cyan
+base16_color07="c1/c1/c1" # Base 05 - White
+base16_color08="33/33/33" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c1/c1/c1" # Base 07 - Bright White
+base16_color16="aa/aa/aa" # Base 09
+base16_color17="44/44/44" # Base 0F
+base16_color18="12/12/12" # Base 01
+base16_color19="22/22/22" # Base 02
+base16_color20="99/99/99" # Base 04
+base16_color21="99/99/99" # Base 06
+base16_color_foreground="c1/c1/c1" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c1c1c1 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-black-metal.sh
+++ b/scripts/base16-black-metal.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Black Metal scheme by metalelf0 (https://github.com/metalelf0)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="5f/87/87" # Base 08 - Red
-base16_color02="dd/99/99" # Base 0B - Green
-base16_color03="a0/66/66" # Base 0A - Yellow
-base16_color04="88/88/88" # Base 0D - Blue
-base16_color05="99/99/99" # Base 0E - Magenta
-base16_color06="aa/aa/aa" # Base 0C - Cyan
-base16_color07="c1/c1/c1" # Base 05 - White
-base16_color08="33/33/33" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c1/c1/c1" # Base 07 - Bright White
-base16_color16="aa/aa/aa" # Base 09
-base16_color17="44/44/44" # Base 0F
-base16_color18="12/12/12" # Base 01
-base16_color19="22/22/22" # Base 02
-base16_color20="99/99/99" # Base 04
-base16_color21="99/99/99" # Base 06
-base16_color_foreground="c1/c1/c1" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="5f/87/87" # Base 08 - Red
+export base16_color02="dd/99/99" # Base 0B - Green
+export base16_color03="a0/66/66" # Base 0A - Yellow
+export base16_color04="88/88/88" # Base 0D - Blue
+export base16_color05="99/99/99" # Base 0E - Magenta
+export base16_color06="aa/aa/aa" # Base 0C - Cyan
+export base16_color07="c1/c1/c1" # Base 05 - White
+export base16_color08="33/33/33" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c1/c1/c1" # Base 07 - Bright White
+export base16_color16="aa/aa/aa" # Base 09
+export base16_color17="44/44/44" # Base 0F
+export base16_color18="12/12/12" # Base 01
+export base16_color19="22/22/22" # Base 02
+export base16_color20="99/99/99" # Base 04
+export base16_color21="99/99/99" # Base 06
+export base16_color_foreground="c1/c1/c1" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-brewer.sh
+++ b/scripts/base16-brewer.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Brewer scheme by Timothée Poisot (http://github.com/tpoisot)
 
-base16_color00="0c/0d/0e" # Base 00 - Black
-base16_color01="e3/1a/1c" # Base 08 - Red
-base16_color02="31/a3/54" # Base 0B - Green
-base16_color03="dc/a0/60" # Base 0A - Yellow
-base16_color04="31/82/bd" # Base 0D - Blue
-base16_color05="75/6b/b1" # Base 0E - Magenta
-base16_color06="80/b1/d3" # Base 0C - Cyan
-base16_color07="b7/b8/b9" # Base 05 - White
-base16_color08="73/74/75" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="fc/fd/fe" # Base 07 - Bright White
-base16_color16="e6/55/0d" # Base 09
-base16_color17="b1/59/28" # Base 0F
-base16_color18="2e/2f/30" # Base 01
-base16_color19="51/52/53" # Base 02
-base16_color20="95/96/97" # Base 04
-base16_color21="da/db/dc" # Base 06
-base16_color_foreground="b7/b8/b9" # Base 05
-base16_color_background="0c/0d/0e" # Base 00
+export base16_color00="0c/0d/0e" # Base 00 - Black
+export base16_color01="e3/1a/1c" # Base 08 - Red
+export base16_color02="31/a3/54" # Base 0B - Green
+export base16_color03="dc/a0/60" # Base 0A - Yellow
+export base16_color04="31/82/bd" # Base 0D - Blue
+export base16_color05="75/6b/b1" # Base 0E - Magenta
+export base16_color06="80/b1/d3" # Base 0C - Cyan
+export base16_color07="b7/b8/b9" # Base 05 - White
+export base16_color08="73/74/75" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="fc/fd/fe" # Base 07 - Bright White
+export base16_color16="e6/55/0d" # Base 09
+export base16_color17="b1/59/28" # Base 0F
+export base16_color18="2e/2f/30" # Base 01
+export base16_color19="51/52/53" # Base 02
+export base16_color20="95/96/97" # Base 04
+export base16_color21="da/db/dc" # Base 06
+export base16_color_foreground="b7/b8/b9" # Base 05
+export base16_color_background="0c/0d/0e" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-brewer.sh
+++ b/scripts/base16-brewer.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Brewer scheme by Timothée Poisot (http://github.com/tpoisot)
 
-color00="0c/0d/0e" # Base 00 - Black
-color01="e3/1a/1c" # Base 08 - Red
-color02="31/a3/54" # Base 0B - Green
-color03="dc/a0/60" # Base 0A - Yellow
-color04="31/82/bd" # Base 0D - Blue
-color05="75/6b/b1" # Base 0E - Magenta
-color06="80/b1/d3" # Base 0C - Cyan
-color07="b7/b8/b9" # Base 05 - White
-color08="73/74/75" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fc/fd/fe" # Base 07 - Bright White
-color16="e6/55/0d" # Base 09
-color17="b1/59/28" # Base 0F
-color18="2e/2f/30" # Base 01
-color19="51/52/53" # Base 02
-color20="95/96/97" # Base 04
-color21="da/db/dc" # Base 06
-color_foreground="b7/b8/b9" # Base 05
-color_background="0c/0d/0e" # Base 00
+base16_color00="0c/0d/0e" # Base 00 - Black
+base16_color01="e3/1a/1c" # Base 08 - Red
+base16_color02="31/a3/54" # Base 0B - Green
+base16_color03="dc/a0/60" # Base 0A - Yellow
+base16_color04="31/82/bd" # Base 0D - Blue
+base16_color05="75/6b/b1" # Base 0E - Magenta
+base16_color06="80/b1/d3" # Base 0C - Cyan
+base16_color07="b7/b8/b9" # Base 05 - White
+base16_color08="73/74/75" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="fc/fd/fe" # Base 07 - Bright White
+base16_color16="e6/55/0d" # Base 09
+base16_color17="b1/59/28" # Base 0F
+base16_color18="2e/2f/30" # Base 01
+base16_color19="51/52/53" # Base 02
+base16_color20="95/96/97" # Base 04
+base16_color21="da/db/dc" # Base 06
+base16_color_foreground="b7/b8/b9" # Base 05
+base16_color_background="0c/0d/0e" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl b7b8b9 # cursor
   put_template_custom Pm 0c0d0e # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-bright.sh
+++ b/scripts/base16-bright.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Bright scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="fb/01/20" # Base 08 - Red
-base16_color02="a1/c6/59" # Base 0B - Green
-base16_color03="fd/a3/31" # Base 0A - Yellow
-base16_color04="6f/b3/d2" # Base 0D - Blue
-base16_color05="d3/81/c3" # Base 0E - Magenta
-base16_color06="76/c7/b7" # Base 0C - Cyan
-base16_color07="e0/e0/e0" # Base 05 - White
-base16_color08="b0/b0/b0" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="fc/6d/24" # Base 09
-base16_color17="be/64/3c" # Base 0F
-base16_color18="30/30/30" # Base 01
-base16_color19="50/50/50" # Base 02
-base16_color20="d0/d0/d0" # Base 04
-base16_color21="f5/f5/f5" # Base 06
-base16_color_foreground="e0/e0/e0" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="fb/01/20" # Base 08 - Red
+export base16_color02="a1/c6/59" # Base 0B - Green
+export base16_color03="fd/a3/31" # Base 0A - Yellow
+export base16_color04="6f/b3/d2" # Base 0D - Blue
+export base16_color05="d3/81/c3" # Base 0E - Magenta
+export base16_color06="76/c7/b7" # Base 0C - Cyan
+export base16_color07="e0/e0/e0" # Base 05 - White
+export base16_color08="b0/b0/b0" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="fc/6d/24" # Base 09
+export base16_color17="be/64/3c" # Base 0F
+export base16_color18="30/30/30" # Base 01
+export base16_color19="50/50/50" # Base 02
+export base16_color20="d0/d0/d0" # Base 04
+export base16_color21="f5/f5/f5" # Base 06
+export base16_color_foreground="e0/e0/e0" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-bright.sh
+++ b/scripts/base16-bright.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Bright scheme by Chris Kempson (http://chriskempson.com)
 
-color00="00/00/00" # Base 00 - Black
-color01="fb/01/20" # Base 08 - Red
-color02="a1/c6/59" # Base 0B - Green
-color03="fd/a3/31" # Base 0A - Yellow
-color04="6f/b3/d2" # Base 0D - Blue
-color05="d3/81/c3" # Base 0E - Magenta
-color06="76/c7/b7" # Base 0C - Cyan
-color07="e0/e0/e0" # Base 05 - White
-color08="b0/b0/b0" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="fc/6d/24" # Base 09
-color17="be/64/3c" # Base 0F
-color18="30/30/30" # Base 01
-color19="50/50/50" # Base 02
-color20="d0/d0/d0" # Base 04
-color21="f5/f5/f5" # Base 06
-color_foreground="e0/e0/e0" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="fb/01/20" # Base 08 - Red
+base16_color02="a1/c6/59" # Base 0B - Green
+base16_color03="fd/a3/31" # Base 0A - Yellow
+base16_color04="6f/b3/d2" # Base 0D - Blue
+base16_color05="d3/81/c3" # Base 0E - Magenta
+base16_color06="76/c7/b7" # Base 0C - Cyan
+base16_color07="e0/e0/e0" # Base 05 - White
+base16_color08="b0/b0/b0" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="fc/6d/24" # Base 09
+base16_color17="be/64/3c" # Base 0F
+base16_color18="30/30/30" # Base 01
+base16_color19="50/50/50" # Base 02
+base16_color20="d0/d0/d0" # Base 04
+base16_color21="f5/f5/f5" # Base 06
+base16_color_foreground="e0/e0/e0" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl e0e0e0 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-brogrammer.sh
+++ b/scripts/base16-brogrammer.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Brogrammer scheme by Vik Ramanujam (http://github.com/piggyslasher)
 
-base16_color00="1f/1f/1f" # Base 00 - Black
-base16_color01="d6/db/e5" # Base 08 - Red
-base16_color02="f3/bd/09" # Base 0B - Green
-base16_color03="1d/d3/61" # Base 0A - Yellow
-base16_color04="53/50/b9" # Base 0D - Blue
-base16_color05="0f/7d/db" # Base 0E - Magenta
-base16_color06="10/81/d6" # Base 0C - Cyan
-base16_color07="4e/5a/b7" # Base 05 - White
-base16_color08="ec/ba/0f" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="d6/db/e5" # Base 07 - Bright White
-base16_color16="de/35/2e" # Base 09
-base16_color17="ff/ff/ff" # Base 0F
-base16_color18="f8/11/18" # Base 01
-base16_color19="2d/c5/5e" # Base 02
-base16_color20="2a/84/d2" # Base 04
-base16_color21="10/81/d6" # Base 06
-base16_color_foreground="4e/5a/b7" # Base 05
-base16_color_background="1f/1f/1f" # Base 00
+export base16_color00="1f/1f/1f" # Base 00 - Black
+export base16_color01="d6/db/e5" # Base 08 - Red
+export base16_color02="f3/bd/09" # Base 0B - Green
+export base16_color03="1d/d3/61" # Base 0A - Yellow
+export base16_color04="53/50/b9" # Base 0D - Blue
+export base16_color05="0f/7d/db" # Base 0E - Magenta
+export base16_color06="10/81/d6" # Base 0C - Cyan
+export base16_color07="4e/5a/b7" # Base 05 - White
+export base16_color08="ec/ba/0f" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="d6/db/e5" # Base 07 - Bright White
+export base16_color16="de/35/2e" # Base 09
+export base16_color17="ff/ff/ff" # Base 0F
+export base16_color18="f8/11/18" # Base 01
+export base16_color19="2d/c5/5e" # Base 02
+export base16_color20="2a/84/d2" # Base 04
+export base16_color21="10/81/d6" # Base 06
+export base16_color_foreground="4e/5a/b7" # Base 05
+export base16_color_background="1f/1f/1f" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-brogrammer.sh
+++ b/scripts/base16-brogrammer.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Brogrammer scheme by Vik Ramanujam (http://github.com/piggyslasher)
 
-color00="1f/1f/1f" # Base 00 - Black
-color01="d6/db/e5" # Base 08 - Red
-color02="f3/bd/09" # Base 0B - Green
-color03="1d/d3/61" # Base 0A - Yellow
-color04="53/50/b9" # Base 0D - Blue
-color05="0f/7d/db" # Base 0E - Magenta
-color06="10/81/d6" # Base 0C - Cyan
-color07="4e/5a/b7" # Base 05 - White
-color08="ec/ba/0f" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="d6/db/e5" # Base 07 - Bright White
-color16="de/35/2e" # Base 09
-color17="ff/ff/ff" # Base 0F
-color18="f8/11/18" # Base 01
-color19="2d/c5/5e" # Base 02
-color20="2a/84/d2" # Base 04
-color21="10/81/d6" # Base 06
-color_foreground="4e/5a/b7" # Base 05
-color_background="1f/1f/1f" # Base 00
+base16_color00="1f/1f/1f" # Base 00 - Black
+base16_color01="d6/db/e5" # Base 08 - Red
+base16_color02="f3/bd/09" # Base 0B - Green
+base16_color03="1d/d3/61" # Base 0A - Yellow
+base16_color04="53/50/b9" # Base 0D - Blue
+base16_color05="0f/7d/db" # Base 0E - Magenta
+base16_color06="10/81/d6" # Base 0C - Cyan
+base16_color07="4e/5a/b7" # Base 05 - White
+base16_color08="ec/ba/0f" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="d6/db/e5" # Base 07 - Bright White
+base16_color16="de/35/2e" # Base 09
+base16_color17="ff/ff/ff" # Base 0F
+base16_color18="f8/11/18" # Base 01
+base16_color19="2d/c5/5e" # Base 02
+base16_color20="2a/84/d2" # Base 04
+base16_color21="10/81/d6" # Base 06
+base16_color_foreground="4e/5a/b7" # Base 05
+base16_color_background="1f/1f/1f" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 4e5ab7 # cursor
   put_template_custom Pm 1f1f1f # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-brushtrees-dark.sh
+++ b/scripts/base16-brushtrees-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Brush Trees Dark scheme by Abraham White &lt;abelincoln.white@gmail.com&gt;
 
-color00="48/58/67" # Base 00 - Black
-color01="b3/86/86" # Base 08 - Red
-color02="87/b3/86" # Base 0B - Green
-color03="aa/b3/86" # Base 0A - Yellow
-color04="86/8c/b3" # Base 0D - Blue
-color05="b3/86/b2" # Base 0E - Magenta
-color06="86/b3/b3" # Base 0C - Cyan
-color07="B0/C5/C8" # Base 05 - White
-color08="82/99/A1" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="E3/EF/EF" # Base 07 - Bright White
-color16="d8/bb/a2" # Base 09
-color17="b3/9f/9f" # Base 0F
-color18="5A/6D/7A" # Base 01
-color19="6D/82/8E" # Base 02
-color20="98/AF/B5" # Base 04
-color21="C9/DB/DC" # Base 06
-color_foreground="B0/C5/C8" # Base 05
-color_background="48/58/67" # Base 00
+base16_color00="48/58/67" # Base 00 - Black
+base16_color01="b3/86/86" # Base 08 - Red
+base16_color02="87/b3/86" # Base 0B - Green
+base16_color03="aa/b3/86" # Base 0A - Yellow
+base16_color04="86/8c/b3" # Base 0D - Blue
+base16_color05="b3/86/b2" # Base 0E - Magenta
+base16_color06="86/b3/b3" # Base 0C - Cyan
+base16_color07="B0/C5/C8" # Base 05 - White
+base16_color08="82/99/A1" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="E3/EF/EF" # Base 07 - Bright White
+base16_color16="d8/bb/a2" # Base 09
+base16_color17="b3/9f/9f" # Base 0F
+base16_color18="5A/6D/7A" # Base 01
+base16_color19="6D/82/8E" # Base 02
+base16_color20="98/AF/B5" # Base 04
+base16_color21="C9/DB/DC" # Base 06
+base16_color_foreground="B0/C5/C8" # Base 05
+base16_color_background="48/58/67" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl B0C5C8 # cursor
   put_template_custom Pm 485867 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-brushtrees-dark.sh
+++ b/scripts/base16-brushtrees-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Brush Trees Dark scheme by Abraham White &lt;abelincoln.white@gmail.com&gt;
 
-base16_color00="48/58/67" # Base 00 - Black
-base16_color01="b3/86/86" # Base 08 - Red
-base16_color02="87/b3/86" # Base 0B - Green
-base16_color03="aa/b3/86" # Base 0A - Yellow
-base16_color04="86/8c/b3" # Base 0D - Blue
-base16_color05="b3/86/b2" # Base 0E - Magenta
-base16_color06="86/b3/b3" # Base 0C - Cyan
-base16_color07="B0/C5/C8" # Base 05 - White
-base16_color08="82/99/A1" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="E3/EF/EF" # Base 07 - Bright White
-base16_color16="d8/bb/a2" # Base 09
-base16_color17="b3/9f/9f" # Base 0F
-base16_color18="5A/6D/7A" # Base 01
-base16_color19="6D/82/8E" # Base 02
-base16_color20="98/AF/B5" # Base 04
-base16_color21="C9/DB/DC" # Base 06
-base16_color_foreground="B0/C5/C8" # Base 05
-base16_color_background="48/58/67" # Base 00
+export base16_color00="48/58/67" # Base 00 - Black
+export base16_color01="b3/86/86" # Base 08 - Red
+export base16_color02="87/b3/86" # Base 0B - Green
+export base16_color03="aa/b3/86" # Base 0A - Yellow
+export base16_color04="86/8c/b3" # Base 0D - Blue
+export base16_color05="b3/86/b2" # Base 0E - Magenta
+export base16_color06="86/b3/b3" # Base 0C - Cyan
+export base16_color07="B0/C5/C8" # Base 05 - White
+export base16_color08="82/99/A1" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="E3/EF/EF" # Base 07 - Bright White
+export base16_color16="d8/bb/a2" # Base 09
+export base16_color17="b3/9f/9f" # Base 0F
+export base16_color18="5A/6D/7A" # Base 01
+export base16_color19="6D/82/8E" # Base 02
+export base16_color20="98/AF/B5" # Base 04
+export base16_color21="C9/DB/DC" # Base 06
+export base16_color_foreground="B0/C5/C8" # Base 05
+export base16_color_background="48/58/67" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-brushtrees.sh
+++ b/scripts/base16-brushtrees.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Brush Trees scheme by Abraham White &lt;abelincoln.white@gmail.com&gt;
 
-color00="E3/EF/EF" # Base 00 - Black
-color01="b3/86/86" # Base 08 - Red
-color02="87/b3/86" # Base 0B - Green
-color03="aa/b3/86" # Base 0A - Yellow
-color04="86/8c/b3" # Base 0D - Blue
-color05="b3/86/b2" # Base 0E - Magenta
-color06="86/b3/b3" # Base 0C - Cyan
-color07="6D/82/8E" # Base 05 - White
-color08="98/AF/B5" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="48/58/67" # Base 07 - Bright White
-color16="d8/bb/a2" # Base 09
-color17="b3/9f/9f" # Base 0F
-color18="C9/DB/DC" # Base 01
-color19="B0/C5/C8" # Base 02
-color20="82/99/A1" # Base 04
-color21="5A/6D/7A" # Base 06
-color_foreground="6D/82/8E" # Base 05
-color_background="E3/EF/EF" # Base 00
+base16_color00="E3/EF/EF" # Base 00 - Black
+base16_color01="b3/86/86" # Base 08 - Red
+base16_color02="87/b3/86" # Base 0B - Green
+base16_color03="aa/b3/86" # Base 0A - Yellow
+base16_color04="86/8c/b3" # Base 0D - Blue
+base16_color05="b3/86/b2" # Base 0E - Magenta
+base16_color06="86/b3/b3" # Base 0C - Cyan
+base16_color07="6D/82/8E" # Base 05 - White
+base16_color08="98/AF/B5" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="48/58/67" # Base 07 - Bright White
+base16_color16="d8/bb/a2" # Base 09
+base16_color17="b3/9f/9f" # Base 0F
+base16_color18="C9/DB/DC" # Base 01
+base16_color19="B0/C5/C8" # Base 02
+base16_color20="82/99/A1" # Base 04
+base16_color21="5A/6D/7A" # Base 06
+base16_color_foreground="6D/82/8E" # Base 05
+base16_color_background="E3/EF/EF" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 6D828E # cursor
   put_template_custom Pm E3EFEF # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-brushtrees.sh
+++ b/scripts/base16-brushtrees.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Brush Trees scheme by Abraham White &lt;abelincoln.white@gmail.com&gt;
 
-base16_color00="E3/EF/EF" # Base 00 - Black
-base16_color01="b3/86/86" # Base 08 - Red
-base16_color02="87/b3/86" # Base 0B - Green
-base16_color03="aa/b3/86" # Base 0A - Yellow
-base16_color04="86/8c/b3" # Base 0D - Blue
-base16_color05="b3/86/b2" # Base 0E - Magenta
-base16_color06="86/b3/b3" # Base 0C - Cyan
-base16_color07="6D/82/8E" # Base 05 - White
-base16_color08="98/AF/B5" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="48/58/67" # Base 07 - Bright White
-base16_color16="d8/bb/a2" # Base 09
-base16_color17="b3/9f/9f" # Base 0F
-base16_color18="C9/DB/DC" # Base 01
-base16_color19="B0/C5/C8" # Base 02
-base16_color20="82/99/A1" # Base 04
-base16_color21="5A/6D/7A" # Base 06
-base16_color_foreground="6D/82/8E" # Base 05
-base16_color_background="E3/EF/EF" # Base 00
+export base16_color00="E3/EF/EF" # Base 00 - Black
+export base16_color01="b3/86/86" # Base 08 - Red
+export base16_color02="87/b3/86" # Base 0B - Green
+export base16_color03="aa/b3/86" # Base 0A - Yellow
+export base16_color04="86/8c/b3" # Base 0D - Blue
+export base16_color05="b3/86/b2" # Base 0E - Magenta
+export base16_color06="86/b3/b3" # Base 0C - Cyan
+export base16_color07="6D/82/8E" # Base 05 - White
+export base16_color08="98/AF/B5" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="48/58/67" # Base 07 - Bright White
+export base16_color16="d8/bb/a2" # Base 09
+export base16_color17="b3/9f/9f" # Base 0F
+export base16_color18="C9/DB/DC" # Base 01
+export base16_color19="B0/C5/C8" # Base 02
+export base16_color20="82/99/A1" # Base 04
+export base16_color21="5A/6D/7A" # Base 06
+export base16_color_foreground="6D/82/8E" # Base 05
+export base16_color_background="E3/EF/EF" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-chalk.sh
+++ b/scripts/base16-chalk.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Chalk scheme by Chris Kempson (http://chriskempson.com)
 
-color00="15/15/15" # Base 00 - Black
-color01="fb/9f/b1" # Base 08 - Red
-color02="ac/c2/67" # Base 0B - Green
-color03="dd/b2/6f" # Base 0A - Yellow
-color04="6f/c2/ef" # Base 0D - Blue
-color05="e1/a3/ee" # Base 0E - Magenta
-color06="12/cf/c0" # Base 0C - Cyan
-color07="d0/d0/d0" # Base 05 - White
-color08="50/50/50" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f5/f5/f5" # Base 07 - Bright White
-color16="ed/a9/87" # Base 09
-color17="de/af/8f" # Base 0F
-color18="20/20/20" # Base 01
-color19="30/30/30" # Base 02
-color20="b0/b0/b0" # Base 04
-color21="e0/e0/e0" # Base 06
-color_foreground="d0/d0/d0" # Base 05
-color_background="15/15/15" # Base 00
+base16_color00="15/15/15" # Base 00 - Black
+base16_color01="fb/9f/b1" # Base 08 - Red
+base16_color02="ac/c2/67" # Base 0B - Green
+base16_color03="dd/b2/6f" # Base 0A - Yellow
+base16_color04="6f/c2/ef" # Base 0D - Blue
+base16_color05="e1/a3/ee" # Base 0E - Magenta
+base16_color06="12/cf/c0" # Base 0C - Cyan
+base16_color07="d0/d0/d0" # Base 05 - White
+base16_color08="50/50/50" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f5/f5/f5" # Base 07 - Bright White
+base16_color16="ed/a9/87" # Base 09
+base16_color17="de/af/8f" # Base 0F
+base16_color18="20/20/20" # Base 01
+base16_color19="30/30/30" # Base 02
+base16_color20="b0/b0/b0" # Base 04
+base16_color21="e0/e0/e0" # Base 06
+base16_color_foreground="d0/d0/d0" # Base 05
+base16_color_background="15/15/15" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d0d0d0 # cursor
   put_template_custom Pm 151515 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-chalk.sh
+++ b/scripts/base16-chalk.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Chalk scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="15/15/15" # Base 00 - Black
-base16_color01="fb/9f/b1" # Base 08 - Red
-base16_color02="ac/c2/67" # Base 0B - Green
-base16_color03="dd/b2/6f" # Base 0A - Yellow
-base16_color04="6f/c2/ef" # Base 0D - Blue
-base16_color05="e1/a3/ee" # Base 0E - Magenta
-base16_color06="12/cf/c0" # Base 0C - Cyan
-base16_color07="d0/d0/d0" # Base 05 - White
-base16_color08="50/50/50" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f5/f5/f5" # Base 07 - Bright White
-base16_color16="ed/a9/87" # Base 09
-base16_color17="de/af/8f" # Base 0F
-base16_color18="20/20/20" # Base 01
-base16_color19="30/30/30" # Base 02
-base16_color20="b0/b0/b0" # Base 04
-base16_color21="e0/e0/e0" # Base 06
-base16_color_foreground="d0/d0/d0" # Base 05
-base16_color_background="15/15/15" # Base 00
+export base16_color00="15/15/15" # Base 00 - Black
+export base16_color01="fb/9f/b1" # Base 08 - Red
+export base16_color02="ac/c2/67" # Base 0B - Green
+export base16_color03="dd/b2/6f" # Base 0A - Yellow
+export base16_color04="6f/c2/ef" # Base 0D - Blue
+export base16_color05="e1/a3/ee" # Base 0E - Magenta
+export base16_color06="12/cf/c0" # Base 0C - Cyan
+export base16_color07="d0/d0/d0" # Base 05 - White
+export base16_color08="50/50/50" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f5/f5/f5" # Base 07 - Bright White
+export base16_color16="ed/a9/87" # Base 09
+export base16_color17="de/af/8f" # Base 0F
+export base16_color18="20/20/20" # Base 01
+export base16_color19="30/30/30" # Base 02
+export base16_color20="b0/b0/b0" # Base 04
+export base16_color21="e0/e0/e0" # Base 06
+export base16_color_foreground="d0/d0/d0" # Base 05
+export base16_color_background="15/15/15" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-circus.sh
+++ b/scripts/base16-circus.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Circus scheme by Stephan Boyer (https://github.com/stepchowfun) and Esther Wang (https://github.com/ewang12)
 
-color00="19/19/19" # Base 00 - Black
-color01="dc/65/7d" # Base 08 - Red
-color02="84/b9/7c" # Base 0B - Green
-color03="c3/ba/63" # Base 0A - Yellow
-color04="63/9e/e4" # Base 0D - Blue
-color05="b8/88/e2" # Base 0E - Magenta
-color06="4b/b1/a7" # Base 0C - Cyan
-color07="a7/a7/a7" # Base 05 - White
-color08="5f/5a/60" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="4b/b1/a7" # Base 09
-color17="b8/88/e2" # Base 0F
-color18="20/20/20" # Base 01
-color19="30/30/30" # Base 02
-color20="50/50/50" # Base 04
-color21="80/80/80" # Base 06
-color_foreground="a7/a7/a7" # Base 05
-color_background="19/19/19" # Base 00
+base16_color00="19/19/19" # Base 00 - Black
+base16_color01="dc/65/7d" # Base 08 - Red
+base16_color02="84/b9/7c" # Base 0B - Green
+base16_color03="c3/ba/63" # Base 0A - Yellow
+base16_color04="63/9e/e4" # Base 0D - Blue
+base16_color05="b8/88/e2" # Base 0E - Magenta
+base16_color06="4b/b1/a7" # Base 0C - Cyan
+base16_color07="a7/a7/a7" # Base 05 - White
+base16_color08="5f/5a/60" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="4b/b1/a7" # Base 09
+base16_color17="b8/88/e2" # Base 0F
+base16_color18="20/20/20" # Base 01
+base16_color19="30/30/30" # Base 02
+base16_color20="50/50/50" # Base 04
+base16_color21="80/80/80" # Base 06
+base16_color_foreground="a7/a7/a7" # Base 05
+base16_color_background="19/19/19" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl a7a7a7 # cursor
   put_template_custom Pm 191919 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-circus.sh
+++ b/scripts/base16-circus.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Circus scheme by Stephan Boyer (https://github.com/stepchowfun) and Esther Wang (https://github.com/ewang12)
 
-base16_color00="19/19/19" # Base 00 - Black
-base16_color01="dc/65/7d" # Base 08 - Red
-base16_color02="84/b9/7c" # Base 0B - Green
-base16_color03="c3/ba/63" # Base 0A - Yellow
-base16_color04="63/9e/e4" # Base 0D - Blue
-base16_color05="b8/88/e2" # Base 0E - Magenta
-base16_color06="4b/b1/a7" # Base 0C - Cyan
-base16_color07="a7/a7/a7" # Base 05 - White
-base16_color08="5f/5a/60" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="4b/b1/a7" # Base 09
-base16_color17="b8/88/e2" # Base 0F
-base16_color18="20/20/20" # Base 01
-base16_color19="30/30/30" # Base 02
-base16_color20="50/50/50" # Base 04
-base16_color21="80/80/80" # Base 06
-base16_color_foreground="a7/a7/a7" # Base 05
-base16_color_background="19/19/19" # Base 00
+export base16_color00="19/19/19" # Base 00 - Black
+export base16_color01="dc/65/7d" # Base 08 - Red
+export base16_color02="84/b9/7c" # Base 0B - Green
+export base16_color03="c3/ba/63" # Base 0A - Yellow
+export base16_color04="63/9e/e4" # Base 0D - Blue
+export base16_color05="b8/88/e2" # Base 0E - Magenta
+export base16_color06="4b/b1/a7" # Base 0C - Cyan
+export base16_color07="a7/a7/a7" # Base 05 - White
+export base16_color08="5f/5a/60" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="4b/b1/a7" # Base 09
+export base16_color17="b8/88/e2" # Base 0F
+export base16_color18="20/20/20" # Base 01
+export base16_color19="30/30/30" # Base 02
+export base16_color20="50/50/50" # Base 04
+export base16_color21="80/80/80" # Base 06
+export base16_color_foreground="a7/a7/a7" # Base 05
+export base16_color_background="19/19/19" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-classic-dark.sh
+++ b/scripts/base16-classic-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Classic Dark scheme by Jason Heeris (http://heeris.id.au)
 
-base16_color00="15/15/15" # Base 00 - Black
-base16_color01="AC/41/42" # Base 08 - Red
-base16_color02="90/A9/59" # Base 0B - Green
-base16_color03="F4/BF/75" # Base 0A - Yellow
-base16_color04="6A/9F/B5" # Base 0D - Blue
-base16_color05="AA/75/9F" # Base 0E - Magenta
-base16_color06="75/B5/AA" # Base 0C - Cyan
-base16_color07="D0/D0/D0" # Base 05 - White
-base16_color08="50/50/50" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="F5/F5/F5" # Base 07 - Bright White
-base16_color16="D2/84/45" # Base 09
-base16_color17="8F/55/36" # Base 0F
-base16_color18="20/20/20" # Base 01
-base16_color19="30/30/30" # Base 02
-base16_color20="B0/B0/B0" # Base 04
-base16_color21="E0/E0/E0" # Base 06
-base16_color_foreground="D0/D0/D0" # Base 05
-base16_color_background="15/15/15" # Base 00
+export base16_color00="15/15/15" # Base 00 - Black
+export base16_color01="AC/41/42" # Base 08 - Red
+export base16_color02="90/A9/59" # Base 0B - Green
+export base16_color03="F4/BF/75" # Base 0A - Yellow
+export base16_color04="6A/9F/B5" # Base 0D - Blue
+export base16_color05="AA/75/9F" # Base 0E - Magenta
+export base16_color06="75/B5/AA" # Base 0C - Cyan
+export base16_color07="D0/D0/D0" # Base 05 - White
+export base16_color08="50/50/50" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="F5/F5/F5" # Base 07 - Bright White
+export base16_color16="D2/84/45" # Base 09
+export base16_color17="8F/55/36" # Base 0F
+export base16_color18="20/20/20" # Base 01
+export base16_color19="30/30/30" # Base 02
+export base16_color20="B0/B0/B0" # Base 04
+export base16_color21="E0/E0/E0" # Base 06
+export base16_color_foreground="D0/D0/D0" # Base 05
+export base16_color_background="15/15/15" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-classic-dark.sh
+++ b/scripts/base16-classic-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Classic Dark scheme by Jason Heeris (http://heeris.id.au)
 
-color00="15/15/15" # Base 00 - Black
-color01="AC/41/42" # Base 08 - Red
-color02="90/A9/59" # Base 0B - Green
-color03="F4/BF/75" # Base 0A - Yellow
-color04="6A/9F/B5" # Base 0D - Blue
-color05="AA/75/9F" # Base 0E - Magenta
-color06="75/B5/AA" # Base 0C - Cyan
-color07="D0/D0/D0" # Base 05 - White
-color08="50/50/50" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="F5/F5/F5" # Base 07 - Bright White
-color16="D2/84/45" # Base 09
-color17="8F/55/36" # Base 0F
-color18="20/20/20" # Base 01
-color19="30/30/30" # Base 02
-color20="B0/B0/B0" # Base 04
-color21="E0/E0/E0" # Base 06
-color_foreground="D0/D0/D0" # Base 05
-color_background="15/15/15" # Base 00
+base16_color00="15/15/15" # Base 00 - Black
+base16_color01="AC/41/42" # Base 08 - Red
+base16_color02="90/A9/59" # Base 0B - Green
+base16_color03="F4/BF/75" # Base 0A - Yellow
+base16_color04="6A/9F/B5" # Base 0D - Blue
+base16_color05="AA/75/9F" # Base 0E - Magenta
+base16_color06="75/B5/AA" # Base 0C - Cyan
+base16_color07="D0/D0/D0" # Base 05 - White
+base16_color08="50/50/50" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="F5/F5/F5" # Base 07 - Bright White
+base16_color16="D2/84/45" # Base 09
+base16_color17="8F/55/36" # Base 0F
+base16_color18="20/20/20" # Base 01
+base16_color19="30/30/30" # Base 02
+base16_color20="B0/B0/B0" # Base 04
+base16_color21="E0/E0/E0" # Base 06
+base16_color_foreground="D0/D0/D0" # Base 05
+base16_color_background="15/15/15" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl D0D0D0 # cursor
   put_template_custom Pm 151515 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-classic-light.sh
+++ b/scripts/base16-classic-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Classic Light scheme by Jason Heeris (http://heeris.id.au)
 
-base16_color00="F5/F5/F5" # Base 00 - Black
-base16_color01="AC/41/42" # Base 08 - Red
-base16_color02="90/A9/59" # Base 0B - Green
-base16_color03="F4/BF/75" # Base 0A - Yellow
-base16_color04="6A/9F/B5" # Base 0D - Blue
-base16_color05="AA/75/9F" # Base 0E - Magenta
-base16_color06="75/B5/AA" # Base 0C - Cyan
-base16_color07="30/30/30" # Base 05 - White
-base16_color08="B0/B0/B0" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="15/15/15" # Base 07 - Bright White
-base16_color16="D2/84/45" # Base 09
-base16_color17="8F/55/36" # Base 0F
-base16_color18="E0/E0/E0" # Base 01
-base16_color19="D0/D0/D0" # Base 02
-base16_color20="50/50/50" # Base 04
-base16_color21="20/20/20" # Base 06
-base16_color_foreground="30/30/30" # Base 05
-base16_color_background="F5/F5/F5" # Base 00
+export base16_color00="F5/F5/F5" # Base 00 - Black
+export base16_color01="AC/41/42" # Base 08 - Red
+export base16_color02="90/A9/59" # Base 0B - Green
+export base16_color03="F4/BF/75" # Base 0A - Yellow
+export base16_color04="6A/9F/B5" # Base 0D - Blue
+export base16_color05="AA/75/9F" # Base 0E - Magenta
+export base16_color06="75/B5/AA" # Base 0C - Cyan
+export base16_color07="30/30/30" # Base 05 - White
+export base16_color08="B0/B0/B0" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="15/15/15" # Base 07 - Bright White
+export base16_color16="D2/84/45" # Base 09
+export base16_color17="8F/55/36" # Base 0F
+export base16_color18="E0/E0/E0" # Base 01
+export base16_color19="D0/D0/D0" # Base 02
+export base16_color20="50/50/50" # Base 04
+export base16_color21="20/20/20" # Base 06
+export base16_color_foreground="30/30/30" # Base 05
+export base16_color_background="F5/F5/F5" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-classic-light.sh
+++ b/scripts/base16-classic-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Classic Light scheme by Jason Heeris (http://heeris.id.au)
 
-color00="F5/F5/F5" # Base 00 - Black
-color01="AC/41/42" # Base 08 - Red
-color02="90/A9/59" # Base 0B - Green
-color03="F4/BF/75" # Base 0A - Yellow
-color04="6A/9F/B5" # Base 0D - Blue
-color05="AA/75/9F" # Base 0E - Magenta
-color06="75/B5/AA" # Base 0C - Cyan
-color07="30/30/30" # Base 05 - White
-color08="B0/B0/B0" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="15/15/15" # Base 07 - Bright White
-color16="D2/84/45" # Base 09
-color17="8F/55/36" # Base 0F
-color18="E0/E0/E0" # Base 01
-color19="D0/D0/D0" # Base 02
-color20="50/50/50" # Base 04
-color21="20/20/20" # Base 06
-color_foreground="30/30/30" # Base 05
-color_background="F5/F5/F5" # Base 00
+base16_color00="F5/F5/F5" # Base 00 - Black
+base16_color01="AC/41/42" # Base 08 - Red
+base16_color02="90/A9/59" # Base 0B - Green
+base16_color03="F4/BF/75" # Base 0A - Yellow
+base16_color04="6A/9F/B5" # Base 0D - Blue
+base16_color05="AA/75/9F" # Base 0E - Magenta
+base16_color06="75/B5/AA" # Base 0C - Cyan
+base16_color07="30/30/30" # Base 05 - White
+base16_color08="B0/B0/B0" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="15/15/15" # Base 07 - Bright White
+base16_color16="D2/84/45" # Base 09
+base16_color17="8F/55/36" # Base 0F
+base16_color18="E0/E0/E0" # Base 01
+base16_color19="D0/D0/D0" # Base 02
+base16_color20="50/50/50" # Base 04
+base16_color21="20/20/20" # Base 06
+base16_color_foreground="30/30/30" # Base 05
+base16_color_background="F5/F5/F5" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 303030 # cursor
   put_template_custom Pm F5F5F5 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-codeschool.sh
+++ b/scripts/base16-codeschool.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Codeschool scheme by blockloop
 
-color00="23/2c/31" # Base 00 - Black
-color01="2a/54/91" # Base 08 - Red
-color02="23/79/86" # Base 0B - Green
-color03="a0/3b/1e" # Base 0A - Yellow
-color04="48/4d/79" # Base 0D - Blue
-color05="c5/98/20" # Base 0E - Magenta
-color06="b0/2f/30" # Base 0C - Cyan
-color07="9e/a7/a6" # Base 05 - White
-color08="3f/49/44" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="b5/d8/f6" # Base 07 - Bright White
-color16="43/82/0d" # Base 09
-color17="c9/83/44" # Base 0F
-color18="1c/36/57" # Base 01
-color19="2a/34/3a" # Base 02
-color20="84/89/8c" # Base 04
-color21="a7/cf/a3" # Base 06
-color_foreground="9e/a7/a6" # Base 05
-color_background="23/2c/31" # Base 00
+base16_color00="23/2c/31" # Base 00 - Black
+base16_color01="2a/54/91" # Base 08 - Red
+base16_color02="23/79/86" # Base 0B - Green
+base16_color03="a0/3b/1e" # Base 0A - Yellow
+base16_color04="48/4d/79" # Base 0D - Blue
+base16_color05="c5/98/20" # Base 0E - Magenta
+base16_color06="b0/2f/30" # Base 0C - Cyan
+base16_color07="9e/a7/a6" # Base 05 - White
+base16_color08="3f/49/44" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="b5/d8/f6" # Base 07 - Bright White
+base16_color16="43/82/0d" # Base 09
+base16_color17="c9/83/44" # Base 0F
+base16_color18="1c/36/57" # Base 01
+base16_color19="2a/34/3a" # Base 02
+base16_color20="84/89/8c" # Base 04
+base16_color21="a7/cf/a3" # Base 06
+base16_color_foreground="9e/a7/a6" # Base 05
+base16_color_background="23/2c/31" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 9ea7a6 # cursor
   put_template_custom Pm 232c31 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-codeschool.sh
+++ b/scripts/base16-codeschool.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Codeschool scheme by blockloop
 
-base16_color00="23/2c/31" # Base 00 - Black
-base16_color01="2a/54/91" # Base 08 - Red
-base16_color02="23/79/86" # Base 0B - Green
-base16_color03="a0/3b/1e" # Base 0A - Yellow
-base16_color04="48/4d/79" # Base 0D - Blue
-base16_color05="c5/98/20" # Base 0E - Magenta
-base16_color06="b0/2f/30" # Base 0C - Cyan
-base16_color07="9e/a7/a6" # Base 05 - White
-base16_color08="3f/49/44" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="b5/d8/f6" # Base 07 - Bright White
-base16_color16="43/82/0d" # Base 09
-base16_color17="c9/83/44" # Base 0F
-base16_color18="1c/36/57" # Base 01
-base16_color19="2a/34/3a" # Base 02
-base16_color20="84/89/8c" # Base 04
-base16_color21="a7/cf/a3" # Base 06
-base16_color_foreground="9e/a7/a6" # Base 05
-base16_color_background="23/2c/31" # Base 00
+export base16_color00="23/2c/31" # Base 00 - Black
+export base16_color01="2a/54/91" # Base 08 - Red
+export base16_color02="23/79/86" # Base 0B - Green
+export base16_color03="a0/3b/1e" # Base 0A - Yellow
+export base16_color04="48/4d/79" # Base 0D - Blue
+export base16_color05="c5/98/20" # Base 0E - Magenta
+export base16_color06="b0/2f/30" # Base 0C - Cyan
+export base16_color07="9e/a7/a6" # Base 05 - White
+export base16_color08="3f/49/44" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="b5/d8/f6" # Base 07 - Bright White
+export base16_color16="43/82/0d" # Base 09
+export base16_color17="c9/83/44" # Base 0F
+export base16_color18="1c/36/57" # Base 01
+export base16_color19="2a/34/3a" # Base 02
+export base16_color20="84/89/8c" # Base 04
+export base16_color21="a7/cf/a3" # Base 06
+export base16_color_foreground="9e/a7/a6" # Base 05
+export base16_color_background="23/2c/31" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-cupcake.sh
+++ b/scripts/base16-cupcake.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Cupcake scheme by Chris Kempson (http://chriskempson.com)
 
-color00="fb/f1/f2" # Base 00 - Black
-color01="D5/7E/85" # Base 08 - Red
-color02="A3/B3/67" # Base 0B - Green
-color03="DC/B1/6C" # Base 0A - Yellow
-color04="72/97/B9" # Base 0D - Blue
-color05="BB/99/B4" # Base 0E - Magenta
-color06="69/A9/A7" # Base 0C - Cyan
-color07="8b/81/98" # Base 05 - White
-color08="bf/b9/c6" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="58/50/62" # Base 07 - Bright White
-color16="EB/B7/90" # Base 09
-color17="BA/A5/8C" # Base 0F
-color18="f2/f1/f4" # Base 01
-color19="d8/d5/dd" # Base 02
-color20="a5/9d/af" # Base 04
-color21="72/67/7E" # Base 06
-color_foreground="8b/81/98" # Base 05
-color_background="fb/f1/f2" # Base 00
+base16_color00="fb/f1/f2" # Base 00 - Black
+base16_color01="D5/7E/85" # Base 08 - Red
+base16_color02="A3/B3/67" # Base 0B - Green
+base16_color03="DC/B1/6C" # Base 0A - Yellow
+base16_color04="72/97/B9" # Base 0D - Blue
+base16_color05="BB/99/B4" # Base 0E - Magenta
+base16_color06="69/A9/A7" # Base 0C - Cyan
+base16_color07="8b/81/98" # Base 05 - White
+base16_color08="bf/b9/c6" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="58/50/62" # Base 07 - Bright White
+base16_color16="EB/B7/90" # Base 09
+base16_color17="BA/A5/8C" # Base 0F
+base16_color18="f2/f1/f4" # Base 01
+base16_color19="d8/d5/dd" # Base 02
+base16_color20="a5/9d/af" # Base 04
+base16_color21="72/67/7E" # Base 06
+base16_color_foreground="8b/81/98" # Base 05
+base16_color_background="fb/f1/f2" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 8b8198 # cursor
   put_template_custom Pm fbf1f2 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-cupcake.sh
+++ b/scripts/base16-cupcake.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Cupcake scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="fb/f1/f2" # Base 00 - Black
-base16_color01="D5/7E/85" # Base 08 - Red
-base16_color02="A3/B3/67" # Base 0B - Green
-base16_color03="DC/B1/6C" # Base 0A - Yellow
-base16_color04="72/97/B9" # Base 0D - Blue
-base16_color05="BB/99/B4" # Base 0E - Magenta
-base16_color06="69/A9/A7" # Base 0C - Cyan
-base16_color07="8b/81/98" # Base 05 - White
-base16_color08="bf/b9/c6" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="58/50/62" # Base 07 - Bright White
-base16_color16="EB/B7/90" # Base 09
-base16_color17="BA/A5/8C" # Base 0F
-base16_color18="f2/f1/f4" # Base 01
-base16_color19="d8/d5/dd" # Base 02
-base16_color20="a5/9d/af" # Base 04
-base16_color21="72/67/7E" # Base 06
-base16_color_foreground="8b/81/98" # Base 05
-base16_color_background="fb/f1/f2" # Base 00
+export base16_color00="fb/f1/f2" # Base 00 - Black
+export base16_color01="D5/7E/85" # Base 08 - Red
+export base16_color02="A3/B3/67" # Base 0B - Green
+export base16_color03="DC/B1/6C" # Base 0A - Yellow
+export base16_color04="72/97/B9" # Base 0D - Blue
+export base16_color05="BB/99/B4" # Base 0E - Magenta
+export base16_color06="69/A9/A7" # Base 0C - Cyan
+export base16_color07="8b/81/98" # Base 05 - White
+export base16_color08="bf/b9/c6" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="58/50/62" # Base 07 - Bright White
+export base16_color16="EB/B7/90" # Base 09
+export base16_color17="BA/A5/8C" # Base 0F
+export base16_color18="f2/f1/f4" # Base 01
+export base16_color19="d8/d5/dd" # Base 02
+export base16_color20="a5/9d/af" # Base 04
+export base16_color21="72/67/7E" # Base 06
+export base16_color_foreground="8b/81/98" # Base 05
+export base16_color_background="fb/f1/f2" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-cupertino.sh
+++ b/scripts/base16-cupertino.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Cupertino scheme by Defman21
 
-color00="ff/ff/ff" # Base 00 - Black
-color01="c4/1a/15" # Base 08 - Red
-color02="00/74/00" # Base 0B - Green
-color03="82/6b/28" # Base 0A - Yellow
-color04="00/00/ff" # Base 0D - Blue
-color05="a9/0d/91" # Base 0E - Magenta
-color06="31/84/95" # Base 0C - Cyan
-color07="40/40/40" # Base 05 - White
-color08="80/80/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="5e/5e/5e" # Base 07 - Bright White
-color16="eb/85/00" # Base 09
-color17="82/6b/28" # Base 0F
-color18="c0/c0/c0" # Base 01
-color19="c0/c0/c0" # Base 02
-color20="80/80/80" # Base 04
-color21="40/40/40" # Base 06
-color_foreground="40/40/40" # Base 05
-color_background="ff/ff/ff" # Base 00
+base16_color00="ff/ff/ff" # Base 00 - Black
+base16_color01="c4/1a/15" # Base 08 - Red
+base16_color02="00/74/00" # Base 0B - Green
+base16_color03="82/6b/28" # Base 0A - Yellow
+base16_color04="00/00/ff" # Base 0D - Blue
+base16_color05="a9/0d/91" # Base 0E - Magenta
+base16_color06="31/84/95" # Base 0C - Cyan
+base16_color07="40/40/40" # Base 05 - White
+base16_color08="80/80/80" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="5e/5e/5e" # Base 07 - Bright White
+base16_color16="eb/85/00" # Base 09
+base16_color17="82/6b/28" # Base 0F
+base16_color18="c0/c0/c0" # Base 01
+base16_color19="c0/c0/c0" # Base 02
+base16_color20="80/80/80" # Base 04
+base16_color21="40/40/40" # Base 06
+base16_color_foreground="40/40/40" # Base 05
+base16_color_background="ff/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 404040 # cursor
   put_template_custom Pm ffffff # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-cupertino.sh
+++ b/scripts/base16-cupertino.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Cupertino scheme by Defman21
 
-base16_color00="ff/ff/ff" # Base 00 - Black
-base16_color01="c4/1a/15" # Base 08 - Red
-base16_color02="00/74/00" # Base 0B - Green
-base16_color03="82/6b/28" # Base 0A - Yellow
-base16_color04="00/00/ff" # Base 0D - Blue
-base16_color05="a9/0d/91" # Base 0E - Magenta
-base16_color06="31/84/95" # Base 0C - Cyan
-base16_color07="40/40/40" # Base 05 - White
-base16_color08="80/80/80" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="5e/5e/5e" # Base 07 - Bright White
-base16_color16="eb/85/00" # Base 09
-base16_color17="82/6b/28" # Base 0F
-base16_color18="c0/c0/c0" # Base 01
-base16_color19="c0/c0/c0" # Base 02
-base16_color20="80/80/80" # Base 04
-base16_color21="40/40/40" # Base 06
-base16_color_foreground="40/40/40" # Base 05
-base16_color_background="ff/ff/ff" # Base 00
+export base16_color00="ff/ff/ff" # Base 00 - Black
+export base16_color01="c4/1a/15" # Base 08 - Red
+export base16_color02="00/74/00" # Base 0B - Green
+export base16_color03="82/6b/28" # Base 0A - Yellow
+export base16_color04="00/00/ff" # Base 0D - Blue
+export base16_color05="a9/0d/91" # Base 0E - Magenta
+export base16_color06="31/84/95" # Base 0C - Cyan
+export base16_color07="40/40/40" # Base 05 - White
+export base16_color08="80/80/80" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="5e/5e/5e" # Base 07 - Bright White
+export base16_color16="eb/85/00" # Base 09
+export base16_color17="82/6b/28" # Base 0F
+export base16_color18="c0/c0/c0" # Base 01
+export base16_color19="c0/c0/c0" # Base 02
+export base16_color20="80/80/80" # Base 04
+export base16_color21="40/40/40" # Base 06
+export base16_color_foreground="40/40/40" # Base 05
+export base16_color_background="ff/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-darktooth.sh
+++ b/scripts/base16-darktooth.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Darktooth scheme by Jason Milkins (https://github.com/jasonm23)
 
-base16_color00="1D/20/21" # Base 00 - Black
-base16_color01="FB/54/3F" # Base 08 - Red
-base16_color02="95/C0/85" # Base 0B - Green
-base16_color03="FA/C0/3B" # Base 0A - Yellow
-base16_color04="0D/66/78" # Base 0D - Blue
-base16_color05="8F/46/73" # Base 0E - Magenta
-base16_color06="8B/A5/9B" # Base 0C - Cyan
-base16_color07="A8/99/84" # Base 05 - White
-base16_color08="66/5C/54" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="FD/F4/C1" # Base 07 - Bright White
-base16_color16="FE/86/25" # Base 09
-base16_color17="A8/73/22" # Base 0F
-base16_color18="32/30/2F" # Base 01
-base16_color19="50/49/45" # Base 02
-base16_color20="92/83/74" # Base 04
-base16_color21="D5/C4/A1" # Base 06
-base16_color_foreground="A8/99/84" # Base 05
-base16_color_background="1D/20/21" # Base 00
+export base16_color00="1D/20/21" # Base 00 - Black
+export base16_color01="FB/54/3F" # Base 08 - Red
+export base16_color02="95/C0/85" # Base 0B - Green
+export base16_color03="FA/C0/3B" # Base 0A - Yellow
+export base16_color04="0D/66/78" # Base 0D - Blue
+export base16_color05="8F/46/73" # Base 0E - Magenta
+export base16_color06="8B/A5/9B" # Base 0C - Cyan
+export base16_color07="A8/99/84" # Base 05 - White
+export base16_color08="66/5C/54" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="FD/F4/C1" # Base 07 - Bright White
+export base16_color16="FE/86/25" # Base 09
+export base16_color17="A8/73/22" # Base 0F
+export base16_color18="32/30/2F" # Base 01
+export base16_color19="50/49/45" # Base 02
+export base16_color20="92/83/74" # Base 04
+export base16_color21="D5/C4/A1" # Base 06
+export base16_color_foreground="A8/99/84" # Base 05
+export base16_color_background="1D/20/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-darktooth.sh
+++ b/scripts/base16-darktooth.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Darktooth scheme by Jason Milkins (https://github.com/jasonm23)
 
-color00="1D/20/21" # Base 00 - Black
-color01="FB/54/3F" # Base 08 - Red
-color02="95/C0/85" # Base 0B - Green
-color03="FA/C0/3B" # Base 0A - Yellow
-color04="0D/66/78" # Base 0D - Blue
-color05="8F/46/73" # Base 0E - Magenta
-color06="8B/A5/9B" # Base 0C - Cyan
-color07="A8/99/84" # Base 05 - White
-color08="66/5C/54" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FD/F4/C1" # Base 07 - Bright White
-color16="FE/86/25" # Base 09
-color17="A8/73/22" # Base 0F
-color18="32/30/2F" # Base 01
-color19="50/49/45" # Base 02
-color20="92/83/74" # Base 04
-color21="D5/C4/A1" # Base 06
-color_foreground="A8/99/84" # Base 05
-color_background="1D/20/21" # Base 00
+base16_color00="1D/20/21" # Base 00 - Black
+base16_color01="FB/54/3F" # Base 08 - Red
+base16_color02="95/C0/85" # Base 0B - Green
+base16_color03="FA/C0/3B" # Base 0A - Yellow
+base16_color04="0D/66/78" # Base 0D - Blue
+base16_color05="8F/46/73" # Base 0E - Magenta
+base16_color06="8B/A5/9B" # Base 0C - Cyan
+base16_color07="A8/99/84" # Base 05 - White
+base16_color08="66/5C/54" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="FD/F4/C1" # Base 07 - Bright White
+base16_color16="FE/86/25" # Base 09
+base16_color17="A8/73/22" # Base 0F
+base16_color18="32/30/2F" # Base 01
+base16_color19="50/49/45" # Base 02
+base16_color20="92/83/74" # Base 04
+base16_color21="D5/C4/A1" # Base 06
+base16_color_foreground="A8/99/84" # Base 05
+base16_color_background="1D/20/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl A89984 # cursor
   put_template_custom Pm 1D2021 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-default-dark.sh
+++ b/scripts/base16-default-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Default Dark scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="18/18/18" # Base 00 - Black
-base16_color01="ab/46/42" # Base 08 - Red
-base16_color02="a1/b5/6c" # Base 0B - Green
-base16_color03="f7/ca/88" # Base 0A - Yellow
-base16_color04="7c/af/c2" # Base 0D - Blue
-base16_color05="ba/8b/af" # Base 0E - Magenta
-base16_color06="86/c1/b9" # Base 0C - Cyan
-base16_color07="d8/d8/d8" # Base 05 - White
-base16_color08="58/58/58" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f8/f8/f8" # Base 07 - Bright White
-base16_color16="dc/96/56" # Base 09
-base16_color17="a1/69/46" # Base 0F
-base16_color18="28/28/28" # Base 01
-base16_color19="38/38/38" # Base 02
-base16_color20="b8/b8/b8" # Base 04
-base16_color21="e8/e8/e8" # Base 06
-base16_color_foreground="d8/d8/d8" # Base 05
-base16_color_background="18/18/18" # Base 00
+export base16_color00="18/18/18" # Base 00 - Black
+export base16_color01="ab/46/42" # Base 08 - Red
+export base16_color02="a1/b5/6c" # Base 0B - Green
+export base16_color03="f7/ca/88" # Base 0A - Yellow
+export base16_color04="7c/af/c2" # Base 0D - Blue
+export base16_color05="ba/8b/af" # Base 0E - Magenta
+export base16_color06="86/c1/b9" # Base 0C - Cyan
+export base16_color07="d8/d8/d8" # Base 05 - White
+export base16_color08="58/58/58" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f8/f8/f8" # Base 07 - Bright White
+export base16_color16="dc/96/56" # Base 09
+export base16_color17="a1/69/46" # Base 0F
+export base16_color18="28/28/28" # Base 01
+export base16_color19="38/38/38" # Base 02
+export base16_color20="b8/b8/b8" # Base 04
+export base16_color21="e8/e8/e8" # Base 06
+export base16_color_foreground="d8/d8/d8" # Base 05
+export base16_color_background="18/18/18" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-default-dark.sh
+++ b/scripts/base16-default-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Default Dark scheme by Chris Kempson (http://chriskempson.com)
 
-color00="18/18/18" # Base 00 - Black
-color01="ab/46/42" # Base 08 - Red
-color02="a1/b5/6c" # Base 0B - Green
-color03="f7/ca/88" # Base 0A - Yellow
-color04="7c/af/c2" # Base 0D - Blue
-color05="ba/8b/af" # Base 0E - Magenta
-color06="86/c1/b9" # Base 0C - Cyan
-color07="d8/d8/d8" # Base 05 - White
-color08="58/58/58" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/f8/f8" # Base 07 - Bright White
-color16="dc/96/56" # Base 09
-color17="a1/69/46" # Base 0F
-color18="28/28/28" # Base 01
-color19="38/38/38" # Base 02
-color20="b8/b8/b8" # Base 04
-color21="e8/e8/e8" # Base 06
-color_foreground="d8/d8/d8" # Base 05
-color_background="18/18/18" # Base 00
+base16_color00="18/18/18" # Base 00 - Black
+base16_color01="ab/46/42" # Base 08 - Red
+base16_color02="a1/b5/6c" # Base 0B - Green
+base16_color03="f7/ca/88" # Base 0A - Yellow
+base16_color04="7c/af/c2" # Base 0D - Blue
+base16_color05="ba/8b/af" # Base 0E - Magenta
+base16_color06="86/c1/b9" # Base 0C - Cyan
+base16_color07="d8/d8/d8" # Base 05 - White
+base16_color08="58/58/58" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f8/f8/f8" # Base 07 - Bright White
+base16_color16="dc/96/56" # Base 09
+base16_color17="a1/69/46" # Base 0F
+base16_color18="28/28/28" # Base 01
+base16_color19="38/38/38" # Base 02
+base16_color20="b8/b8/b8" # Base 04
+base16_color21="e8/e8/e8" # Base 06
+base16_color_foreground="d8/d8/d8" # Base 05
+base16_color_background="18/18/18" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d8d8d8 # cursor
   put_template_custom Pm 181818 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-default-light.sh
+++ b/scripts/base16-default-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Default Light scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="f8/f8/f8" # Base 00 - Black
-base16_color01="ab/46/42" # Base 08 - Red
-base16_color02="a1/b5/6c" # Base 0B - Green
-base16_color03="f7/ca/88" # Base 0A - Yellow
-base16_color04="7c/af/c2" # Base 0D - Blue
-base16_color05="ba/8b/af" # Base 0E - Magenta
-base16_color06="86/c1/b9" # Base 0C - Cyan
-base16_color07="38/38/38" # Base 05 - White
-base16_color08="b8/b8/b8" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="18/18/18" # Base 07 - Bright White
-base16_color16="dc/96/56" # Base 09
-base16_color17="a1/69/46" # Base 0F
-base16_color18="e8/e8/e8" # Base 01
-base16_color19="d8/d8/d8" # Base 02
-base16_color20="58/58/58" # Base 04
-base16_color21="28/28/28" # Base 06
-base16_color_foreground="38/38/38" # Base 05
-base16_color_background="f8/f8/f8" # Base 00
+export base16_color00="f8/f8/f8" # Base 00 - Black
+export base16_color01="ab/46/42" # Base 08 - Red
+export base16_color02="a1/b5/6c" # Base 0B - Green
+export base16_color03="f7/ca/88" # Base 0A - Yellow
+export base16_color04="7c/af/c2" # Base 0D - Blue
+export base16_color05="ba/8b/af" # Base 0E - Magenta
+export base16_color06="86/c1/b9" # Base 0C - Cyan
+export base16_color07="38/38/38" # Base 05 - White
+export base16_color08="b8/b8/b8" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="18/18/18" # Base 07 - Bright White
+export base16_color16="dc/96/56" # Base 09
+export base16_color17="a1/69/46" # Base 0F
+export base16_color18="e8/e8/e8" # Base 01
+export base16_color19="d8/d8/d8" # Base 02
+export base16_color20="58/58/58" # Base 04
+export base16_color21="28/28/28" # Base 06
+export base16_color_foreground="38/38/38" # Base 05
+export base16_color_background="f8/f8/f8" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-default-light.sh
+++ b/scripts/base16-default-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Default Light scheme by Chris Kempson (http://chriskempson.com)
 
-color00="f8/f8/f8" # Base 00 - Black
-color01="ab/46/42" # Base 08 - Red
-color02="a1/b5/6c" # Base 0B - Green
-color03="f7/ca/88" # Base 0A - Yellow
-color04="7c/af/c2" # Base 0D - Blue
-color05="ba/8b/af" # Base 0E - Magenta
-color06="86/c1/b9" # Base 0C - Cyan
-color07="38/38/38" # Base 05 - White
-color08="b8/b8/b8" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="18/18/18" # Base 07 - Bright White
-color16="dc/96/56" # Base 09
-color17="a1/69/46" # Base 0F
-color18="e8/e8/e8" # Base 01
-color19="d8/d8/d8" # Base 02
-color20="58/58/58" # Base 04
-color21="28/28/28" # Base 06
-color_foreground="38/38/38" # Base 05
-color_background="f8/f8/f8" # Base 00
+base16_color00="f8/f8/f8" # Base 00 - Black
+base16_color01="ab/46/42" # Base 08 - Red
+base16_color02="a1/b5/6c" # Base 0B - Green
+base16_color03="f7/ca/88" # Base 0A - Yellow
+base16_color04="7c/af/c2" # Base 0D - Blue
+base16_color05="ba/8b/af" # Base 0E - Magenta
+base16_color06="86/c1/b9" # Base 0C - Cyan
+base16_color07="38/38/38" # Base 05 - White
+base16_color08="b8/b8/b8" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="18/18/18" # Base 07 - Bright White
+base16_color16="dc/96/56" # Base 09
+base16_color17="a1/69/46" # Base 0F
+base16_color18="e8/e8/e8" # Base 01
+base16_color19="d8/d8/d8" # Base 02
+base16_color20="58/58/58" # Base 04
+base16_color21="28/28/28" # Base 06
+base16_color_foreground="38/38/38" # Base 05
+base16_color_background="f8/f8/f8" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 383838 # cursor
   put_template_custom Pm f8f8f8 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-dracula.sh
+++ b/scripts/base16-dracula.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Dracula scheme by Mike Barkmin (http://github.com/mikebarkmin) based on Dracula Theme (http://github.com/dracula)
 
-color00="28/29/36" # Base 00 - Black
-color01="ea/51/b2" # Base 08 - Red
-color02="eb/ff/87" # Base 0B - Green
-color03="00/f7/69" # Base 0A - Yellow
-color04="62/d6/e8" # Base 0D - Blue
-color05="b4/5b/cf" # Base 0E - Magenta
-color06="a1/ef/e4" # Base 0C - Cyan
-color07="e9/e9/f4" # Base 05 - White
-color08="62/64/83" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f7/fb" # Base 07 - Bright White
-color16="b4/5b/cf" # Base 09
-color17="00/f7/69" # Base 0F
-color18="3a/3c/4e" # Base 01
-color19="4d/4f/68" # Base 02
-color20="62/d6/e8" # Base 04
-color21="f1/f2/f8" # Base 06
-color_foreground="e9/e9/f4" # Base 05
-color_background="28/29/36" # Base 00
+base16_color00="28/29/36" # Base 00 - Black
+base16_color01="ea/51/b2" # Base 08 - Red
+base16_color02="eb/ff/87" # Base 0B - Green
+base16_color03="00/f7/69" # Base 0A - Yellow
+base16_color04="62/d6/e8" # Base 0D - Blue
+base16_color05="b4/5b/cf" # Base 0E - Magenta
+base16_color06="a1/ef/e4" # Base 0C - Cyan
+base16_color07="e9/e9/f4" # Base 05 - White
+base16_color08="62/64/83" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f7/f7/fb" # Base 07 - Bright White
+base16_color16="b4/5b/cf" # Base 09
+base16_color17="00/f7/69" # Base 0F
+base16_color18="3a/3c/4e" # Base 01
+base16_color19="4d/4f/68" # Base 02
+base16_color20="62/d6/e8" # Base 04
+base16_color21="f1/f2/f8" # Base 06
+base16_color_foreground="e9/e9/f4" # Base 05
+base16_color_background="28/29/36" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl e9e9f4 # cursor
   put_template_custom Pm 282936 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-dracula.sh
+++ b/scripts/base16-dracula.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Dracula scheme by Mike Barkmin (http://github.com/mikebarkmin) based on Dracula Theme (http://github.com/dracula)
 
-base16_color00="28/29/36" # Base 00 - Black
-base16_color01="ea/51/b2" # Base 08 - Red
-base16_color02="eb/ff/87" # Base 0B - Green
-base16_color03="00/f7/69" # Base 0A - Yellow
-base16_color04="62/d6/e8" # Base 0D - Blue
-base16_color05="b4/5b/cf" # Base 0E - Magenta
-base16_color06="a1/ef/e4" # Base 0C - Cyan
-base16_color07="e9/e9/f4" # Base 05 - White
-base16_color08="62/64/83" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f7/f7/fb" # Base 07 - Bright White
-base16_color16="b4/5b/cf" # Base 09
-base16_color17="00/f7/69" # Base 0F
-base16_color18="3a/3c/4e" # Base 01
-base16_color19="4d/4f/68" # Base 02
-base16_color20="62/d6/e8" # Base 04
-base16_color21="f1/f2/f8" # Base 06
-base16_color_foreground="e9/e9/f4" # Base 05
-base16_color_background="28/29/36" # Base 00
+export base16_color00="28/29/36" # Base 00 - Black
+export base16_color01="ea/51/b2" # Base 08 - Red
+export base16_color02="eb/ff/87" # Base 0B - Green
+export base16_color03="00/f7/69" # Base 0A - Yellow
+export base16_color04="62/d6/e8" # Base 0D - Blue
+export base16_color05="b4/5b/cf" # Base 0E - Magenta
+export base16_color06="a1/ef/e4" # Base 0C - Cyan
+export base16_color07="e9/e9/f4" # Base 05 - White
+export base16_color08="62/64/83" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f7/f7/fb" # Base 07 - Bright White
+export base16_color16="b4/5b/cf" # Base 09
+export base16_color17="00/f7/69" # Base 0F
+export base16_color18="3a/3c/4e" # Base 01
+export base16_color19="4d/4f/68" # Base 02
+export base16_color20="62/d6/e8" # Base 04
+export base16_color21="f1/f2/f8" # Base 06
+export base16_color_foreground="e9/e9/f4" # Base 05
+export base16_color_background="28/29/36" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-eighties.sh
+++ b/scripts/base16-eighties.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Eighties scheme by Chris Kempson (http://chriskempson.com)
 
-color00="2d/2d/2d" # Base 00 - Black
-color01="f2/77/7a" # Base 08 - Red
-color02="99/cc/99" # Base 0B - Green
-color03="ff/cc/66" # Base 0A - Yellow
-color04="66/99/cc" # Base 0D - Blue
-color05="cc/99/cc" # Base 0E - Magenta
-color06="66/cc/cc" # Base 0C - Cyan
-color07="d3/d0/c8" # Base 05 - White
-color08="74/73/69" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f2/f0/ec" # Base 07 - Bright White
-color16="f9/91/57" # Base 09
-color17="d2/7b/53" # Base 0F
-color18="39/39/39" # Base 01
-color19="51/51/51" # Base 02
-color20="a0/9f/93" # Base 04
-color21="e8/e6/df" # Base 06
-color_foreground="d3/d0/c8" # Base 05
-color_background="2d/2d/2d" # Base 00
+base16_color00="2d/2d/2d" # Base 00 - Black
+base16_color01="f2/77/7a" # Base 08 - Red
+base16_color02="99/cc/99" # Base 0B - Green
+base16_color03="ff/cc/66" # Base 0A - Yellow
+base16_color04="66/99/cc" # Base 0D - Blue
+base16_color05="cc/99/cc" # Base 0E - Magenta
+base16_color06="66/cc/cc" # Base 0C - Cyan
+base16_color07="d3/d0/c8" # Base 05 - White
+base16_color08="74/73/69" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f2/f0/ec" # Base 07 - Bright White
+base16_color16="f9/91/57" # Base 09
+base16_color17="d2/7b/53" # Base 0F
+base16_color18="39/39/39" # Base 01
+base16_color19="51/51/51" # Base 02
+base16_color20="a0/9f/93" # Base 04
+base16_color21="e8/e6/df" # Base 06
+base16_color_foreground="d3/d0/c8" # Base 05
+base16_color_background="2d/2d/2d" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d3d0c8 # cursor
   put_template_custom Pm 2d2d2d # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-eighties.sh
+++ b/scripts/base16-eighties.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Eighties scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="2d/2d/2d" # Base 00 - Black
-base16_color01="f2/77/7a" # Base 08 - Red
-base16_color02="99/cc/99" # Base 0B - Green
-base16_color03="ff/cc/66" # Base 0A - Yellow
-base16_color04="66/99/cc" # Base 0D - Blue
-base16_color05="cc/99/cc" # Base 0E - Magenta
-base16_color06="66/cc/cc" # Base 0C - Cyan
-base16_color07="d3/d0/c8" # Base 05 - White
-base16_color08="74/73/69" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f2/f0/ec" # Base 07 - Bright White
-base16_color16="f9/91/57" # Base 09
-base16_color17="d2/7b/53" # Base 0F
-base16_color18="39/39/39" # Base 01
-base16_color19="51/51/51" # Base 02
-base16_color20="a0/9f/93" # Base 04
-base16_color21="e8/e6/df" # Base 06
-base16_color_foreground="d3/d0/c8" # Base 05
-base16_color_background="2d/2d/2d" # Base 00
+export base16_color00="2d/2d/2d" # Base 00 - Black
+export base16_color01="f2/77/7a" # Base 08 - Red
+export base16_color02="99/cc/99" # Base 0B - Green
+export base16_color03="ff/cc/66" # Base 0A - Yellow
+export base16_color04="66/99/cc" # Base 0D - Blue
+export base16_color05="cc/99/cc" # Base 0E - Magenta
+export base16_color06="66/cc/cc" # Base 0C - Cyan
+export base16_color07="d3/d0/c8" # Base 05 - White
+export base16_color08="74/73/69" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f2/f0/ec" # Base 07 - Bright White
+export base16_color16="f9/91/57" # Base 09
+export base16_color17="d2/7b/53" # Base 0F
+export base16_color18="39/39/39" # Base 01
+export base16_color19="51/51/51" # Base 02
+export base16_color20="a0/9f/93" # Base 04
+export base16_color21="e8/e6/df" # Base 06
+export base16_color_foreground="d3/d0/c8" # Base 05
+export base16_color_background="2d/2d/2d" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-embers.sh
+++ b/scripts/base16-embers.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Embers scheme by Jannik Siebert (https://github.com/janniks)
 
-base16_color00="16/13/0F" # Base 00 - Black
-base16_color01="82/6D/57" # Base 08 - Red
-base16_color02="57/82/6D" # Base 0B - Green
-base16_color03="6D/82/57" # Base 0A - Yellow
-base16_color04="6D/57/82" # Base 0D - Blue
-base16_color05="82/57/6D" # Base 0E - Magenta
-base16_color06="57/6D/82" # Base 0C - Cyan
-base16_color07="A3/9A/90" # Base 05 - White
-base16_color08="5A/50/47" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="DB/D6/D1" # Base 07 - Bright White
-base16_color16="82/82/57" # Base 09
-base16_color17="82/57/57" # Base 0F
-base16_color18="2C/26/20" # Base 01
-base16_color19="43/3B/32" # Base 02
-base16_color20="8A/80/75" # Base 04
-base16_color21="BE/B6/AE" # Base 06
-base16_color_foreground="A3/9A/90" # Base 05
-base16_color_background="16/13/0F" # Base 00
+export base16_color00="16/13/0F" # Base 00 - Black
+export base16_color01="82/6D/57" # Base 08 - Red
+export base16_color02="57/82/6D" # Base 0B - Green
+export base16_color03="6D/82/57" # Base 0A - Yellow
+export base16_color04="6D/57/82" # Base 0D - Blue
+export base16_color05="82/57/6D" # Base 0E - Magenta
+export base16_color06="57/6D/82" # Base 0C - Cyan
+export base16_color07="A3/9A/90" # Base 05 - White
+export base16_color08="5A/50/47" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="DB/D6/D1" # Base 07 - Bright White
+export base16_color16="82/82/57" # Base 09
+export base16_color17="82/57/57" # Base 0F
+export base16_color18="2C/26/20" # Base 01
+export base16_color19="43/3B/32" # Base 02
+export base16_color20="8A/80/75" # Base 04
+export base16_color21="BE/B6/AE" # Base 06
+export base16_color_foreground="A3/9A/90" # Base 05
+export base16_color_background="16/13/0F" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-embers.sh
+++ b/scripts/base16-embers.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Embers scheme by Jannik Siebert (https://github.com/janniks)
 
-color00="16/13/0F" # Base 00 - Black
-color01="82/6D/57" # Base 08 - Red
-color02="57/82/6D" # Base 0B - Green
-color03="6D/82/57" # Base 0A - Yellow
-color04="6D/57/82" # Base 0D - Blue
-color05="82/57/6D" # Base 0E - Magenta
-color06="57/6D/82" # Base 0C - Cyan
-color07="A3/9A/90" # Base 05 - White
-color08="5A/50/47" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="DB/D6/D1" # Base 07 - Bright White
-color16="82/82/57" # Base 09
-color17="82/57/57" # Base 0F
-color18="2C/26/20" # Base 01
-color19="43/3B/32" # Base 02
-color20="8A/80/75" # Base 04
-color21="BE/B6/AE" # Base 06
-color_foreground="A3/9A/90" # Base 05
-color_background="16/13/0F" # Base 00
+base16_color00="16/13/0F" # Base 00 - Black
+base16_color01="82/6D/57" # Base 08 - Red
+base16_color02="57/82/6D" # Base 0B - Green
+base16_color03="6D/82/57" # Base 0A - Yellow
+base16_color04="6D/57/82" # Base 0D - Blue
+base16_color05="82/57/6D" # Base 0E - Magenta
+base16_color06="57/6D/82" # Base 0C - Cyan
+base16_color07="A3/9A/90" # Base 05 - White
+base16_color08="5A/50/47" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="DB/D6/D1" # Base 07 - Bright White
+base16_color16="82/82/57" # Base 09
+base16_color17="82/57/57" # Base 0F
+base16_color18="2C/26/20" # Base 01
+base16_color19="43/3B/32" # Base 02
+base16_color20="8A/80/75" # Base 04
+base16_color21="BE/B6/AE" # Base 06
+base16_color_foreground="A3/9A/90" # Base 05
+base16_color_background="16/13/0F" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl A39A90 # cursor
   put_template_custom Pm 16130F # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-flat.sh
+++ b/scripts/base16-flat.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Flat scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="2C/3E/50" # Base 00 - Black
-base16_color01="E7/4C/3C" # Base 08 - Red
-base16_color02="2E/CC/71" # Base 0B - Green
-base16_color03="F1/C4/0F" # Base 0A - Yellow
-base16_color04="34/98/DB" # Base 0D - Blue
-base16_color05="9B/59/B6" # Base 0E - Magenta
-base16_color06="1A/BC/9C" # Base 0C - Cyan
-base16_color07="e0/e0/e0" # Base 05 - White
-base16_color08="95/A5/A6" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="EC/F0/F1" # Base 07 - Bright White
-base16_color16="E6/7E/22" # Base 09
-base16_color17="be/64/3c" # Base 0F
-base16_color18="34/49/5E" # Base 01
-base16_color19="7F/8C/8D" # Base 02
-base16_color20="BD/C3/C7" # Base 04
-base16_color21="f5/f5/f5" # Base 06
-base16_color_foreground="e0/e0/e0" # Base 05
-base16_color_background="2C/3E/50" # Base 00
+export base16_color00="2C/3E/50" # Base 00 - Black
+export base16_color01="E7/4C/3C" # Base 08 - Red
+export base16_color02="2E/CC/71" # Base 0B - Green
+export base16_color03="F1/C4/0F" # Base 0A - Yellow
+export base16_color04="34/98/DB" # Base 0D - Blue
+export base16_color05="9B/59/B6" # Base 0E - Magenta
+export base16_color06="1A/BC/9C" # Base 0C - Cyan
+export base16_color07="e0/e0/e0" # Base 05 - White
+export base16_color08="95/A5/A6" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="EC/F0/F1" # Base 07 - Bright White
+export base16_color16="E6/7E/22" # Base 09
+export base16_color17="be/64/3c" # Base 0F
+export base16_color18="34/49/5E" # Base 01
+export base16_color19="7F/8C/8D" # Base 02
+export base16_color20="BD/C3/C7" # Base 04
+export base16_color21="f5/f5/f5" # Base 06
+export base16_color_foreground="e0/e0/e0" # Base 05
+export base16_color_background="2C/3E/50" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-flat.sh
+++ b/scripts/base16-flat.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Flat scheme by Chris Kempson (http://chriskempson.com)
 
-color00="2C/3E/50" # Base 00 - Black
-color01="E7/4C/3C" # Base 08 - Red
-color02="2E/CC/71" # Base 0B - Green
-color03="F1/C4/0F" # Base 0A - Yellow
-color04="34/98/DB" # Base 0D - Blue
-color05="9B/59/B6" # Base 0E - Magenta
-color06="1A/BC/9C" # Base 0C - Cyan
-color07="e0/e0/e0" # Base 05 - White
-color08="95/A5/A6" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="EC/F0/F1" # Base 07 - Bright White
-color16="E6/7E/22" # Base 09
-color17="be/64/3c" # Base 0F
-color18="34/49/5E" # Base 01
-color19="7F/8C/8D" # Base 02
-color20="BD/C3/C7" # Base 04
-color21="f5/f5/f5" # Base 06
-color_foreground="e0/e0/e0" # Base 05
-color_background="2C/3E/50" # Base 00
+base16_color00="2C/3E/50" # Base 00 - Black
+base16_color01="E7/4C/3C" # Base 08 - Red
+base16_color02="2E/CC/71" # Base 0B - Green
+base16_color03="F1/C4/0F" # Base 0A - Yellow
+base16_color04="34/98/DB" # Base 0D - Blue
+base16_color05="9B/59/B6" # Base 0E - Magenta
+base16_color06="1A/BC/9C" # Base 0C - Cyan
+base16_color07="e0/e0/e0" # Base 05 - White
+base16_color08="95/A5/A6" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="EC/F0/F1" # Base 07 - Bright White
+base16_color16="E6/7E/22" # Base 09
+base16_color17="be/64/3c" # Base 0F
+base16_color18="34/49/5E" # Base 01
+base16_color19="7F/8C/8D" # Base 02
+base16_color20="BD/C3/C7" # Base 04
+base16_color21="f5/f5/f5" # Base 06
+base16_color_foreground="e0/e0/e0" # Base 05
+base16_color_background="2C/3E/50" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl e0e0e0 # cursor
   put_template_custom Pm 2C3E50 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-fruit-soda.sh
+++ b/scripts/base16-fruit-soda.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Fruit Soda scheme by jozip
 
-color00="f1/ec/f1" # Base 00 - Black
-color01="fe/3e/31" # Base 08 - Red
-color02="47/f7/4c" # Base 0B - Green
-color03="f7/e2/03" # Base 0A - Yellow
-color04="29/31/df" # Base 0D - Blue
-color05="61/1f/ce" # Base 0E - Magenta
-color06="0f/9c/fd" # Base 0C - Cyan
-color07="51/51/51" # Base 05 - White
-color08="b5/b4/b6" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="2d/2c/2c" # Base 07 - Bright White
-color16="fe/6d/08" # Base 09
-color17="b1/6f/40" # Base 0F
-color18="e0/de/e0" # Base 01
-color19="d8/d5/d5" # Base 02
-color20="97/95/98" # Base 04
-color21="47/45/45" # Base 06
-color_foreground="51/51/51" # Base 05
-color_background="f1/ec/f1" # Base 00
+base16_color00="f1/ec/f1" # Base 00 - Black
+base16_color01="fe/3e/31" # Base 08 - Red
+base16_color02="47/f7/4c" # Base 0B - Green
+base16_color03="f7/e2/03" # Base 0A - Yellow
+base16_color04="29/31/df" # Base 0D - Blue
+base16_color05="61/1f/ce" # Base 0E - Magenta
+base16_color06="0f/9c/fd" # Base 0C - Cyan
+base16_color07="51/51/51" # Base 05 - White
+base16_color08="b5/b4/b6" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="2d/2c/2c" # Base 07 - Bright White
+base16_color16="fe/6d/08" # Base 09
+base16_color17="b1/6f/40" # Base 0F
+base16_color18="e0/de/e0" # Base 01
+base16_color19="d8/d5/d5" # Base 02
+base16_color20="97/95/98" # Base 04
+base16_color21="47/45/45" # Base 06
+base16_color_foreground="51/51/51" # Base 05
+base16_color_background="f1/ec/f1" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 515151 # cursor
   put_template_custom Pm f1ecf1 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-fruit-soda.sh
+++ b/scripts/base16-fruit-soda.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Fruit Soda scheme by jozip
 
-base16_color00="f1/ec/f1" # Base 00 - Black
-base16_color01="fe/3e/31" # Base 08 - Red
-base16_color02="47/f7/4c" # Base 0B - Green
-base16_color03="f7/e2/03" # Base 0A - Yellow
-base16_color04="29/31/df" # Base 0D - Blue
-base16_color05="61/1f/ce" # Base 0E - Magenta
-base16_color06="0f/9c/fd" # Base 0C - Cyan
-base16_color07="51/51/51" # Base 05 - White
-base16_color08="b5/b4/b6" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="2d/2c/2c" # Base 07 - Bright White
-base16_color16="fe/6d/08" # Base 09
-base16_color17="b1/6f/40" # Base 0F
-base16_color18="e0/de/e0" # Base 01
-base16_color19="d8/d5/d5" # Base 02
-base16_color20="97/95/98" # Base 04
-base16_color21="47/45/45" # Base 06
-base16_color_foreground="51/51/51" # Base 05
-base16_color_background="f1/ec/f1" # Base 00
+export base16_color00="f1/ec/f1" # Base 00 - Black
+export base16_color01="fe/3e/31" # Base 08 - Red
+export base16_color02="47/f7/4c" # Base 0B - Green
+export base16_color03="f7/e2/03" # Base 0A - Yellow
+export base16_color04="29/31/df" # Base 0D - Blue
+export base16_color05="61/1f/ce" # Base 0E - Magenta
+export base16_color06="0f/9c/fd" # Base 0C - Cyan
+export base16_color07="51/51/51" # Base 05 - White
+export base16_color08="b5/b4/b6" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="2d/2c/2c" # Base 07 - Bright White
+export base16_color16="fe/6d/08" # Base 09
+export base16_color17="b1/6f/40" # Base 0F
+export base16_color18="e0/de/e0" # Base 01
+export base16_color19="d8/d5/d5" # Base 02
+export base16_color20="97/95/98" # Base 04
+export base16_color21="47/45/45" # Base 06
+export base16_color_foreground="51/51/51" # Base 05
+export base16_color_background="f1/ec/f1" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-github.sh
+++ b/scripts/base16-github.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Github scheme by Defman21
 
-color00="ff/ff/ff" # Base 00 - Black
-color01="ed/6a/43" # Base 08 - Red
-color02="18/36/91" # Base 0B - Green
-color03="79/5d/a3" # Base 0A - Yellow
-color04="79/5d/a3" # Base 0D - Blue
-color05="a7/1d/5d" # Base 0E - Magenta
-color06="18/36/91" # Base 0C - Cyan
-color07="33/33/33" # Base 05 - White
-color08="96/98/96" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="00/86/b3" # Base 09
-color17="33/33/33" # Base 0F
-color18="f5/f5/f5" # Base 01
-color19="c8/c8/fa" # Base 02
-color20="e8/e8/e8" # Base 04
-color21="ff/ff/ff" # Base 06
-color_foreground="33/33/33" # Base 05
-color_background="ff/ff/ff" # Base 00
+base16_color00="ff/ff/ff" # Base 00 - Black
+base16_color01="ed/6a/43" # Base 08 - Red
+base16_color02="18/36/91" # Base 0B - Green
+base16_color03="79/5d/a3" # Base 0A - Yellow
+base16_color04="79/5d/a3" # Base 0D - Blue
+base16_color05="a7/1d/5d" # Base 0E - Magenta
+base16_color06="18/36/91" # Base 0C - Cyan
+base16_color07="33/33/33" # Base 05 - White
+base16_color08="96/98/96" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="00/86/b3" # Base 09
+base16_color17="33/33/33" # Base 0F
+base16_color18="f5/f5/f5" # Base 01
+base16_color19="c8/c8/fa" # Base 02
+base16_color20="e8/e8/e8" # Base 04
+base16_color21="ff/ff/ff" # Base 06
+base16_color_foreground="33/33/33" # Base 05
+base16_color_background="ff/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 333333 # cursor
   put_template_custom Pm ffffff # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-github.sh
+++ b/scripts/base16-github.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Github scheme by Defman21
 
-base16_color00="ff/ff/ff" # Base 00 - Black
-base16_color01="ed/6a/43" # Base 08 - Red
-base16_color02="18/36/91" # Base 0B - Green
-base16_color03="79/5d/a3" # Base 0A - Yellow
-base16_color04="79/5d/a3" # Base 0D - Blue
-base16_color05="a7/1d/5d" # Base 0E - Magenta
-base16_color06="18/36/91" # Base 0C - Cyan
-base16_color07="33/33/33" # Base 05 - White
-base16_color08="96/98/96" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="00/86/b3" # Base 09
-base16_color17="33/33/33" # Base 0F
-base16_color18="f5/f5/f5" # Base 01
-base16_color19="c8/c8/fa" # Base 02
-base16_color20="e8/e8/e8" # Base 04
-base16_color21="ff/ff/ff" # Base 06
-base16_color_foreground="33/33/33" # Base 05
-base16_color_background="ff/ff/ff" # Base 00
+export base16_color00="ff/ff/ff" # Base 00 - Black
+export base16_color01="ed/6a/43" # Base 08 - Red
+export base16_color02="18/36/91" # Base 0B - Green
+export base16_color03="79/5d/a3" # Base 0A - Yellow
+export base16_color04="79/5d/a3" # Base 0D - Blue
+export base16_color05="a7/1d/5d" # Base 0E - Magenta
+export base16_color06="18/36/91" # Base 0C - Cyan
+export base16_color07="33/33/33" # Base 05 - White
+export base16_color08="96/98/96" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="00/86/b3" # Base 09
+export base16_color17="33/33/33" # Base 0F
+export base16_color18="f5/f5/f5" # Base 01
+export base16_color19="c8/c8/fa" # Base 02
+export base16_color20="e8/e8/e8" # Base 04
+export base16_color21="ff/ff/ff" # Base 06
+export base16_color_foreground="33/33/33" # Base 05
+export base16_color_background="ff/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-google-dark.sh
+++ b/scripts/base16-google-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Google Dark scheme by Seth Wright (http://sethawright.com)
 
-color00="1d/1f/21" # Base 00 - Black
-color01="CC/34/2B" # Base 08 - Red
-color02="19/88/44" # Base 0B - Green
-color03="FB/A9/22" # Base 0A - Yellow
-color04="39/71/ED" # Base 0D - Blue
-color05="A3/6A/C7" # Base 0E - Magenta
-color06="39/71/ED" # Base 0C - Cyan
-color07="c5/c8/c6" # Base 05 - White
-color08="96/98/96" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="F9/6A/38" # Base 09
-color17="39/71/ED" # Base 0F
-color18="28/2a/2e" # Base 01
-color19="37/3b/41" # Base 02
-color20="b4/b7/b4" # Base 04
-color21="e0/e0/e0" # Base 06
-color_foreground="c5/c8/c6" # Base 05
-color_background="1d/1f/21" # Base 00
+base16_color00="1d/1f/21" # Base 00 - Black
+base16_color01="CC/34/2B" # Base 08 - Red
+base16_color02="19/88/44" # Base 0B - Green
+base16_color03="FB/A9/22" # Base 0A - Yellow
+base16_color04="39/71/ED" # Base 0D - Blue
+base16_color05="A3/6A/C7" # Base 0E - Magenta
+base16_color06="39/71/ED" # Base 0C - Cyan
+base16_color07="c5/c8/c6" # Base 05 - White
+base16_color08="96/98/96" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="F9/6A/38" # Base 09
+base16_color17="39/71/ED" # Base 0F
+base16_color18="28/2a/2e" # Base 01
+base16_color19="37/3b/41" # Base 02
+base16_color20="b4/b7/b4" # Base 04
+base16_color21="e0/e0/e0" # Base 06
+base16_color_foreground="c5/c8/c6" # Base 05
+base16_color_background="1d/1f/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c5c8c6 # cursor
   put_template_custom Pm 1d1f21 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-google-dark.sh
+++ b/scripts/base16-google-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Google Dark scheme by Seth Wright (http://sethawright.com)
 
-base16_color00="1d/1f/21" # Base 00 - Black
-base16_color01="CC/34/2B" # Base 08 - Red
-base16_color02="19/88/44" # Base 0B - Green
-base16_color03="FB/A9/22" # Base 0A - Yellow
-base16_color04="39/71/ED" # Base 0D - Blue
-base16_color05="A3/6A/C7" # Base 0E - Magenta
-base16_color06="39/71/ED" # Base 0C - Cyan
-base16_color07="c5/c8/c6" # Base 05 - White
-base16_color08="96/98/96" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="F9/6A/38" # Base 09
-base16_color17="39/71/ED" # Base 0F
-base16_color18="28/2a/2e" # Base 01
-base16_color19="37/3b/41" # Base 02
-base16_color20="b4/b7/b4" # Base 04
-base16_color21="e0/e0/e0" # Base 06
-base16_color_foreground="c5/c8/c6" # Base 05
-base16_color_background="1d/1f/21" # Base 00
+export base16_color00="1d/1f/21" # Base 00 - Black
+export base16_color01="CC/34/2B" # Base 08 - Red
+export base16_color02="19/88/44" # Base 0B - Green
+export base16_color03="FB/A9/22" # Base 0A - Yellow
+export base16_color04="39/71/ED" # Base 0D - Blue
+export base16_color05="A3/6A/C7" # Base 0E - Magenta
+export base16_color06="39/71/ED" # Base 0C - Cyan
+export base16_color07="c5/c8/c6" # Base 05 - White
+export base16_color08="96/98/96" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="F9/6A/38" # Base 09
+export base16_color17="39/71/ED" # Base 0F
+export base16_color18="28/2a/2e" # Base 01
+export base16_color19="37/3b/41" # Base 02
+export base16_color20="b4/b7/b4" # Base 04
+export base16_color21="e0/e0/e0" # Base 06
+export base16_color_foreground="c5/c8/c6" # Base 05
+export base16_color_background="1d/1f/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-google-light.sh
+++ b/scripts/base16-google-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Google Light scheme by Seth Wright (http://sethawright.com)
 
-color00="ff/ff/ff" # Base 00 - Black
-color01="CC/34/2B" # Base 08 - Red
-color02="19/88/44" # Base 0B - Green
-color03="FB/A9/22" # Base 0A - Yellow
-color04="39/71/ED" # Base 0D - Blue
-color05="A3/6A/C7" # Base 0E - Magenta
-color06="39/71/ED" # Base 0C - Cyan
-color07="37/3b/41" # Base 05 - White
-color08="b4/b7/b4" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="1d/1f/21" # Base 07 - Bright White
-color16="F9/6A/38" # Base 09
-color17="39/71/ED" # Base 0F
-color18="e0/e0/e0" # Base 01
-color19="c5/c8/c6" # Base 02
-color20="96/98/96" # Base 04
-color21="28/2a/2e" # Base 06
-color_foreground="37/3b/41" # Base 05
-color_background="ff/ff/ff" # Base 00
+base16_color00="ff/ff/ff" # Base 00 - Black
+base16_color01="CC/34/2B" # Base 08 - Red
+base16_color02="19/88/44" # Base 0B - Green
+base16_color03="FB/A9/22" # Base 0A - Yellow
+base16_color04="39/71/ED" # Base 0D - Blue
+base16_color05="A3/6A/C7" # Base 0E - Magenta
+base16_color06="39/71/ED" # Base 0C - Cyan
+base16_color07="37/3b/41" # Base 05 - White
+base16_color08="b4/b7/b4" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="1d/1f/21" # Base 07 - Bright White
+base16_color16="F9/6A/38" # Base 09
+base16_color17="39/71/ED" # Base 0F
+base16_color18="e0/e0/e0" # Base 01
+base16_color19="c5/c8/c6" # Base 02
+base16_color20="96/98/96" # Base 04
+base16_color21="28/2a/2e" # Base 06
+base16_color_foreground="37/3b/41" # Base 05
+base16_color_background="ff/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 373b41 # cursor
   put_template_custom Pm ffffff # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-google-light.sh
+++ b/scripts/base16-google-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Google Light scheme by Seth Wright (http://sethawright.com)
 
-base16_color00="ff/ff/ff" # Base 00 - Black
-base16_color01="CC/34/2B" # Base 08 - Red
-base16_color02="19/88/44" # Base 0B - Green
-base16_color03="FB/A9/22" # Base 0A - Yellow
-base16_color04="39/71/ED" # Base 0D - Blue
-base16_color05="A3/6A/C7" # Base 0E - Magenta
-base16_color06="39/71/ED" # Base 0C - Cyan
-base16_color07="37/3b/41" # Base 05 - White
-base16_color08="b4/b7/b4" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="1d/1f/21" # Base 07 - Bright White
-base16_color16="F9/6A/38" # Base 09
-base16_color17="39/71/ED" # Base 0F
-base16_color18="e0/e0/e0" # Base 01
-base16_color19="c5/c8/c6" # Base 02
-base16_color20="96/98/96" # Base 04
-base16_color21="28/2a/2e" # Base 06
-base16_color_foreground="37/3b/41" # Base 05
-base16_color_background="ff/ff/ff" # Base 00
+export base16_color00="ff/ff/ff" # Base 00 - Black
+export base16_color01="CC/34/2B" # Base 08 - Red
+export base16_color02="19/88/44" # Base 0B - Green
+export base16_color03="FB/A9/22" # Base 0A - Yellow
+export base16_color04="39/71/ED" # Base 0D - Blue
+export base16_color05="A3/6A/C7" # Base 0E - Magenta
+export base16_color06="39/71/ED" # Base 0C - Cyan
+export base16_color07="37/3b/41" # Base 05 - White
+export base16_color08="b4/b7/b4" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="1d/1f/21" # Base 07 - Bright White
+export base16_color16="F9/6A/38" # Base 09
+export base16_color17="39/71/ED" # Base 0F
+export base16_color18="e0/e0/e0" # Base 01
+export base16_color19="c5/c8/c6" # Base 02
+export base16_color20="96/98/96" # Base 04
+export base16_color21="28/2a/2e" # Base 06
+export base16_color_foreground="37/3b/41" # Base 05
+export base16_color_background="ff/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-grayscale-dark.sh
+++ b/scripts/base16-grayscale-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Grayscale Dark scheme by Alexandre Gavioli (https://github.com/Alexx2/)
 
-base16_color00="10/10/10" # Base 00 - Black
-base16_color01="7c/7c/7c" # Base 08 - Red
-base16_color02="8e/8e/8e" # Base 0B - Green
-base16_color03="a0/a0/a0" # Base 0A - Yellow
-base16_color04="68/68/68" # Base 0D - Blue
-base16_color05="74/74/74" # Base 0E - Magenta
-base16_color06="86/86/86" # Base 0C - Cyan
-base16_color07="b9/b9/b9" # Base 05 - White
-base16_color08="52/52/52" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f7/f7/f7" # Base 07 - Bright White
-base16_color16="99/99/99" # Base 09
-base16_color17="5e/5e/5e" # Base 0F
-base16_color18="25/25/25" # Base 01
-base16_color19="46/46/46" # Base 02
-base16_color20="ab/ab/ab" # Base 04
-base16_color21="e3/e3/e3" # Base 06
-base16_color_foreground="b9/b9/b9" # Base 05
-base16_color_background="10/10/10" # Base 00
+export base16_color00="10/10/10" # Base 00 - Black
+export base16_color01="7c/7c/7c" # Base 08 - Red
+export base16_color02="8e/8e/8e" # Base 0B - Green
+export base16_color03="a0/a0/a0" # Base 0A - Yellow
+export base16_color04="68/68/68" # Base 0D - Blue
+export base16_color05="74/74/74" # Base 0E - Magenta
+export base16_color06="86/86/86" # Base 0C - Cyan
+export base16_color07="b9/b9/b9" # Base 05 - White
+export base16_color08="52/52/52" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f7/f7/f7" # Base 07 - Bright White
+export base16_color16="99/99/99" # Base 09
+export base16_color17="5e/5e/5e" # Base 0F
+export base16_color18="25/25/25" # Base 01
+export base16_color19="46/46/46" # Base 02
+export base16_color20="ab/ab/ab" # Base 04
+export base16_color21="e3/e3/e3" # Base 06
+export base16_color_foreground="b9/b9/b9" # Base 05
+export base16_color_background="10/10/10" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-grayscale-dark.sh
+++ b/scripts/base16-grayscale-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Grayscale Dark scheme by Alexandre Gavioli (https://github.com/Alexx2/)
 
-color00="10/10/10" # Base 00 - Black
-color01="7c/7c/7c" # Base 08 - Red
-color02="8e/8e/8e" # Base 0B - Green
-color03="a0/a0/a0" # Base 0A - Yellow
-color04="68/68/68" # Base 0D - Blue
-color05="74/74/74" # Base 0E - Magenta
-color06="86/86/86" # Base 0C - Cyan
-color07="b9/b9/b9" # Base 05 - White
-color08="52/52/52" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f7/f7" # Base 07 - Bright White
-color16="99/99/99" # Base 09
-color17="5e/5e/5e" # Base 0F
-color18="25/25/25" # Base 01
-color19="46/46/46" # Base 02
-color20="ab/ab/ab" # Base 04
-color21="e3/e3/e3" # Base 06
-color_foreground="b9/b9/b9" # Base 05
-color_background="10/10/10" # Base 00
+base16_color00="10/10/10" # Base 00 - Black
+base16_color01="7c/7c/7c" # Base 08 - Red
+base16_color02="8e/8e/8e" # Base 0B - Green
+base16_color03="a0/a0/a0" # Base 0A - Yellow
+base16_color04="68/68/68" # Base 0D - Blue
+base16_color05="74/74/74" # Base 0E - Magenta
+base16_color06="86/86/86" # Base 0C - Cyan
+base16_color07="b9/b9/b9" # Base 05 - White
+base16_color08="52/52/52" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f7/f7/f7" # Base 07 - Bright White
+base16_color16="99/99/99" # Base 09
+base16_color17="5e/5e/5e" # Base 0F
+base16_color18="25/25/25" # Base 01
+base16_color19="46/46/46" # Base 02
+base16_color20="ab/ab/ab" # Base 04
+base16_color21="e3/e3/e3" # Base 06
+base16_color_foreground="b9/b9/b9" # Base 05
+base16_color_background="10/10/10" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl b9b9b9 # cursor
   put_template_custom Pm 101010 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-grayscale-light.sh
+++ b/scripts/base16-grayscale-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Grayscale Light scheme by Alexandre Gavioli (https://github.com/Alexx2/)
 
-color00="f7/f7/f7" # Base 00 - Black
-color01="7c/7c/7c" # Base 08 - Red
-color02="8e/8e/8e" # Base 0B - Green
-color03="a0/a0/a0" # Base 0A - Yellow
-color04="68/68/68" # Base 0D - Blue
-color05="74/74/74" # Base 0E - Magenta
-color06="86/86/86" # Base 0C - Cyan
-color07="46/46/46" # Base 05 - White
-color08="ab/ab/ab" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="10/10/10" # Base 07 - Bright White
-color16="99/99/99" # Base 09
-color17="5e/5e/5e" # Base 0F
-color18="e3/e3/e3" # Base 01
-color19="b9/b9/b9" # Base 02
-color20="52/52/52" # Base 04
-color21="25/25/25" # Base 06
-color_foreground="46/46/46" # Base 05
-color_background="f7/f7/f7" # Base 00
+base16_color00="f7/f7/f7" # Base 00 - Black
+base16_color01="7c/7c/7c" # Base 08 - Red
+base16_color02="8e/8e/8e" # Base 0B - Green
+base16_color03="a0/a0/a0" # Base 0A - Yellow
+base16_color04="68/68/68" # Base 0D - Blue
+base16_color05="74/74/74" # Base 0E - Magenta
+base16_color06="86/86/86" # Base 0C - Cyan
+base16_color07="46/46/46" # Base 05 - White
+base16_color08="ab/ab/ab" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="10/10/10" # Base 07 - Bright White
+base16_color16="99/99/99" # Base 09
+base16_color17="5e/5e/5e" # Base 0F
+base16_color18="e3/e3/e3" # Base 01
+base16_color19="b9/b9/b9" # Base 02
+base16_color20="52/52/52" # Base 04
+base16_color21="25/25/25" # Base 06
+base16_color_foreground="46/46/46" # Base 05
+base16_color_background="f7/f7/f7" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 464646 # cursor
   put_template_custom Pm f7f7f7 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-grayscale-light.sh
+++ b/scripts/base16-grayscale-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Grayscale Light scheme by Alexandre Gavioli (https://github.com/Alexx2/)
 
-base16_color00="f7/f7/f7" # Base 00 - Black
-base16_color01="7c/7c/7c" # Base 08 - Red
-base16_color02="8e/8e/8e" # Base 0B - Green
-base16_color03="a0/a0/a0" # Base 0A - Yellow
-base16_color04="68/68/68" # Base 0D - Blue
-base16_color05="74/74/74" # Base 0E - Magenta
-base16_color06="86/86/86" # Base 0C - Cyan
-base16_color07="46/46/46" # Base 05 - White
-base16_color08="ab/ab/ab" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="10/10/10" # Base 07 - Bright White
-base16_color16="99/99/99" # Base 09
-base16_color17="5e/5e/5e" # Base 0F
-base16_color18="e3/e3/e3" # Base 01
-base16_color19="b9/b9/b9" # Base 02
-base16_color20="52/52/52" # Base 04
-base16_color21="25/25/25" # Base 06
-base16_color_foreground="46/46/46" # Base 05
-base16_color_background="f7/f7/f7" # Base 00
+export base16_color00="f7/f7/f7" # Base 00 - Black
+export base16_color01="7c/7c/7c" # Base 08 - Red
+export base16_color02="8e/8e/8e" # Base 0B - Green
+export base16_color03="a0/a0/a0" # Base 0A - Yellow
+export base16_color04="68/68/68" # Base 0D - Blue
+export base16_color05="74/74/74" # Base 0E - Magenta
+export base16_color06="86/86/86" # Base 0C - Cyan
+export base16_color07="46/46/46" # Base 05 - White
+export base16_color08="ab/ab/ab" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="10/10/10" # Base 07 - Bright White
+export base16_color16="99/99/99" # Base 09
+export base16_color17="5e/5e/5e" # Base 0F
+export base16_color18="e3/e3/e3" # Base 01
+export base16_color19="b9/b9/b9" # Base 02
+export base16_color20="52/52/52" # Base 04
+export base16_color21="25/25/25" # Base 06
+export base16_color_foreground="46/46/46" # Base 05
+export base16_color_background="f7/f7/f7" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-greenscreen.sh
+++ b/scripts/base16-greenscreen.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Green Screen scheme by Chris Kempson (http://chriskempson.com)
 
-color00="00/11/00" # Base 00 - Black
-color01="00/77/00" # Base 08 - Red
-color02="00/bb/00" # Base 0B - Green
-color03="00/77/00" # Base 0A - Yellow
-color04="00/99/00" # Base 0D - Blue
-color05="00/bb/00" # Base 0E - Magenta
-color06="00/55/00" # Base 0C - Cyan
-color07="00/bb/00" # Base 05 - White
-color08="00/77/00" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="00/ff/00" # Base 07 - Bright White
-color16="00/99/00" # Base 09
-color17="00/55/00" # Base 0F
-color18="00/33/00" # Base 01
-color19="00/55/00" # Base 02
-color20="00/99/00" # Base 04
-color21="00/dd/00" # Base 06
-color_foreground="00/bb/00" # Base 05
-color_background="00/11/00" # Base 00
+base16_color00="00/11/00" # Base 00 - Black
+base16_color01="00/77/00" # Base 08 - Red
+base16_color02="00/bb/00" # Base 0B - Green
+base16_color03="00/77/00" # Base 0A - Yellow
+base16_color04="00/99/00" # Base 0D - Blue
+base16_color05="00/bb/00" # Base 0E - Magenta
+base16_color06="00/55/00" # Base 0C - Cyan
+base16_color07="00/bb/00" # Base 05 - White
+base16_color08="00/77/00" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="00/ff/00" # Base 07 - Bright White
+base16_color16="00/99/00" # Base 09
+base16_color17="00/55/00" # Base 0F
+base16_color18="00/33/00" # Base 01
+base16_color19="00/55/00" # Base 02
+base16_color20="00/99/00" # Base 04
+base16_color21="00/dd/00" # Base 06
+base16_color_foreground="00/bb/00" # Base 05
+base16_color_background="00/11/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 00bb00 # cursor
   put_template_custom Pm 001100 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-greenscreen.sh
+++ b/scripts/base16-greenscreen.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Green Screen scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="00/11/00" # Base 00 - Black
-base16_color01="00/77/00" # Base 08 - Red
-base16_color02="00/bb/00" # Base 0B - Green
-base16_color03="00/77/00" # Base 0A - Yellow
-base16_color04="00/99/00" # Base 0D - Blue
-base16_color05="00/bb/00" # Base 0E - Magenta
-base16_color06="00/55/00" # Base 0C - Cyan
-base16_color07="00/bb/00" # Base 05 - White
-base16_color08="00/77/00" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="00/ff/00" # Base 07 - Bright White
-base16_color16="00/99/00" # Base 09
-base16_color17="00/55/00" # Base 0F
-base16_color18="00/33/00" # Base 01
-base16_color19="00/55/00" # Base 02
-base16_color20="00/99/00" # Base 04
-base16_color21="00/dd/00" # Base 06
-base16_color_foreground="00/bb/00" # Base 05
-base16_color_background="00/11/00" # Base 00
+export base16_color00="00/11/00" # Base 00 - Black
+export base16_color01="00/77/00" # Base 08 - Red
+export base16_color02="00/bb/00" # Base 0B - Green
+export base16_color03="00/77/00" # Base 0A - Yellow
+export base16_color04="00/99/00" # Base 0D - Blue
+export base16_color05="00/bb/00" # Base 0E - Magenta
+export base16_color06="00/55/00" # Base 0C - Cyan
+export base16_color07="00/bb/00" # Base 05 - White
+export base16_color08="00/77/00" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="00/ff/00" # Base 07 - Bright White
+export base16_color16="00/99/00" # Base 09
+export base16_color17="00/55/00" # Base 0F
+export base16_color18="00/33/00" # Base 01
+export base16_color19="00/55/00" # Base 02
+export base16_color20="00/99/00" # Base 04
+export base16_color21="00/dd/00" # Base 06
+export base16_color_foreground="00/bb/00" # Base 05
+export base16_color_background="00/11/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-gruvbox-dark-hard.sh
+++ b/scripts/base16-gruvbox-dark-hard.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox dark, hard scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-base16_color00="1d/20/21" # Base 00 - Black
-base16_color01="fb/49/34" # Base 08 - Red
-base16_color02="b8/bb/26" # Base 0B - Green
-base16_color03="fa/bd/2f" # Base 0A - Yellow
-base16_color04="83/a5/98" # Base 0D - Blue
-base16_color05="d3/86/9b" # Base 0E - Magenta
-base16_color06="8e/c0/7c" # Base 0C - Cyan
-base16_color07="d5/c4/a1" # Base 05 - White
-base16_color08="66/5c/54" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="fb/f1/c7" # Base 07 - Bright White
-base16_color16="fe/80/19" # Base 09
-base16_color17="d6/5d/0e" # Base 0F
-base16_color18="3c/38/36" # Base 01
-base16_color19="50/49/45" # Base 02
-base16_color20="bd/ae/93" # Base 04
-base16_color21="eb/db/b2" # Base 06
-base16_color_foreground="d5/c4/a1" # Base 05
-base16_color_background="1d/20/21" # Base 00
+export base16_color00="1d/20/21" # Base 00 - Black
+export base16_color01="fb/49/34" # Base 08 - Red
+export base16_color02="b8/bb/26" # Base 0B - Green
+export base16_color03="fa/bd/2f" # Base 0A - Yellow
+export base16_color04="83/a5/98" # Base 0D - Blue
+export base16_color05="d3/86/9b" # Base 0E - Magenta
+export base16_color06="8e/c0/7c" # Base 0C - Cyan
+export base16_color07="d5/c4/a1" # Base 05 - White
+export base16_color08="66/5c/54" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="fb/f1/c7" # Base 07 - Bright White
+export base16_color16="fe/80/19" # Base 09
+export base16_color17="d6/5d/0e" # Base 0F
+export base16_color18="3c/38/36" # Base 01
+export base16_color19="50/49/45" # Base 02
+export base16_color20="bd/ae/93" # Base 04
+export base16_color21="eb/db/b2" # Base 06
+export base16_color_foreground="d5/c4/a1" # Base 05
+export base16_color_background="1d/20/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-gruvbox-dark-hard.sh
+++ b/scripts/base16-gruvbox-dark-hard.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox dark, hard scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-color00="1d/20/21" # Base 00 - Black
-color01="fb/49/34" # Base 08 - Red
-color02="b8/bb/26" # Base 0B - Green
-color03="fa/bd/2f" # Base 0A - Yellow
-color04="83/a5/98" # Base 0D - Blue
-color05="d3/86/9b" # Base 0E - Magenta
-color06="8e/c0/7c" # Base 0C - Cyan
-color07="d5/c4/a1" # Base 05 - White
-color08="66/5c/54" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fb/f1/c7" # Base 07 - Bright White
-color16="fe/80/19" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="3c/38/36" # Base 01
-color19="50/49/45" # Base 02
-color20="bd/ae/93" # Base 04
-color21="eb/db/b2" # Base 06
-color_foreground="d5/c4/a1" # Base 05
-color_background="1d/20/21" # Base 00
+base16_color00="1d/20/21" # Base 00 - Black
+base16_color01="fb/49/34" # Base 08 - Red
+base16_color02="b8/bb/26" # Base 0B - Green
+base16_color03="fa/bd/2f" # Base 0A - Yellow
+base16_color04="83/a5/98" # Base 0D - Blue
+base16_color05="d3/86/9b" # Base 0E - Magenta
+base16_color06="8e/c0/7c" # Base 0C - Cyan
+base16_color07="d5/c4/a1" # Base 05 - White
+base16_color08="66/5c/54" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="fb/f1/c7" # Base 07 - Bright White
+base16_color16="fe/80/19" # Base 09
+base16_color17="d6/5d/0e" # Base 0F
+base16_color18="3c/38/36" # Base 01
+base16_color19="50/49/45" # Base 02
+base16_color20="bd/ae/93" # Base 04
+base16_color21="eb/db/b2" # Base 06
+base16_color_foreground="d5/c4/a1" # Base 05
+base16_color_background="1d/20/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d5c4a1 # cursor
   put_template_custom Pm 1d2021 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-gruvbox-dark-medium.sh
+++ b/scripts/base16-gruvbox-dark-medium.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox dark, medium scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-base16_color00="28/28/28" # Base 00 - Black
-base16_color01="fb/49/34" # Base 08 - Red
-base16_color02="b8/bb/26" # Base 0B - Green
-base16_color03="fa/bd/2f" # Base 0A - Yellow
-base16_color04="83/a5/98" # Base 0D - Blue
-base16_color05="d3/86/9b" # Base 0E - Magenta
-base16_color06="8e/c0/7c" # Base 0C - Cyan
-base16_color07="d5/c4/a1" # Base 05 - White
-base16_color08="66/5c/54" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="fb/f1/c7" # Base 07 - Bright White
-base16_color16="fe/80/19" # Base 09
-base16_color17="d6/5d/0e" # Base 0F
-base16_color18="3c/38/36" # Base 01
-base16_color19="50/49/45" # Base 02
-base16_color20="bd/ae/93" # Base 04
-base16_color21="eb/db/b2" # Base 06
-base16_color_foreground="d5/c4/a1" # Base 05
-base16_color_background="28/28/28" # Base 00
+export base16_color00="28/28/28" # Base 00 - Black
+export base16_color01="fb/49/34" # Base 08 - Red
+export base16_color02="b8/bb/26" # Base 0B - Green
+export base16_color03="fa/bd/2f" # Base 0A - Yellow
+export base16_color04="83/a5/98" # Base 0D - Blue
+export base16_color05="d3/86/9b" # Base 0E - Magenta
+export base16_color06="8e/c0/7c" # Base 0C - Cyan
+export base16_color07="d5/c4/a1" # Base 05 - White
+export base16_color08="66/5c/54" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="fb/f1/c7" # Base 07 - Bright White
+export base16_color16="fe/80/19" # Base 09
+export base16_color17="d6/5d/0e" # Base 0F
+export base16_color18="3c/38/36" # Base 01
+export base16_color19="50/49/45" # Base 02
+export base16_color20="bd/ae/93" # Base 04
+export base16_color21="eb/db/b2" # Base 06
+export base16_color_foreground="d5/c4/a1" # Base 05
+export base16_color_background="28/28/28" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-gruvbox-dark-medium.sh
+++ b/scripts/base16-gruvbox-dark-medium.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox dark, medium scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-color00="28/28/28" # Base 00 - Black
-color01="fb/49/34" # Base 08 - Red
-color02="b8/bb/26" # Base 0B - Green
-color03="fa/bd/2f" # Base 0A - Yellow
-color04="83/a5/98" # Base 0D - Blue
-color05="d3/86/9b" # Base 0E - Magenta
-color06="8e/c0/7c" # Base 0C - Cyan
-color07="d5/c4/a1" # Base 05 - White
-color08="66/5c/54" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fb/f1/c7" # Base 07 - Bright White
-color16="fe/80/19" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="3c/38/36" # Base 01
-color19="50/49/45" # Base 02
-color20="bd/ae/93" # Base 04
-color21="eb/db/b2" # Base 06
-color_foreground="d5/c4/a1" # Base 05
-color_background="28/28/28" # Base 00
+base16_color00="28/28/28" # Base 00 - Black
+base16_color01="fb/49/34" # Base 08 - Red
+base16_color02="b8/bb/26" # Base 0B - Green
+base16_color03="fa/bd/2f" # Base 0A - Yellow
+base16_color04="83/a5/98" # Base 0D - Blue
+base16_color05="d3/86/9b" # Base 0E - Magenta
+base16_color06="8e/c0/7c" # Base 0C - Cyan
+base16_color07="d5/c4/a1" # Base 05 - White
+base16_color08="66/5c/54" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="fb/f1/c7" # Base 07 - Bright White
+base16_color16="fe/80/19" # Base 09
+base16_color17="d6/5d/0e" # Base 0F
+base16_color18="3c/38/36" # Base 01
+base16_color19="50/49/45" # Base 02
+base16_color20="bd/ae/93" # Base 04
+base16_color21="eb/db/b2" # Base 06
+base16_color_foreground="d5/c4/a1" # Base 05
+base16_color_background="28/28/28" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d5c4a1 # cursor
   put_template_custom Pm 282828 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-gruvbox-dark-pale.sh
+++ b/scripts/base16-gruvbox-dark-pale.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox dark, pale scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-base16_color00="26/26/26" # Base 00 - Black
-base16_color01="d7/5f/5f" # Base 08 - Red
-base16_color02="af/af/00" # Base 0B - Green
-base16_color03="ff/af/00" # Base 0A - Yellow
-base16_color04="83/ad/ad" # Base 0D - Blue
-base16_color05="d4/85/ad" # Base 0E - Magenta
-base16_color06="85/ad/85" # Base 0C - Cyan
-base16_color07="da/b9/97" # Base 05 - White
-base16_color08="8a/8a/8a" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="eb/db/b2" # Base 07 - Bright White
-base16_color16="ff/87/00" # Base 09
-base16_color17="d6/5d/0e" # Base 0F
-base16_color18="3a/3a/3a" # Base 01
-base16_color19="4e/4e/4e" # Base 02
-base16_color20="94/94/94" # Base 04
-base16_color21="d5/c4/a1" # Base 06
-base16_color_foreground="da/b9/97" # Base 05
-base16_color_background="26/26/26" # Base 00
+export base16_color00="26/26/26" # Base 00 - Black
+export base16_color01="d7/5f/5f" # Base 08 - Red
+export base16_color02="af/af/00" # Base 0B - Green
+export base16_color03="ff/af/00" # Base 0A - Yellow
+export base16_color04="83/ad/ad" # Base 0D - Blue
+export base16_color05="d4/85/ad" # Base 0E - Magenta
+export base16_color06="85/ad/85" # Base 0C - Cyan
+export base16_color07="da/b9/97" # Base 05 - White
+export base16_color08="8a/8a/8a" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="eb/db/b2" # Base 07 - Bright White
+export base16_color16="ff/87/00" # Base 09
+export base16_color17="d6/5d/0e" # Base 0F
+export base16_color18="3a/3a/3a" # Base 01
+export base16_color19="4e/4e/4e" # Base 02
+export base16_color20="94/94/94" # Base 04
+export base16_color21="d5/c4/a1" # Base 06
+export base16_color_foreground="da/b9/97" # Base 05
+export base16_color_background="26/26/26" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-gruvbox-dark-pale.sh
+++ b/scripts/base16-gruvbox-dark-pale.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox dark, pale scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-color00="26/26/26" # Base 00 - Black
-color01="d7/5f/5f" # Base 08 - Red
-color02="af/af/00" # Base 0B - Green
-color03="ff/af/00" # Base 0A - Yellow
-color04="83/ad/ad" # Base 0D - Blue
-color05="d4/85/ad" # Base 0E - Magenta
-color06="85/ad/85" # Base 0C - Cyan
-color07="da/b9/97" # Base 05 - White
-color08="8a/8a/8a" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="eb/db/b2" # Base 07 - Bright White
-color16="ff/87/00" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="3a/3a/3a" # Base 01
-color19="4e/4e/4e" # Base 02
-color20="94/94/94" # Base 04
-color21="d5/c4/a1" # Base 06
-color_foreground="da/b9/97" # Base 05
-color_background="26/26/26" # Base 00
+base16_color00="26/26/26" # Base 00 - Black
+base16_color01="d7/5f/5f" # Base 08 - Red
+base16_color02="af/af/00" # Base 0B - Green
+base16_color03="ff/af/00" # Base 0A - Yellow
+base16_color04="83/ad/ad" # Base 0D - Blue
+base16_color05="d4/85/ad" # Base 0E - Magenta
+base16_color06="85/ad/85" # Base 0C - Cyan
+base16_color07="da/b9/97" # Base 05 - White
+base16_color08="8a/8a/8a" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="eb/db/b2" # Base 07 - Bright White
+base16_color16="ff/87/00" # Base 09
+base16_color17="d6/5d/0e" # Base 0F
+base16_color18="3a/3a/3a" # Base 01
+base16_color19="4e/4e/4e" # Base 02
+base16_color20="94/94/94" # Base 04
+base16_color21="d5/c4/a1" # Base 06
+base16_color_foreground="da/b9/97" # Base 05
+base16_color_background="26/26/26" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl dab997 # cursor
   put_template_custom Pm 262626 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-gruvbox-dark-soft.sh
+++ b/scripts/base16-gruvbox-dark-soft.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox dark, soft scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-base16_color00="32/30/2f" # Base 00 - Black
-base16_color01="fb/49/34" # Base 08 - Red
-base16_color02="b8/bb/26" # Base 0B - Green
-base16_color03="fa/bd/2f" # Base 0A - Yellow
-base16_color04="83/a5/98" # Base 0D - Blue
-base16_color05="d3/86/9b" # Base 0E - Magenta
-base16_color06="8e/c0/7c" # Base 0C - Cyan
-base16_color07="d5/c4/a1" # Base 05 - White
-base16_color08="66/5c/54" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="fb/f1/c7" # Base 07 - Bright White
-base16_color16="fe/80/19" # Base 09
-base16_color17="d6/5d/0e" # Base 0F
-base16_color18="3c/38/36" # Base 01
-base16_color19="50/49/45" # Base 02
-base16_color20="bd/ae/93" # Base 04
-base16_color21="eb/db/b2" # Base 06
-base16_color_foreground="d5/c4/a1" # Base 05
-base16_color_background="32/30/2f" # Base 00
+export base16_color00="32/30/2f" # Base 00 - Black
+export base16_color01="fb/49/34" # Base 08 - Red
+export base16_color02="b8/bb/26" # Base 0B - Green
+export base16_color03="fa/bd/2f" # Base 0A - Yellow
+export base16_color04="83/a5/98" # Base 0D - Blue
+export base16_color05="d3/86/9b" # Base 0E - Magenta
+export base16_color06="8e/c0/7c" # Base 0C - Cyan
+export base16_color07="d5/c4/a1" # Base 05 - White
+export base16_color08="66/5c/54" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="fb/f1/c7" # Base 07 - Bright White
+export base16_color16="fe/80/19" # Base 09
+export base16_color17="d6/5d/0e" # Base 0F
+export base16_color18="3c/38/36" # Base 01
+export base16_color19="50/49/45" # Base 02
+export base16_color20="bd/ae/93" # Base 04
+export base16_color21="eb/db/b2" # Base 06
+export base16_color_foreground="d5/c4/a1" # Base 05
+export base16_color_background="32/30/2f" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-gruvbox-dark-soft.sh
+++ b/scripts/base16-gruvbox-dark-soft.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox dark, soft scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-color00="32/30/2f" # Base 00 - Black
-color01="fb/49/34" # Base 08 - Red
-color02="b8/bb/26" # Base 0B - Green
-color03="fa/bd/2f" # Base 0A - Yellow
-color04="83/a5/98" # Base 0D - Blue
-color05="d3/86/9b" # Base 0E - Magenta
-color06="8e/c0/7c" # Base 0C - Cyan
-color07="d5/c4/a1" # Base 05 - White
-color08="66/5c/54" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fb/f1/c7" # Base 07 - Bright White
-color16="fe/80/19" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="3c/38/36" # Base 01
-color19="50/49/45" # Base 02
-color20="bd/ae/93" # Base 04
-color21="eb/db/b2" # Base 06
-color_foreground="d5/c4/a1" # Base 05
-color_background="32/30/2f" # Base 00
+base16_color00="32/30/2f" # Base 00 - Black
+base16_color01="fb/49/34" # Base 08 - Red
+base16_color02="b8/bb/26" # Base 0B - Green
+base16_color03="fa/bd/2f" # Base 0A - Yellow
+base16_color04="83/a5/98" # Base 0D - Blue
+base16_color05="d3/86/9b" # Base 0E - Magenta
+base16_color06="8e/c0/7c" # Base 0C - Cyan
+base16_color07="d5/c4/a1" # Base 05 - White
+base16_color08="66/5c/54" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="fb/f1/c7" # Base 07 - Bright White
+base16_color16="fe/80/19" # Base 09
+base16_color17="d6/5d/0e" # Base 0F
+base16_color18="3c/38/36" # Base 01
+base16_color19="50/49/45" # Base 02
+base16_color20="bd/ae/93" # Base 04
+base16_color21="eb/db/b2" # Base 06
+base16_color_foreground="d5/c4/a1" # Base 05
+base16_color_background="32/30/2f" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d5c4a1 # cursor
   put_template_custom Pm 32302f # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-gruvbox-light-hard.sh
+++ b/scripts/base16-gruvbox-light-hard.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox light, hard scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-base16_color00="f9/f5/d7" # Base 00 - Black
-base16_color01="9d/00/06" # Base 08 - Red
-base16_color02="79/74/0e" # Base 0B - Green
-base16_color03="b5/76/14" # Base 0A - Yellow
-base16_color04="07/66/78" # Base 0D - Blue
-base16_color05="8f/3f/71" # Base 0E - Magenta
-base16_color06="42/7b/58" # Base 0C - Cyan
-base16_color07="50/49/45" # Base 05 - White
-base16_color08="bd/ae/93" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="28/28/28" # Base 07 - Bright White
-base16_color16="af/3a/03" # Base 09
-base16_color17="d6/5d/0e" # Base 0F
-base16_color18="eb/db/b2" # Base 01
-base16_color19="d5/c4/a1" # Base 02
-base16_color20="66/5c/54" # Base 04
-base16_color21="3c/38/36" # Base 06
-base16_color_foreground="50/49/45" # Base 05
-base16_color_background="f9/f5/d7" # Base 00
+export base16_color00="f9/f5/d7" # Base 00 - Black
+export base16_color01="9d/00/06" # Base 08 - Red
+export base16_color02="79/74/0e" # Base 0B - Green
+export base16_color03="b5/76/14" # Base 0A - Yellow
+export base16_color04="07/66/78" # Base 0D - Blue
+export base16_color05="8f/3f/71" # Base 0E - Magenta
+export base16_color06="42/7b/58" # Base 0C - Cyan
+export base16_color07="50/49/45" # Base 05 - White
+export base16_color08="bd/ae/93" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="28/28/28" # Base 07 - Bright White
+export base16_color16="af/3a/03" # Base 09
+export base16_color17="d6/5d/0e" # Base 0F
+export base16_color18="eb/db/b2" # Base 01
+export base16_color19="d5/c4/a1" # Base 02
+export base16_color20="66/5c/54" # Base 04
+export base16_color21="3c/38/36" # Base 06
+export base16_color_foreground="50/49/45" # Base 05
+export base16_color_background="f9/f5/d7" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-gruvbox-light-hard.sh
+++ b/scripts/base16-gruvbox-light-hard.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox light, hard scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-color00="f9/f5/d7" # Base 00 - Black
-color01="9d/00/06" # Base 08 - Red
-color02="79/74/0e" # Base 0B - Green
-color03="b5/76/14" # Base 0A - Yellow
-color04="07/66/78" # Base 0D - Blue
-color05="8f/3f/71" # Base 0E - Magenta
-color06="42/7b/58" # Base 0C - Cyan
-color07="50/49/45" # Base 05 - White
-color08="bd/ae/93" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="28/28/28" # Base 07 - Bright White
-color16="af/3a/03" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="eb/db/b2" # Base 01
-color19="d5/c4/a1" # Base 02
-color20="66/5c/54" # Base 04
-color21="3c/38/36" # Base 06
-color_foreground="50/49/45" # Base 05
-color_background="f9/f5/d7" # Base 00
+base16_color00="f9/f5/d7" # Base 00 - Black
+base16_color01="9d/00/06" # Base 08 - Red
+base16_color02="79/74/0e" # Base 0B - Green
+base16_color03="b5/76/14" # Base 0A - Yellow
+base16_color04="07/66/78" # Base 0D - Blue
+base16_color05="8f/3f/71" # Base 0E - Magenta
+base16_color06="42/7b/58" # Base 0C - Cyan
+base16_color07="50/49/45" # Base 05 - White
+base16_color08="bd/ae/93" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="28/28/28" # Base 07 - Bright White
+base16_color16="af/3a/03" # Base 09
+base16_color17="d6/5d/0e" # Base 0F
+base16_color18="eb/db/b2" # Base 01
+base16_color19="d5/c4/a1" # Base 02
+base16_color20="66/5c/54" # Base 04
+base16_color21="3c/38/36" # Base 06
+base16_color_foreground="50/49/45" # Base 05
+base16_color_background="f9/f5/d7" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 504945 # cursor
   put_template_custom Pm f9f5d7 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-gruvbox-light-medium.sh
+++ b/scripts/base16-gruvbox-light-medium.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox light, medium scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-color00="fb/f1/c7" # Base 00 - Black
-color01="9d/00/06" # Base 08 - Red
-color02="79/74/0e" # Base 0B - Green
-color03="b5/76/14" # Base 0A - Yellow
-color04="07/66/78" # Base 0D - Blue
-color05="8f/3f/71" # Base 0E - Magenta
-color06="42/7b/58" # Base 0C - Cyan
-color07="50/49/45" # Base 05 - White
-color08="bd/ae/93" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="28/28/28" # Base 07 - Bright White
-color16="af/3a/03" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="eb/db/b2" # Base 01
-color19="d5/c4/a1" # Base 02
-color20="66/5c/54" # Base 04
-color21="3c/38/36" # Base 06
-color_foreground="50/49/45" # Base 05
-color_background="fb/f1/c7" # Base 00
+base16_color00="fb/f1/c7" # Base 00 - Black
+base16_color01="9d/00/06" # Base 08 - Red
+base16_color02="79/74/0e" # Base 0B - Green
+base16_color03="b5/76/14" # Base 0A - Yellow
+base16_color04="07/66/78" # Base 0D - Blue
+base16_color05="8f/3f/71" # Base 0E - Magenta
+base16_color06="42/7b/58" # Base 0C - Cyan
+base16_color07="50/49/45" # Base 05 - White
+base16_color08="bd/ae/93" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="28/28/28" # Base 07 - Bright White
+base16_color16="af/3a/03" # Base 09
+base16_color17="d6/5d/0e" # Base 0F
+base16_color18="eb/db/b2" # Base 01
+base16_color19="d5/c4/a1" # Base 02
+base16_color20="66/5c/54" # Base 04
+base16_color21="3c/38/36" # Base 06
+base16_color_foreground="50/49/45" # Base 05
+base16_color_background="fb/f1/c7" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 504945 # cursor
   put_template_custom Pm fbf1c7 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-gruvbox-light-medium.sh
+++ b/scripts/base16-gruvbox-light-medium.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox light, medium scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-base16_color00="fb/f1/c7" # Base 00 - Black
-base16_color01="9d/00/06" # Base 08 - Red
-base16_color02="79/74/0e" # Base 0B - Green
-base16_color03="b5/76/14" # Base 0A - Yellow
-base16_color04="07/66/78" # Base 0D - Blue
-base16_color05="8f/3f/71" # Base 0E - Magenta
-base16_color06="42/7b/58" # Base 0C - Cyan
-base16_color07="50/49/45" # Base 05 - White
-base16_color08="bd/ae/93" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="28/28/28" # Base 07 - Bright White
-base16_color16="af/3a/03" # Base 09
-base16_color17="d6/5d/0e" # Base 0F
-base16_color18="eb/db/b2" # Base 01
-base16_color19="d5/c4/a1" # Base 02
-base16_color20="66/5c/54" # Base 04
-base16_color21="3c/38/36" # Base 06
-base16_color_foreground="50/49/45" # Base 05
-base16_color_background="fb/f1/c7" # Base 00
+export base16_color00="fb/f1/c7" # Base 00 - Black
+export base16_color01="9d/00/06" # Base 08 - Red
+export base16_color02="79/74/0e" # Base 0B - Green
+export base16_color03="b5/76/14" # Base 0A - Yellow
+export base16_color04="07/66/78" # Base 0D - Blue
+export base16_color05="8f/3f/71" # Base 0E - Magenta
+export base16_color06="42/7b/58" # Base 0C - Cyan
+export base16_color07="50/49/45" # Base 05 - White
+export base16_color08="bd/ae/93" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="28/28/28" # Base 07 - Bright White
+export base16_color16="af/3a/03" # Base 09
+export base16_color17="d6/5d/0e" # Base 0F
+export base16_color18="eb/db/b2" # Base 01
+export base16_color19="d5/c4/a1" # Base 02
+export base16_color20="66/5c/54" # Base 04
+export base16_color21="3c/38/36" # Base 06
+export base16_color_foreground="50/49/45" # Base 05
+export base16_color_background="fb/f1/c7" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-gruvbox-light-soft.sh
+++ b/scripts/base16-gruvbox-light-soft.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox light, soft scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-base16_color00="f2/e5/bc" # Base 00 - Black
-base16_color01="9d/00/06" # Base 08 - Red
-base16_color02="79/74/0e" # Base 0B - Green
-base16_color03="b5/76/14" # Base 0A - Yellow
-base16_color04="07/66/78" # Base 0D - Blue
-base16_color05="8f/3f/71" # Base 0E - Magenta
-base16_color06="42/7b/58" # Base 0C - Cyan
-base16_color07="50/49/45" # Base 05 - White
-base16_color08="bd/ae/93" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="28/28/28" # Base 07 - Bright White
-base16_color16="af/3a/03" # Base 09
-base16_color17="d6/5d/0e" # Base 0F
-base16_color18="eb/db/b2" # Base 01
-base16_color19="d5/c4/a1" # Base 02
-base16_color20="66/5c/54" # Base 04
-base16_color21="3c/38/36" # Base 06
-base16_color_foreground="50/49/45" # Base 05
-base16_color_background="f2/e5/bc" # Base 00
+export base16_color00="f2/e5/bc" # Base 00 - Black
+export base16_color01="9d/00/06" # Base 08 - Red
+export base16_color02="79/74/0e" # Base 0B - Green
+export base16_color03="b5/76/14" # Base 0A - Yellow
+export base16_color04="07/66/78" # Base 0D - Blue
+export base16_color05="8f/3f/71" # Base 0E - Magenta
+export base16_color06="42/7b/58" # Base 0C - Cyan
+export base16_color07="50/49/45" # Base 05 - White
+export base16_color08="bd/ae/93" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="28/28/28" # Base 07 - Bright White
+export base16_color16="af/3a/03" # Base 09
+export base16_color17="d6/5d/0e" # Base 0F
+export base16_color18="eb/db/b2" # Base 01
+export base16_color19="d5/c4/a1" # Base 02
+export base16_color20="66/5c/54" # Base 04
+export base16_color21="3c/38/36" # Base 06
+export base16_color_foreground="50/49/45" # Base 05
+export base16_color_background="f2/e5/bc" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-gruvbox-light-soft.sh
+++ b/scripts/base16-gruvbox-light-soft.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Gruvbox light, soft scheme by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-color00="f2/e5/bc" # Base 00 - Black
-color01="9d/00/06" # Base 08 - Red
-color02="79/74/0e" # Base 0B - Green
-color03="b5/76/14" # Base 0A - Yellow
-color04="07/66/78" # Base 0D - Blue
-color05="8f/3f/71" # Base 0E - Magenta
-color06="42/7b/58" # Base 0C - Cyan
-color07="50/49/45" # Base 05 - White
-color08="bd/ae/93" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="28/28/28" # Base 07 - Bright White
-color16="af/3a/03" # Base 09
-color17="d6/5d/0e" # Base 0F
-color18="eb/db/b2" # Base 01
-color19="d5/c4/a1" # Base 02
-color20="66/5c/54" # Base 04
-color21="3c/38/36" # Base 06
-color_foreground="50/49/45" # Base 05
-color_background="f2/e5/bc" # Base 00
+base16_color00="f2/e5/bc" # Base 00 - Black
+base16_color01="9d/00/06" # Base 08 - Red
+base16_color02="79/74/0e" # Base 0B - Green
+base16_color03="b5/76/14" # Base 0A - Yellow
+base16_color04="07/66/78" # Base 0D - Blue
+base16_color05="8f/3f/71" # Base 0E - Magenta
+base16_color06="42/7b/58" # Base 0C - Cyan
+base16_color07="50/49/45" # Base 05 - White
+base16_color08="bd/ae/93" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="28/28/28" # Base 07 - Bright White
+base16_color16="af/3a/03" # Base 09
+base16_color17="d6/5d/0e" # Base 0F
+base16_color18="eb/db/b2" # Base 01
+base16_color19="d5/c4/a1" # Base 02
+base16_color20="66/5c/54" # Base 04
+base16_color21="3c/38/36" # Base 06
+base16_color_foreground="50/49/45" # Base 05
+base16_color_background="f2/e5/bc" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 504945 # cursor
   put_template_custom Pm f2e5bc # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-harmonic-dark.sh
+++ b/scripts/base16-harmonic-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Harmonic16 Dark scheme by Jannik Siebert (https://github.com/janniks)
 
-color00="0b/1c/2c" # Base 00 - Black
-color01="bf/8b/56" # Base 08 - Red
-color02="56/bf/8b" # Base 0B - Green
-color03="8b/bf/56" # Base 0A - Yellow
-color04="8b/56/bf" # Base 0D - Blue
-color05="bf/56/8b" # Base 0E - Magenta
-color06="56/8b/bf" # Base 0C - Cyan
-color07="cb/d6/e2" # Base 05 - White
-color08="62/7e/99" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f7/f9/fb" # Base 07 - Bright White
-color16="bf/bf/56" # Base 09
-color17="bf/56/56" # Base 0F
-color18="22/3b/54" # Base 01
-color19="40/5c/79" # Base 02
-color20="aa/bc/ce" # Base 04
-color21="e5/eb/f1" # Base 06
-color_foreground="cb/d6/e2" # Base 05
-color_background="0b/1c/2c" # Base 00
+base16_color00="0b/1c/2c" # Base 00 - Black
+base16_color01="bf/8b/56" # Base 08 - Red
+base16_color02="56/bf/8b" # Base 0B - Green
+base16_color03="8b/bf/56" # Base 0A - Yellow
+base16_color04="8b/56/bf" # Base 0D - Blue
+base16_color05="bf/56/8b" # Base 0E - Magenta
+base16_color06="56/8b/bf" # Base 0C - Cyan
+base16_color07="cb/d6/e2" # Base 05 - White
+base16_color08="62/7e/99" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f7/f9/fb" # Base 07 - Bright White
+base16_color16="bf/bf/56" # Base 09
+base16_color17="bf/56/56" # Base 0F
+base16_color18="22/3b/54" # Base 01
+base16_color19="40/5c/79" # Base 02
+base16_color20="aa/bc/ce" # Base 04
+base16_color21="e5/eb/f1" # Base 06
+base16_color_foreground="cb/d6/e2" # Base 05
+base16_color_background="0b/1c/2c" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl cbd6e2 # cursor
   put_template_custom Pm 0b1c2c # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-harmonic-dark.sh
+++ b/scripts/base16-harmonic-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Harmonic16 Dark scheme by Jannik Siebert (https://github.com/janniks)
 
-base16_color00="0b/1c/2c" # Base 00 - Black
-base16_color01="bf/8b/56" # Base 08 - Red
-base16_color02="56/bf/8b" # Base 0B - Green
-base16_color03="8b/bf/56" # Base 0A - Yellow
-base16_color04="8b/56/bf" # Base 0D - Blue
-base16_color05="bf/56/8b" # Base 0E - Magenta
-base16_color06="56/8b/bf" # Base 0C - Cyan
-base16_color07="cb/d6/e2" # Base 05 - White
-base16_color08="62/7e/99" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f7/f9/fb" # Base 07 - Bright White
-base16_color16="bf/bf/56" # Base 09
-base16_color17="bf/56/56" # Base 0F
-base16_color18="22/3b/54" # Base 01
-base16_color19="40/5c/79" # Base 02
-base16_color20="aa/bc/ce" # Base 04
-base16_color21="e5/eb/f1" # Base 06
-base16_color_foreground="cb/d6/e2" # Base 05
-base16_color_background="0b/1c/2c" # Base 00
+export base16_color00="0b/1c/2c" # Base 00 - Black
+export base16_color01="bf/8b/56" # Base 08 - Red
+export base16_color02="56/bf/8b" # Base 0B - Green
+export base16_color03="8b/bf/56" # Base 0A - Yellow
+export base16_color04="8b/56/bf" # Base 0D - Blue
+export base16_color05="bf/56/8b" # Base 0E - Magenta
+export base16_color06="56/8b/bf" # Base 0C - Cyan
+export base16_color07="cb/d6/e2" # Base 05 - White
+export base16_color08="62/7e/99" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f7/f9/fb" # Base 07 - Bright White
+export base16_color16="bf/bf/56" # Base 09
+export base16_color17="bf/56/56" # Base 0F
+export base16_color18="22/3b/54" # Base 01
+export base16_color19="40/5c/79" # Base 02
+export base16_color20="aa/bc/ce" # Base 04
+export base16_color21="e5/eb/f1" # Base 06
+export base16_color_foreground="cb/d6/e2" # Base 05
+export base16_color_background="0b/1c/2c" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-harmonic-light.sh
+++ b/scripts/base16-harmonic-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Harmonic16 Light scheme by Jannik Siebert (https://github.com/janniks)
 
-base16_color00="f7/f9/fb" # Base 00 - Black
-base16_color01="bf/8b/56" # Base 08 - Red
-base16_color02="56/bf/8b" # Base 0B - Green
-base16_color03="8b/bf/56" # Base 0A - Yellow
-base16_color04="8b/56/bf" # Base 0D - Blue
-base16_color05="bf/56/8b" # Base 0E - Magenta
-base16_color06="56/8b/bf" # Base 0C - Cyan
-base16_color07="40/5c/79" # Base 05 - White
-base16_color08="aa/bc/ce" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="0b/1c/2c" # Base 07 - Bright White
-base16_color16="bf/bf/56" # Base 09
-base16_color17="bf/56/56" # Base 0F
-base16_color18="e5/eb/f1" # Base 01
-base16_color19="cb/d6/e2" # Base 02
-base16_color20="62/7e/99" # Base 04
-base16_color21="22/3b/54" # Base 06
-base16_color_foreground="40/5c/79" # Base 05
-base16_color_background="f7/f9/fb" # Base 00
+export base16_color00="f7/f9/fb" # Base 00 - Black
+export base16_color01="bf/8b/56" # Base 08 - Red
+export base16_color02="56/bf/8b" # Base 0B - Green
+export base16_color03="8b/bf/56" # Base 0A - Yellow
+export base16_color04="8b/56/bf" # Base 0D - Blue
+export base16_color05="bf/56/8b" # Base 0E - Magenta
+export base16_color06="56/8b/bf" # Base 0C - Cyan
+export base16_color07="40/5c/79" # Base 05 - White
+export base16_color08="aa/bc/ce" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="0b/1c/2c" # Base 07 - Bright White
+export base16_color16="bf/bf/56" # Base 09
+export base16_color17="bf/56/56" # Base 0F
+export base16_color18="e5/eb/f1" # Base 01
+export base16_color19="cb/d6/e2" # Base 02
+export base16_color20="62/7e/99" # Base 04
+export base16_color21="22/3b/54" # Base 06
+export base16_color_foreground="40/5c/79" # Base 05
+export base16_color_background="f7/f9/fb" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-harmonic-light.sh
+++ b/scripts/base16-harmonic-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Harmonic16 Light scheme by Jannik Siebert (https://github.com/janniks)
 
-color00="f7/f9/fb" # Base 00 - Black
-color01="bf/8b/56" # Base 08 - Red
-color02="56/bf/8b" # Base 0B - Green
-color03="8b/bf/56" # Base 0A - Yellow
-color04="8b/56/bf" # Base 0D - Blue
-color05="bf/56/8b" # Base 0E - Magenta
-color06="56/8b/bf" # Base 0C - Cyan
-color07="40/5c/79" # Base 05 - White
-color08="aa/bc/ce" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="0b/1c/2c" # Base 07 - Bright White
-color16="bf/bf/56" # Base 09
-color17="bf/56/56" # Base 0F
-color18="e5/eb/f1" # Base 01
-color19="cb/d6/e2" # Base 02
-color20="62/7e/99" # Base 04
-color21="22/3b/54" # Base 06
-color_foreground="40/5c/79" # Base 05
-color_background="f7/f9/fb" # Base 00
+base16_color00="f7/f9/fb" # Base 00 - Black
+base16_color01="bf/8b/56" # Base 08 - Red
+base16_color02="56/bf/8b" # Base 0B - Green
+base16_color03="8b/bf/56" # Base 0A - Yellow
+base16_color04="8b/56/bf" # Base 0D - Blue
+base16_color05="bf/56/8b" # Base 0E - Magenta
+base16_color06="56/8b/bf" # Base 0C - Cyan
+base16_color07="40/5c/79" # Base 05 - White
+base16_color08="aa/bc/ce" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="0b/1c/2c" # Base 07 - Bright White
+base16_color16="bf/bf/56" # Base 09
+base16_color17="bf/56/56" # Base 0F
+base16_color18="e5/eb/f1" # Base 01
+base16_color19="cb/d6/e2" # Base 02
+base16_color20="62/7e/99" # Base 04
+base16_color21="22/3b/54" # Base 06
+base16_color_foreground="40/5c/79" # Base 05
+base16_color_background="f7/f9/fb" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 405c79 # cursor
   put_template_custom Pm f7f9fb # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-heetch-light.sh
+++ b/scripts/base16-heetch-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Heetch Light scheme by Geoffrey Teale (tealeg@gmail.com)
 
-color00="fe/ff/ff" # Base 00 - Black
-color01="27/d9/d5" # Base 08 - Red
-color02="f8/00/59" # Base 0B - Green
-color03="5b/a2/b6" # Base 0A - Yellow
-color04="47/f9/f5" # Base 0D - Blue
-color05="bd/01/52" # Base 0E - Magenta
-color06="c3/36/78" # Base 0C - Cyan
-color07="5a/49/6e" # Base 05 - White
-color08="9c/92/a8" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="19/01/34" # Base 07 - Bright White
-color16="bd/b6/c5" # Base 09
-color17="de/da/e2" # Base 0F
-color18="39/25/51" # Base 01
-color19="7b/6d/8b" # Base 02
-color20="dd/d6/e5" # Base 04
-color21="47/05/46" # Base 06
-color_foreground="5a/49/6e" # Base 05
-color_background="fe/ff/ff" # Base 00
+base16_color00="fe/ff/ff" # Base 00 - Black
+base16_color01="27/d9/d5" # Base 08 - Red
+base16_color02="f8/00/59" # Base 0B - Green
+base16_color03="5b/a2/b6" # Base 0A - Yellow
+base16_color04="47/f9/f5" # Base 0D - Blue
+base16_color05="bd/01/52" # Base 0E - Magenta
+base16_color06="c3/36/78" # Base 0C - Cyan
+base16_color07="5a/49/6e" # Base 05 - White
+base16_color08="9c/92/a8" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="19/01/34" # Base 07 - Bright White
+base16_color16="bd/b6/c5" # Base 09
+base16_color17="de/da/e2" # Base 0F
+base16_color18="39/25/51" # Base 01
+base16_color19="7b/6d/8b" # Base 02
+base16_color20="dd/d6/e5" # Base 04
+base16_color21="47/05/46" # Base 06
+base16_color_foreground="5a/49/6e" # Base 05
+base16_color_background="fe/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 5a496e # cursor
   put_template_custom Pm feffff # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-heetch-light.sh
+++ b/scripts/base16-heetch-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Heetch Light scheme by Geoffrey Teale (tealeg@gmail.com)
 
-base16_color00="fe/ff/ff" # Base 00 - Black
-base16_color01="27/d9/d5" # Base 08 - Red
-base16_color02="f8/00/59" # Base 0B - Green
-base16_color03="5b/a2/b6" # Base 0A - Yellow
-base16_color04="47/f9/f5" # Base 0D - Blue
-base16_color05="bd/01/52" # Base 0E - Magenta
-base16_color06="c3/36/78" # Base 0C - Cyan
-base16_color07="5a/49/6e" # Base 05 - White
-base16_color08="9c/92/a8" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="19/01/34" # Base 07 - Bright White
-base16_color16="bd/b6/c5" # Base 09
-base16_color17="de/da/e2" # Base 0F
-base16_color18="39/25/51" # Base 01
-base16_color19="7b/6d/8b" # Base 02
-base16_color20="dd/d6/e5" # Base 04
-base16_color21="47/05/46" # Base 06
-base16_color_foreground="5a/49/6e" # Base 05
-base16_color_background="fe/ff/ff" # Base 00
+export base16_color00="fe/ff/ff" # Base 00 - Black
+export base16_color01="27/d9/d5" # Base 08 - Red
+export base16_color02="f8/00/59" # Base 0B - Green
+export base16_color03="5b/a2/b6" # Base 0A - Yellow
+export base16_color04="47/f9/f5" # Base 0D - Blue
+export base16_color05="bd/01/52" # Base 0E - Magenta
+export base16_color06="c3/36/78" # Base 0C - Cyan
+export base16_color07="5a/49/6e" # Base 05 - White
+export base16_color08="9c/92/a8" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="19/01/34" # Base 07 - Bright White
+export base16_color16="bd/b6/c5" # Base 09
+export base16_color17="de/da/e2" # Base 0F
+export base16_color18="39/25/51" # Base 01
+export base16_color19="7b/6d/8b" # Base 02
+export base16_color20="dd/d6/e5" # Base 04
+export base16_color21="47/05/46" # Base 06
+export base16_color_foreground="5a/49/6e" # Base 05
+export base16_color_background="fe/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-heetch.sh
+++ b/scripts/base16-heetch.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Heetch Dark scheme by Geoffrey Teale (tealeg@gmail.com)
 
-color00="19/01/34" # Base 00 - Black
-color01="27/D9/D5" # Base 08 - Red
-color02="C3/36/78" # Base 0B - Green
-color03="8F/6C/97" # Base 0A - Yellow
-color04="BD/01/52" # Base 0D - Blue
-color05="82/03/4C" # Base 0E - Magenta
-color06="F8/00/59" # Base 0C - Cyan
-color07="BD/B6/C5" # Base 05 - White
-color08="7B/6D/8B" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FE/FF/FF" # Base 07 - Bright White
-color16="5B/A2/B6" # Base 09
-color17="47/05/46" # Base 0F
-color18="39/25/51" # Base 01
-color19="5A/49/6E" # Base 02
-color20="9C/92/A8" # Base 04
-color21="DE/DA/E2" # Base 06
-color_foreground="BD/B6/C5" # Base 05
-color_background="19/01/34" # Base 00
+base16_color00="19/01/34" # Base 00 - Black
+base16_color01="27/D9/D5" # Base 08 - Red
+base16_color02="C3/36/78" # Base 0B - Green
+base16_color03="8F/6C/97" # Base 0A - Yellow
+base16_color04="BD/01/52" # Base 0D - Blue
+base16_color05="82/03/4C" # Base 0E - Magenta
+base16_color06="F8/00/59" # Base 0C - Cyan
+base16_color07="BD/B6/C5" # Base 05 - White
+base16_color08="7B/6D/8B" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="FE/FF/FF" # Base 07 - Bright White
+base16_color16="5B/A2/B6" # Base 09
+base16_color17="47/05/46" # Base 0F
+base16_color18="39/25/51" # Base 01
+base16_color19="5A/49/6E" # Base 02
+base16_color20="9C/92/A8" # Base 04
+base16_color21="DE/DA/E2" # Base 06
+base16_color_foreground="BD/B6/C5" # Base 05
+base16_color_background="19/01/34" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl BDB6C5 # cursor
   put_template_custom Pm 190134 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-heetch.sh
+++ b/scripts/base16-heetch.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Heetch Dark scheme by Geoffrey Teale (tealeg@gmail.com)
 
-base16_color00="19/01/34" # Base 00 - Black
-base16_color01="27/D9/D5" # Base 08 - Red
-base16_color02="C3/36/78" # Base 0B - Green
-base16_color03="8F/6C/97" # Base 0A - Yellow
-base16_color04="BD/01/52" # Base 0D - Blue
-base16_color05="82/03/4C" # Base 0E - Magenta
-base16_color06="F8/00/59" # Base 0C - Cyan
-base16_color07="BD/B6/C5" # Base 05 - White
-base16_color08="7B/6D/8B" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="FE/FF/FF" # Base 07 - Bright White
-base16_color16="5B/A2/B6" # Base 09
-base16_color17="47/05/46" # Base 0F
-base16_color18="39/25/51" # Base 01
-base16_color19="5A/49/6E" # Base 02
-base16_color20="9C/92/A8" # Base 04
-base16_color21="DE/DA/E2" # Base 06
-base16_color_foreground="BD/B6/C5" # Base 05
-base16_color_background="19/01/34" # Base 00
+export base16_color00="19/01/34" # Base 00 - Black
+export base16_color01="27/D9/D5" # Base 08 - Red
+export base16_color02="C3/36/78" # Base 0B - Green
+export base16_color03="8F/6C/97" # Base 0A - Yellow
+export base16_color04="BD/01/52" # Base 0D - Blue
+export base16_color05="82/03/4C" # Base 0E - Magenta
+export base16_color06="F8/00/59" # Base 0C - Cyan
+export base16_color07="BD/B6/C5" # Base 05 - White
+export base16_color08="7B/6D/8B" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="FE/FF/FF" # Base 07 - Bright White
+export base16_color16="5B/A2/B6" # Base 09
+export base16_color17="47/05/46" # Base 0F
+export base16_color18="39/25/51" # Base 01
+export base16_color19="5A/49/6E" # Base 02
+export base16_color20="9C/92/A8" # Base 04
+export base16_color21="DE/DA/E2" # Base 06
+export base16_color_foreground="BD/B6/C5" # Base 05
+export base16_color_background="19/01/34" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-helios.sh
+++ b/scripts/base16-helios.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Helios scheme by Alex Meyer (https://github.com/reyemxela)
 
-color00="1d/20/21" # Base 00 - Black
-color01="d7/26/38" # Base 08 - Red
-color02="88/b9/2d" # Base 0B - Green
-color03="f1/9d/1a" # Base 0A - Yellow
-color04="1e/8b/ac" # Base 0D - Blue
-color05="be/42/64" # Base 0E - Magenta
-color06="1b/a5/95" # Base 0C - Cyan
-color07="d5/d5/d5" # Base 05 - White
-color08="6f/75/79" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="e5/e5/e5" # Base 07 - Bright White
-color16="eb/84/13" # Base 09
-color17="c8/5e/0d" # Base 0F
-color18="38/3c/3e" # Base 01
-color19="53/58/5b" # Base 02
-color20="cd/cd/cd" # Base 04
-color21="dd/dd/dd" # Base 06
-color_foreground="d5/d5/d5" # Base 05
-color_background="1d/20/21" # Base 00
+base16_color00="1d/20/21" # Base 00 - Black
+base16_color01="d7/26/38" # Base 08 - Red
+base16_color02="88/b9/2d" # Base 0B - Green
+base16_color03="f1/9d/1a" # Base 0A - Yellow
+base16_color04="1e/8b/ac" # Base 0D - Blue
+base16_color05="be/42/64" # Base 0E - Magenta
+base16_color06="1b/a5/95" # Base 0C - Cyan
+base16_color07="d5/d5/d5" # Base 05 - White
+base16_color08="6f/75/79" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="e5/e5/e5" # Base 07 - Bright White
+base16_color16="eb/84/13" # Base 09
+base16_color17="c8/5e/0d" # Base 0F
+base16_color18="38/3c/3e" # Base 01
+base16_color19="53/58/5b" # Base 02
+base16_color20="cd/cd/cd" # Base 04
+base16_color21="dd/dd/dd" # Base 06
+base16_color_foreground="d5/d5/d5" # Base 05
+base16_color_background="1d/20/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d5d5d5 # cursor
   put_template_custom Pm 1d2021 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-helios.sh
+++ b/scripts/base16-helios.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Helios scheme by Alex Meyer (https://github.com/reyemxela)
 
-base16_color00="1d/20/21" # Base 00 - Black
-base16_color01="d7/26/38" # Base 08 - Red
-base16_color02="88/b9/2d" # Base 0B - Green
-base16_color03="f1/9d/1a" # Base 0A - Yellow
-base16_color04="1e/8b/ac" # Base 0D - Blue
-base16_color05="be/42/64" # Base 0E - Magenta
-base16_color06="1b/a5/95" # Base 0C - Cyan
-base16_color07="d5/d5/d5" # Base 05 - White
-base16_color08="6f/75/79" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="e5/e5/e5" # Base 07 - Bright White
-base16_color16="eb/84/13" # Base 09
-base16_color17="c8/5e/0d" # Base 0F
-base16_color18="38/3c/3e" # Base 01
-base16_color19="53/58/5b" # Base 02
-base16_color20="cd/cd/cd" # Base 04
-base16_color21="dd/dd/dd" # Base 06
-base16_color_foreground="d5/d5/d5" # Base 05
-base16_color_background="1d/20/21" # Base 00
+export base16_color00="1d/20/21" # Base 00 - Black
+export base16_color01="d7/26/38" # Base 08 - Red
+export base16_color02="88/b9/2d" # Base 0B - Green
+export base16_color03="f1/9d/1a" # Base 0A - Yellow
+export base16_color04="1e/8b/ac" # Base 0D - Blue
+export base16_color05="be/42/64" # Base 0E - Magenta
+export base16_color06="1b/a5/95" # Base 0C - Cyan
+export base16_color07="d5/d5/d5" # Base 05 - White
+export base16_color08="6f/75/79" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="e5/e5/e5" # Base 07 - Bright White
+export base16_color16="eb/84/13" # Base 09
+export base16_color17="c8/5e/0d" # Base 0F
+export base16_color18="38/3c/3e" # Base 01
+export base16_color19="53/58/5b" # Base 02
+export base16_color20="cd/cd/cd" # Base 04
+export base16_color21="dd/dd/dd" # Base 06
+export base16_color_foreground="d5/d5/d5" # Base 05
+export base16_color_background="1d/20/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-hopscotch.sh
+++ b/scripts/base16-hopscotch.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Hopscotch scheme by Jan T. Sott
 
-color00="32/29/31" # Base 00 - Black
-color01="dd/46/4c" # Base 08 - Red
-color02="8f/c1/3e" # Base 0B - Green
-color03="fd/cc/59" # Base 0A - Yellow
-color04="12/90/bf" # Base 0D - Blue
-color05="c8/5e/7c" # Base 0E - Magenta
-color06="14/9b/93" # Base 0C - Cyan
-color07="b9/b5/b8" # Base 05 - White
-color08="79/73/79" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="fd/8b/19" # Base 09
-color17="b3/35/08" # Base 0F
-color18="43/3b/42" # Base 01
-color19="5c/54/5b" # Base 02
-color20="98/94/98" # Base 04
-color21="d5/d3/d5" # Base 06
-color_foreground="b9/b5/b8" # Base 05
-color_background="32/29/31" # Base 00
+base16_color00="32/29/31" # Base 00 - Black
+base16_color01="dd/46/4c" # Base 08 - Red
+base16_color02="8f/c1/3e" # Base 0B - Green
+base16_color03="fd/cc/59" # Base 0A - Yellow
+base16_color04="12/90/bf" # Base 0D - Blue
+base16_color05="c8/5e/7c" # Base 0E - Magenta
+base16_color06="14/9b/93" # Base 0C - Cyan
+base16_color07="b9/b5/b8" # Base 05 - White
+base16_color08="79/73/79" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="fd/8b/19" # Base 09
+base16_color17="b3/35/08" # Base 0F
+base16_color18="43/3b/42" # Base 01
+base16_color19="5c/54/5b" # Base 02
+base16_color20="98/94/98" # Base 04
+base16_color21="d5/d3/d5" # Base 06
+base16_color_foreground="b9/b5/b8" # Base 05
+base16_color_background="32/29/31" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl b9b5b8 # cursor
   put_template_custom Pm 322931 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-hopscotch.sh
+++ b/scripts/base16-hopscotch.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Hopscotch scheme by Jan T. Sott
 
-base16_color00="32/29/31" # Base 00 - Black
-base16_color01="dd/46/4c" # Base 08 - Red
-base16_color02="8f/c1/3e" # Base 0B - Green
-base16_color03="fd/cc/59" # Base 0A - Yellow
-base16_color04="12/90/bf" # Base 0D - Blue
-base16_color05="c8/5e/7c" # Base 0E - Magenta
-base16_color06="14/9b/93" # Base 0C - Cyan
-base16_color07="b9/b5/b8" # Base 05 - White
-base16_color08="79/73/79" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="fd/8b/19" # Base 09
-base16_color17="b3/35/08" # Base 0F
-base16_color18="43/3b/42" # Base 01
-base16_color19="5c/54/5b" # Base 02
-base16_color20="98/94/98" # Base 04
-base16_color21="d5/d3/d5" # Base 06
-base16_color_foreground="b9/b5/b8" # Base 05
-base16_color_background="32/29/31" # Base 00
+export base16_color00="32/29/31" # Base 00 - Black
+export base16_color01="dd/46/4c" # Base 08 - Red
+export base16_color02="8f/c1/3e" # Base 0B - Green
+export base16_color03="fd/cc/59" # Base 0A - Yellow
+export base16_color04="12/90/bf" # Base 0D - Blue
+export base16_color05="c8/5e/7c" # Base 0E - Magenta
+export base16_color06="14/9b/93" # Base 0C - Cyan
+export base16_color07="b9/b5/b8" # Base 05 - White
+export base16_color08="79/73/79" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="fd/8b/19" # Base 09
+export base16_color17="b3/35/08" # Base 0F
+export base16_color18="43/3b/42" # Base 01
+export base16_color19="5c/54/5b" # Base 02
+export base16_color20="98/94/98" # Base 04
+export base16_color21="d5/d3/d5" # Base 06
+export base16_color_foreground="b9/b5/b8" # Base 05
+export base16_color_background="32/29/31" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-horizon-dark.sh
+++ b/scripts/base16-horizon-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Horizon Dark scheme by Michaël Ball (http://github.com/michael-ball/)
 
-base16_color00="1C/1E/26" # Base 00 - Black
-base16_color01="E9/3C/58" # Base 08 - Red
-base16_color02="EF/AF/8E" # Base 0B - Green
-base16_color03="EF/B9/93" # Base 0A - Yellow
-base16_color04="DF/52/73" # Base 0D - Blue
-base16_color05="B0/72/D1" # Base 0E - Magenta
-base16_color06="24/A8/B4" # Base 0C - Cyan
-base16_color07="CB/CE/D0" # Base 05 - White
-base16_color08="67/6A/8D" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="E3/E6/EE" # Base 07 - Bright White
-base16_color16="E5/8D/7D" # Base 09
-base16_color17="E4/A3/82" # Base 0F
-base16_color18="23/25/30" # Base 01
-base16_color19="2E/30/3E" # Base 02
-base16_color20="CE/D1/D0" # Base 04
-base16_color21="DC/DF/E4" # Base 06
-base16_color_foreground="CB/CE/D0" # Base 05
-base16_color_background="1C/1E/26" # Base 00
+export base16_color00="1C/1E/26" # Base 00 - Black
+export base16_color01="E9/3C/58" # Base 08 - Red
+export base16_color02="EF/AF/8E" # Base 0B - Green
+export base16_color03="EF/B9/93" # Base 0A - Yellow
+export base16_color04="DF/52/73" # Base 0D - Blue
+export base16_color05="B0/72/D1" # Base 0E - Magenta
+export base16_color06="24/A8/B4" # Base 0C - Cyan
+export base16_color07="CB/CE/D0" # Base 05 - White
+export base16_color08="67/6A/8D" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="E3/E6/EE" # Base 07 - Bright White
+export base16_color16="E5/8D/7D" # Base 09
+export base16_color17="E4/A3/82" # Base 0F
+export base16_color18="23/25/30" # Base 01
+export base16_color19="2E/30/3E" # Base 02
+export base16_color20="CE/D1/D0" # Base 04
+export base16_color21="DC/DF/E4" # Base 06
+export base16_color_foreground="CB/CE/D0" # Base 05
+export base16_color_background="1C/1E/26" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-horizon-dark.sh
+++ b/scripts/base16-horizon-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Horizon Dark scheme by Michaël Ball (http://github.com/michael-ball/)
 
-color00="1C/1E/26" # Base 00 - Black
-color01="E9/3C/58" # Base 08 - Red
-color02="EF/AF/8E" # Base 0B - Green
-color03="EF/B9/93" # Base 0A - Yellow
-color04="DF/52/73" # Base 0D - Blue
-color05="B0/72/D1" # Base 0E - Magenta
-color06="24/A8/B4" # Base 0C - Cyan
-color07="CB/CE/D0" # Base 05 - White
-color08="67/6A/8D" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="E3/E6/EE" # Base 07 - Bright White
-color16="E5/8D/7D" # Base 09
-color17="E4/A3/82" # Base 0F
-color18="23/25/30" # Base 01
-color19="2E/30/3E" # Base 02
-color20="CE/D1/D0" # Base 04
-color21="DC/DF/E4" # Base 06
-color_foreground="CB/CE/D0" # Base 05
-color_background="1C/1E/26" # Base 00
+base16_color00="1C/1E/26" # Base 00 - Black
+base16_color01="E9/3C/58" # Base 08 - Red
+base16_color02="EF/AF/8E" # Base 0B - Green
+base16_color03="EF/B9/93" # Base 0A - Yellow
+base16_color04="DF/52/73" # Base 0D - Blue
+base16_color05="B0/72/D1" # Base 0E - Magenta
+base16_color06="24/A8/B4" # Base 0C - Cyan
+base16_color07="CB/CE/D0" # Base 05 - White
+base16_color08="67/6A/8D" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="E3/E6/EE" # Base 07 - Bright White
+base16_color16="E5/8D/7D" # Base 09
+base16_color17="E4/A3/82" # Base 0F
+base16_color18="23/25/30" # Base 01
+base16_color19="2E/30/3E" # Base 02
+base16_color20="CE/D1/D0" # Base 04
+base16_color21="DC/DF/E4" # Base 06
+base16_color_foreground="CB/CE/D0" # Base 05
+base16_color_background="1C/1E/26" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl CBCED0 # cursor
   put_template_custom Pm 1C1E26 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-ia-dark.sh
+++ b/scripts/base16-ia-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # iA Dark scheme by iA Inc. (modified by aramisgithub)
 
-color00="1a/1a/1a" # Base 00 - Black
-color01="d8/85/68" # Base 08 - Red
-color02="83/a4/71" # Base 0B - Green
-color03="b9/93/53" # Base 0A - Yellow
-color04="8e/cc/dd" # Base 0D - Blue
-color05="b9/8e/b2" # Base 0E - Magenta
-color06="7c/9c/ae" # Base 0C - Cyan
-color07="cc/cc/cc" # Base 05 - White
-color08="76/76/76" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/f8/f8" # Base 07 - Bright White
-color16="d8/68/68" # Base 09
-color17="8b/6c/37" # Base 0F
-color18="22/22/22" # Base 01
-color19="1d/41/4d" # Base 02
-color20="b8/b8/b8" # Base 04
-color21="e8/e8/e8" # Base 06
-color_foreground="cc/cc/cc" # Base 05
-color_background="1a/1a/1a" # Base 00
+base16_color00="1a/1a/1a" # Base 00 - Black
+base16_color01="d8/85/68" # Base 08 - Red
+base16_color02="83/a4/71" # Base 0B - Green
+base16_color03="b9/93/53" # Base 0A - Yellow
+base16_color04="8e/cc/dd" # Base 0D - Blue
+base16_color05="b9/8e/b2" # Base 0E - Magenta
+base16_color06="7c/9c/ae" # Base 0C - Cyan
+base16_color07="cc/cc/cc" # Base 05 - White
+base16_color08="76/76/76" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f8/f8/f8" # Base 07 - Bright White
+base16_color16="d8/68/68" # Base 09
+base16_color17="8b/6c/37" # Base 0F
+base16_color18="22/22/22" # Base 01
+base16_color19="1d/41/4d" # Base 02
+base16_color20="b8/b8/b8" # Base 04
+base16_color21="e8/e8/e8" # Base 06
+base16_color_foreground="cc/cc/cc" # Base 05
+base16_color_background="1a/1a/1a" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl cccccc # cursor
   put_template_custom Pm 1a1a1a # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-ia-dark.sh
+++ b/scripts/base16-ia-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # iA Dark scheme by iA Inc. (modified by aramisgithub)
 
-base16_color00="1a/1a/1a" # Base 00 - Black
-base16_color01="d8/85/68" # Base 08 - Red
-base16_color02="83/a4/71" # Base 0B - Green
-base16_color03="b9/93/53" # Base 0A - Yellow
-base16_color04="8e/cc/dd" # Base 0D - Blue
-base16_color05="b9/8e/b2" # Base 0E - Magenta
-base16_color06="7c/9c/ae" # Base 0C - Cyan
-base16_color07="cc/cc/cc" # Base 05 - White
-base16_color08="76/76/76" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f8/f8/f8" # Base 07 - Bright White
-base16_color16="d8/68/68" # Base 09
-base16_color17="8b/6c/37" # Base 0F
-base16_color18="22/22/22" # Base 01
-base16_color19="1d/41/4d" # Base 02
-base16_color20="b8/b8/b8" # Base 04
-base16_color21="e8/e8/e8" # Base 06
-base16_color_foreground="cc/cc/cc" # Base 05
-base16_color_background="1a/1a/1a" # Base 00
+export base16_color00="1a/1a/1a" # Base 00 - Black
+export base16_color01="d8/85/68" # Base 08 - Red
+export base16_color02="83/a4/71" # Base 0B - Green
+export base16_color03="b9/93/53" # Base 0A - Yellow
+export base16_color04="8e/cc/dd" # Base 0D - Blue
+export base16_color05="b9/8e/b2" # Base 0E - Magenta
+export base16_color06="7c/9c/ae" # Base 0C - Cyan
+export base16_color07="cc/cc/cc" # Base 05 - White
+export base16_color08="76/76/76" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f8/f8/f8" # Base 07 - Bright White
+export base16_color16="d8/68/68" # Base 09
+export base16_color17="8b/6c/37" # Base 0F
+export base16_color18="22/22/22" # Base 01
+export base16_color19="1d/41/4d" # Base 02
+export base16_color20="b8/b8/b8" # Base 04
+export base16_color21="e8/e8/e8" # Base 06
+export base16_color_foreground="cc/cc/cc" # Base 05
+export base16_color_background="1a/1a/1a" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-ia-light.sh
+++ b/scripts/base16-ia-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # iA Light scheme by iA Inc. (modified by aramisgithub)
 
-base16_color00="f6/f6/f6" # Base 00 - Black
-base16_color01="9c/5a/02" # Base 08 - Red
-base16_color02="38/78/1c" # Base 0B - Green
-base16_color03="c4/82/18" # Base 0A - Yellow
-base16_color04="48/ba/c2" # Base 0D - Blue
-base16_color05="a9/45/98" # Base 0E - Magenta
-base16_color06="2d/6b/b1" # Base 0C - Cyan
-base16_color07="18/18/18" # Base 05 - White
-base16_color08="89/89/89" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f8/f8/f8" # Base 07 - Bright White
-base16_color16="c4/3e/18" # Base 09
-base16_color17="8b/6c/37" # Base 0F
-base16_color18="de/de/de" # Base 01
-base16_color19="bd/e5/f2" # Base 02
-base16_color20="76/76/76" # Base 04
-base16_color21="e8/e8/e8" # Base 06
-base16_color_foreground="18/18/18" # Base 05
-base16_color_background="f6/f6/f6" # Base 00
+export base16_color00="f6/f6/f6" # Base 00 - Black
+export base16_color01="9c/5a/02" # Base 08 - Red
+export base16_color02="38/78/1c" # Base 0B - Green
+export base16_color03="c4/82/18" # Base 0A - Yellow
+export base16_color04="48/ba/c2" # Base 0D - Blue
+export base16_color05="a9/45/98" # Base 0E - Magenta
+export base16_color06="2d/6b/b1" # Base 0C - Cyan
+export base16_color07="18/18/18" # Base 05 - White
+export base16_color08="89/89/89" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f8/f8/f8" # Base 07 - Bright White
+export base16_color16="c4/3e/18" # Base 09
+export base16_color17="8b/6c/37" # Base 0F
+export base16_color18="de/de/de" # Base 01
+export base16_color19="bd/e5/f2" # Base 02
+export base16_color20="76/76/76" # Base 04
+export base16_color21="e8/e8/e8" # Base 06
+export base16_color_foreground="18/18/18" # Base 05
+export base16_color_background="f6/f6/f6" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-ia-light.sh
+++ b/scripts/base16-ia-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # iA Light scheme by iA Inc. (modified by aramisgithub)
 
-color00="f6/f6/f6" # Base 00 - Black
-color01="9c/5a/02" # Base 08 - Red
-color02="38/78/1c" # Base 0B - Green
-color03="c4/82/18" # Base 0A - Yellow
-color04="48/ba/c2" # Base 0D - Blue
-color05="a9/45/98" # Base 0E - Magenta
-color06="2d/6b/b1" # Base 0C - Cyan
-color07="18/18/18" # Base 05 - White
-color08="89/89/89" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/f8/f8" # Base 07 - Bright White
-color16="c4/3e/18" # Base 09
-color17="8b/6c/37" # Base 0F
-color18="de/de/de" # Base 01
-color19="bd/e5/f2" # Base 02
-color20="76/76/76" # Base 04
-color21="e8/e8/e8" # Base 06
-color_foreground="18/18/18" # Base 05
-color_background="f6/f6/f6" # Base 00
+base16_color00="f6/f6/f6" # Base 00 - Black
+base16_color01="9c/5a/02" # Base 08 - Red
+base16_color02="38/78/1c" # Base 0B - Green
+base16_color03="c4/82/18" # Base 0A - Yellow
+base16_color04="48/ba/c2" # Base 0D - Blue
+base16_color05="a9/45/98" # Base 0E - Magenta
+base16_color06="2d/6b/b1" # Base 0C - Cyan
+base16_color07="18/18/18" # Base 05 - White
+base16_color08="89/89/89" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f8/f8/f8" # Base 07 - Bright White
+base16_color16="c4/3e/18" # Base 09
+base16_color17="8b/6c/37" # Base 0F
+base16_color18="de/de/de" # Base 01
+base16_color19="bd/e5/f2" # Base 02
+base16_color20="76/76/76" # Base 04
+base16_color21="e8/e8/e8" # Base 06
+base16_color_foreground="18/18/18" # Base 05
+base16_color_background="f6/f6/f6" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 181818 # cursor
   put_template_custom Pm f6f6f6 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-icy.sh
+++ b/scripts/base16-icy.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Icy Dark scheme by icyphox (https://icyphox.ga)
 
-color00="02/10/12" # Base 00 - Black
-color01="16/c1/d9" # Base 08 - Red
-color02="4d/d0/e1" # Base 0B - Green
-color03="80/de/ea" # Base 0A - Yellow
-color04="00/bc/d4" # Base 0D - Blue
-color05="00/ac/c1" # Base 0E - Magenta
-color06="26/c6/da" # Base 0C - Cyan
-color07="09/5b/67" # Base 05 - White
-color08="05/2e/34" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="10/9c/b0" # Base 07 - Bright White
-color16="b3/eb/f2" # Base 09
-color17="00/97/a7" # Base 0F
-color18="03/16/19" # Base 01
-color19="04/1f/23" # Base 02
-color20="06/40/48" # Base 04
-color21="0c/7c/8c" # Base 06
-color_foreground="09/5b/67" # Base 05
-color_background="02/10/12" # Base 00
+base16_color00="02/10/12" # Base 00 - Black
+base16_color01="16/c1/d9" # Base 08 - Red
+base16_color02="4d/d0/e1" # Base 0B - Green
+base16_color03="80/de/ea" # Base 0A - Yellow
+base16_color04="00/bc/d4" # Base 0D - Blue
+base16_color05="00/ac/c1" # Base 0E - Magenta
+base16_color06="26/c6/da" # Base 0C - Cyan
+base16_color07="09/5b/67" # Base 05 - White
+base16_color08="05/2e/34" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="10/9c/b0" # Base 07 - Bright White
+base16_color16="b3/eb/f2" # Base 09
+base16_color17="00/97/a7" # Base 0F
+base16_color18="03/16/19" # Base 01
+base16_color19="04/1f/23" # Base 02
+base16_color20="06/40/48" # Base 04
+base16_color21="0c/7c/8c" # Base 06
+base16_color_foreground="09/5b/67" # Base 05
+base16_color_background="02/10/12" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 095b67 # cursor
   put_template_custom Pm 021012 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-icy.sh
+++ b/scripts/base16-icy.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Icy Dark scheme by icyphox (https://icyphox.ga)
 
-base16_color00="02/10/12" # Base 00 - Black
-base16_color01="16/c1/d9" # Base 08 - Red
-base16_color02="4d/d0/e1" # Base 0B - Green
-base16_color03="80/de/ea" # Base 0A - Yellow
-base16_color04="00/bc/d4" # Base 0D - Blue
-base16_color05="00/ac/c1" # Base 0E - Magenta
-base16_color06="26/c6/da" # Base 0C - Cyan
-base16_color07="09/5b/67" # Base 05 - White
-base16_color08="05/2e/34" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="10/9c/b0" # Base 07 - Bright White
-base16_color16="b3/eb/f2" # Base 09
-base16_color17="00/97/a7" # Base 0F
-base16_color18="03/16/19" # Base 01
-base16_color19="04/1f/23" # Base 02
-base16_color20="06/40/48" # Base 04
-base16_color21="0c/7c/8c" # Base 06
-base16_color_foreground="09/5b/67" # Base 05
-base16_color_background="02/10/12" # Base 00
+export base16_color00="02/10/12" # Base 00 - Black
+export base16_color01="16/c1/d9" # Base 08 - Red
+export base16_color02="4d/d0/e1" # Base 0B - Green
+export base16_color03="80/de/ea" # Base 0A - Yellow
+export base16_color04="00/bc/d4" # Base 0D - Blue
+export base16_color05="00/ac/c1" # Base 0E - Magenta
+export base16_color06="26/c6/da" # Base 0C - Cyan
+export base16_color07="09/5b/67" # Base 05 - White
+export base16_color08="05/2e/34" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="10/9c/b0" # Base 07 - Bright White
+export base16_color16="b3/eb/f2" # Base 09
+export base16_color17="00/97/a7" # Base 0F
+export base16_color18="03/16/19" # Base 01
+export base16_color19="04/1f/23" # Base 02
+export base16_color20="06/40/48" # Base 04
+export base16_color21="0c/7c/8c" # Base 06
+export base16_color_foreground="09/5b/67" # Base 05
+export base16_color_background="02/10/12" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-irblack.sh
+++ b/scripts/base16-irblack.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # IR Black scheme by Timothée Poisot (http://timotheepoisot.fr)
 
-color00="00/00/00" # Base 00 - Black
-color01="ff/6c/60" # Base 08 - Red
-color02="a8/ff/60" # Base 0B - Green
-color03="ff/ff/b6" # Base 0A - Yellow
-color04="96/cb/fe" # Base 0D - Blue
-color05="ff/73/fd" # Base 0E - Magenta
-color06="c6/c5/fe" # Base 0C - Cyan
-color07="b5/b3/aa" # Base 05 - White
-color08="6c/6c/66" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fd/fb/ee" # Base 07 - Bright White
-color16="e9/c0/62" # Base 09
-color17="b1/8a/3d" # Base 0F
-color18="24/24/22" # Base 01
-color19="48/48/44" # Base 02
-color20="91/8f/88" # Base 04
-color21="d9/d7/cc" # Base 06
-color_foreground="b5/b3/aa" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="ff/6c/60" # Base 08 - Red
+base16_color02="a8/ff/60" # Base 0B - Green
+base16_color03="ff/ff/b6" # Base 0A - Yellow
+base16_color04="96/cb/fe" # Base 0D - Blue
+base16_color05="ff/73/fd" # Base 0E - Magenta
+base16_color06="c6/c5/fe" # Base 0C - Cyan
+base16_color07="b5/b3/aa" # Base 05 - White
+base16_color08="6c/6c/66" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="fd/fb/ee" # Base 07 - Bright White
+base16_color16="e9/c0/62" # Base 09
+base16_color17="b1/8a/3d" # Base 0F
+base16_color18="24/24/22" # Base 01
+base16_color19="48/48/44" # Base 02
+base16_color20="91/8f/88" # Base 04
+base16_color21="d9/d7/cc" # Base 06
+base16_color_foreground="b5/b3/aa" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl b5b3aa # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-irblack.sh
+++ b/scripts/base16-irblack.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # IR Black scheme by Timothée Poisot (http://timotheepoisot.fr)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="ff/6c/60" # Base 08 - Red
-base16_color02="a8/ff/60" # Base 0B - Green
-base16_color03="ff/ff/b6" # Base 0A - Yellow
-base16_color04="96/cb/fe" # Base 0D - Blue
-base16_color05="ff/73/fd" # Base 0E - Magenta
-base16_color06="c6/c5/fe" # Base 0C - Cyan
-base16_color07="b5/b3/aa" # Base 05 - White
-base16_color08="6c/6c/66" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="fd/fb/ee" # Base 07 - Bright White
-base16_color16="e9/c0/62" # Base 09
-base16_color17="b1/8a/3d" # Base 0F
-base16_color18="24/24/22" # Base 01
-base16_color19="48/48/44" # Base 02
-base16_color20="91/8f/88" # Base 04
-base16_color21="d9/d7/cc" # Base 06
-base16_color_foreground="b5/b3/aa" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="ff/6c/60" # Base 08 - Red
+export base16_color02="a8/ff/60" # Base 0B - Green
+export base16_color03="ff/ff/b6" # Base 0A - Yellow
+export base16_color04="96/cb/fe" # Base 0D - Blue
+export base16_color05="ff/73/fd" # Base 0E - Magenta
+export base16_color06="c6/c5/fe" # Base 0C - Cyan
+export base16_color07="b5/b3/aa" # Base 05 - White
+export base16_color08="6c/6c/66" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="fd/fb/ee" # Base 07 - Bright White
+export base16_color16="e9/c0/62" # Base 09
+export base16_color17="b1/8a/3d" # Base 0F
+export base16_color18="24/24/22" # Base 01
+export base16_color19="48/48/44" # Base 02
+export base16_color20="91/8f/88" # Base 04
+export base16_color21="d9/d7/cc" # Base 06
+export base16_color_foreground="b5/b3/aa" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-isotope.sh
+++ b/scripts/base16-isotope.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Isotope scheme by Jan T. Sott
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="ff/00/00" # Base 08 - Red
-base16_color02="33/ff/00" # Base 0B - Green
-base16_color03="ff/00/99" # Base 0A - Yellow
-base16_color04="00/66/ff" # Base 0D - Blue
-base16_color05="cc/00/ff" # Base 0E - Magenta
-base16_color06="00/ff/ff" # Base 0C - Cyan
-base16_color07="d0/d0/d0" # Base 05 - White
-base16_color08="80/80/80" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="ff/99/00" # Base 09
-base16_color17="33/00/ff" # Base 0F
-base16_color18="40/40/40" # Base 01
-base16_color19="60/60/60" # Base 02
-base16_color20="c0/c0/c0" # Base 04
-base16_color21="e0/e0/e0" # Base 06
-base16_color_foreground="d0/d0/d0" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="ff/00/00" # Base 08 - Red
+export base16_color02="33/ff/00" # Base 0B - Green
+export base16_color03="ff/00/99" # Base 0A - Yellow
+export base16_color04="00/66/ff" # Base 0D - Blue
+export base16_color05="cc/00/ff" # Base 0E - Magenta
+export base16_color06="00/ff/ff" # Base 0C - Cyan
+export base16_color07="d0/d0/d0" # Base 05 - White
+export base16_color08="80/80/80" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="ff/99/00" # Base 09
+export base16_color17="33/00/ff" # Base 0F
+export base16_color18="40/40/40" # Base 01
+export base16_color19="60/60/60" # Base 02
+export base16_color20="c0/c0/c0" # Base 04
+export base16_color21="e0/e0/e0" # Base 06
+export base16_color_foreground="d0/d0/d0" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-isotope.sh
+++ b/scripts/base16-isotope.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Isotope scheme by Jan T. Sott
 
-color00="00/00/00" # Base 00 - Black
-color01="ff/00/00" # Base 08 - Red
-color02="33/ff/00" # Base 0B - Green
-color03="ff/00/99" # Base 0A - Yellow
-color04="00/66/ff" # Base 0D - Blue
-color05="cc/00/ff" # Base 0E - Magenta
-color06="00/ff/ff" # Base 0C - Cyan
-color07="d0/d0/d0" # Base 05 - White
-color08="80/80/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="ff/99/00" # Base 09
-color17="33/00/ff" # Base 0F
-color18="40/40/40" # Base 01
-color19="60/60/60" # Base 02
-color20="c0/c0/c0" # Base 04
-color21="e0/e0/e0" # Base 06
-color_foreground="d0/d0/d0" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="ff/00/00" # Base 08 - Red
+base16_color02="33/ff/00" # Base 0B - Green
+base16_color03="ff/00/99" # Base 0A - Yellow
+base16_color04="00/66/ff" # Base 0D - Blue
+base16_color05="cc/00/ff" # Base 0E - Magenta
+base16_color06="00/ff/ff" # Base 0C - Cyan
+base16_color07="d0/d0/d0" # Base 05 - White
+base16_color08="80/80/80" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="ff/99/00" # Base 09
+base16_color17="33/00/ff" # Base 0F
+base16_color18="40/40/40" # Base 01
+base16_color19="60/60/60" # Base 02
+base16_color20="c0/c0/c0" # Base 04
+base16_color21="e0/e0/e0" # Base 06
+base16_color_foreground="d0/d0/d0" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d0d0d0 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-macintosh.sh
+++ b/scripts/base16-macintosh.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Macintosh scheme by Rebecca Bettencourt (http://www.kreativekorp.com)
 
-color00="00/00/00" # Base 00 - Black
-color01="dd/09/07" # Base 08 - Red
-color02="1f/b7/14" # Base 0B - Green
-color03="fb/f3/05" # Base 0A - Yellow
-color04="00/00/d3" # Base 0D - Blue
-color05="47/00/a5" # Base 0E - Magenta
-color06="02/ab/ea" # Base 0C - Cyan
-color07="c0/c0/c0" # Base 05 - White
-color08="80/80/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="ff/64/03" # Base 09
-color17="90/71/3a" # Base 0F
-color18="40/40/40" # Base 01
-color19="40/40/40" # Base 02
-color20="80/80/80" # Base 04
-color21="c0/c0/c0" # Base 06
-color_foreground="c0/c0/c0" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="dd/09/07" # Base 08 - Red
+base16_color02="1f/b7/14" # Base 0B - Green
+base16_color03="fb/f3/05" # Base 0A - Yellow
+base16_color04="00/00/d3" # Base 0D - Blue
+base16_color05="47/00/a5" # Base 0E - Magenta
+base16_color06="02/ab/ea" # Base 0C - Cyan
+base16_color07="c0/c0/c0" # Base 05 - White
+base16_color08="80/80/80" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="ff/64/03" # Base 09
+base16_color17="90/71/3a" # Base 0F
+base16_color18="40/40/40" # Base 01
+base16_color19="40/40/40" # Base 02
+base16_color20="80/80/80" # Base 04
+base16_color21="c0/c0/c0" # Base 06
+base16_color_foreground="c0/c0/c0" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c0c0c0 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-macintosh.sh
+++ b/scripts/base16-macintosh.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Macintosh scheme by Rebecca Bettencourt (http://www.kreativekorp.com)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="dd/09/07" # Base 08 - Red
-base16_color02="1f/b7/14" # Base 0B - Green
-base16_color03="fb/f3/05" # Base 0A - Yellow
-base16_color04="00/00/d3" # Base 0D - Blue
-base16_color05="47/00/a5" # Base 0E - Magenta
-base16_color06="02/ab/ea" # Base 0C - Cyan
-base16_color07="c0/c0/c0" # Base 05 - White
-base16_color08="80/80/80" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="ff/64/03" # Base 09
-base16_color17="90/71/3a" # Base 0F
-base16_color18="40/40/40" # Base 01
-base16_color19="40/40/40" # Base 02
-base16_color20="80/80/80" # Base 04
-base16_color21="c0/c0/c0" # Base 06
-base16_color_foreground="c0/c0/c0" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="dd/09/07" # Base 08 - Red
+export base16_color02="1f/b7/14" # Base 0B - Green
+export base16_color03="fb/f3/05" # Base 0A - Yellow
+export base16_color04="00/00/d3" # Base 0D - Blue
+export base16_color05="47/00/a5" # Base 0E - Magenta
+export base16_color06="02/ab/ea" # Base 0C - Cyan
+export base16_color07="c0/c0/c0" # Base 05 - White
+export base16_color08="80/80/80" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="ff/64/03" # Base 09
+export base16_color17="90/71/3a" # Base 0F
+export base16_color18="40/40/40" # Base 01
+export base16_color19="40/40/40" # Base 02
+export base16_color20="80/80/80" # Base 04
+export base16_color21="c0/c0/c0" # Base 06
+export base16_color_foreground="c0/c0/c0" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-marrakesh.sh
+++ b/scripts/base16-marrakesh.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Marrakesh scheme by Alexandre Gavioli (http://github.com/Alexx2/)
 
-base16_color00="20/16/02" # Base 00 - Black
-base16_color01="c3/53/59" # Base 08 - Red
-base16_color02="18/97/4e" # Base 0B - Green
-base16_color03="a8/83/39" # Base 0A - Yellow
-base16_color04="47/7c/a1" # Base 0D - Blue
-base16_color05="88/68/b3" # Base 0E - Magenta
-base16_color06="75/a7/38" # Base 0C - Cyan
-base16_color07="94/8e/48" # Base 05 - White
-base16_color08="6c/68/23" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="fa/f0/a5" # Base 07 - Bright White
-base16_color16="b3/61/44" # Base 09
-base16_color17="b3/58/8e" # Base 0F
-base16_color18="30/2e/00" # Base 01
-base16_color19="5f/5b/17" # Base 02
-base16_color20="86/81/3b" # Base 04
-base16_color21="cc/c3/7a" # Base 06
-base16_color_foreground="94/8e/48" # Base 05
-base16_color_background="20/16/02" # Base 00
+export base16_color00="20/16/02" # Base 00 - Black
+export base16_color01="c3/53/59" # Base 08 - Red
+export base16_color02="18/97/4e" # Base 0B - Green
+export base16_color03="a8/83/39" # Base 0A - Yellow
+export base16_color04="47/7c/a1" # Base 0D - Blue
+export base16_color05="88/68/b3" # Base 0E - Magenta
+export base16_color06="75/a7/38" # Base 0C - Cyan
+export base16_color07="94/8e/48" # Base 05 - White
+export base16_color08="6c/68/23" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="fa/f0/a5" # Base 07 - Bright White
+export base16_color16="b3/61/44" # Base 09
+export base16_color17="b3/58/8e" # Base 0F
+export base16_color18="30/2e/00" # Base 01
+export base16_color19="5f/5b/17" # Base 02
+export base16_color20="86/81/3b" # Base 04
+export base16_color21="cc/c3/7a" # Base 06
+export base16_color_foreground="94/8e/48" # Base 05
+export base16_color_background="20/16/02" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-marrakesh.sh
+++ b/scripts/base16-marrakesh.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Marrakesh scheme by Alexandre Gavioli (http://github.com/Alexx2/)
 
-color00="20/16/02" # Base 00 - Black
-color01="c3/53/59" # Base 08 - Red
-color02="18/97/4e" # Base 0B - Green
-color03="a8/83/39" # Base 0A - Yellow
-color04="47/7c/a1" # Base 0D - Blue
-color05="88/68/b3" # Base 0E - Magenta
-color06="75/a7/38" # Base 0C - Cyan
-color07="94/8e/48" # Base 05 - White
-color08="6c/68/23" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fa/f0/a5" # Base 07 - Bright White
-color16="b3/61/44" # Base 09
-color17="b3/58/8e" # Base 0F
-color18="30/2e/00" # Base 01
-color19="5f/5b/17" # Base 02
-color20="86/81/3b" # Base 04
-color21="cc/c3/7a" # Base 06
-color_foreground="94/8e/48" # Base 05
-color_background="20/16/02" # Base 00
+base16_color00="20/16/02" # Base 00 - Black
+base16_color01="c3/53/59" # Base 08 - Red
+base16_color02="18/97/4e" # Base 0B - Green
+base16_color03="a8/83/39" # Base 0A - Yellow
+base16_color04="47/7c/a1" # Base 0D - Blue
+base16_color05="88/68/b3" # Base 0E - Magenta
+base16_color06="75/a7/38" # Base 0C - Cyan
+base16_color07="94/8e/48" # Base 05 - White
+base16_color08="6c/68/23" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="fa/f0/a5" # Base 07 - Bright White
+base16_color16="b3/61/44" # Base 09
+base16_color17="b3/58/8e" # Base 0F
+base16_color18="30/2e/00" # Base 01
+base16_color19="5f/5b/17" # Base 02
+base16_color20="86/81/3b" # Base 04
+base16_color21="cc/c3/7a" # Base 06
+base16_color_foreground="94/8e/48" # Base 05
+base16_color_background="20/16/02" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 948e48 # cursor
   put_template_custom Pm 201602 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-materia.sh
+++ b/scripts/base16-materia.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Materia scheme by Defman21
 
-color00="26/32/38" # Base 00 - Black
-color01="EC/5F/67" # Base 08 - Red
-color02="8B/D6/49" # Base 0B - Green
-color03="FF/CC/00" # Base 0A - Yellow
-color04="89/DD/FF" # Base 0D - Blue
-color05="82/AA/FF" # Base 0E - Magenta
-color06="80/CB/C4" # Base 0C - Cyan
-color07="CD/D3/DE" # Base 05 - White
-color08="70/78/80" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="EA/95/60" # Base 09
-color17="EC/5F/67" # Base 0F
-color18="2C/39/3F" # Base 01
-color19="37/47/4F" # Base 02
-color20="C9/CC/D3" # Base 04
-color21="D5/DB/E5" # Base 06
-color_foreground="CD/D3/DE" # Base 05
-color_background="26/32/38" # Base 00
+base16_color00="26/32/38" # Base 00 - Black
+base16_color01="EC/5F/67" # Base 08 - Red
+base16_color02="8B/D6/49" # Base 0B - Green
+base16_color03="FF/CC/00" # Base 0A - Yellow
+base16_color04="89/DD/FF" # Base 0D - Blue
+base16_color05="82/AA/FF" # Base 0E - Magenta
+base16_color06="80/CB/C4" # Base 0C - Cyan
+base16_color07="CD/D3/DE" # Base 05 - White
+base16_color08="70/78/80" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="FF/FF/FF" # Base 07 - Bright White
+base16_color16="EA/95/60" # Base 09
+base16_color17="EC/5F/67" # Base 0F
+base16_color18="2C/39/3F" # Base 01
+base16_color19="37/47/4F" # Base 02
+base16_color20="C9/CC/D3" # Base 04
+base16_color21="D5/DB/E5" # Base 06
+base16_color_foreground="CD/D3/DE" # Base 05
+base16_color_background="26/32/38" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl CDD3DE # cursor
   put_template_custom Pm 263238 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-materia.sh
+++ b/scripts/base16-materia.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Materia scheme by Defman21
 
-base16_color00="26/32/38" # Base 00 - Black
-base16_color01="EC/5F/67" # Base 08 - Red
-base16_color02="8B/D6/49" # Base 0B - Green
-base16_color03="FF/CC/00" # Base 0A - Yellow
-base16_color04="89/DD/FF" # Base 0D - Blue
-base16_color05="82/AA/FF" # Base 0E - Magenta
-base16_color06="80/CB/C4" # Base 0C - Cyan
-base16_color07="CD/D3/DE" # Base 05 - White
-base16_color08="70/78/80" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="FF/FF/FF" # Base 07 - Bright White
-base16_color16="EA/95/60" # Base 09
-base16_color17="EC/5F/67" # Base 0F
-base16_color18="2C/39/3F" # Base 01
-base16_color19="37/47/4F" # Base 02
-base16_color20="C9/CC/D3" # Base 04
-base16_color21="D5/DB/E5" # Base 06
-base16_color_foreground="CD/D3/DE" # Base 05
-base16_color_background="26/32/38" # Base 00
+export base16_color00="26/32/38" # Base 00 - Black
+export base16_color01="EC/5F/67" # Base 08 - Red
+export base16_color02="8B/D6/49" # Base 0B - Green
+export base16_color03="FF/CC/00" # Base 0A - Yellow
+export base16_color04="89/DD/FF" # Base 0D - Blue
+export base16_color05="82/AA/FF" # Base 0E - Magenta
+export base16_color06="80/CB/C4" # Base 0C - Cyan
+export base16_color07="CD/D3/DE" # Base 05 - White
+export base16_color08="70/78/80" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="FF/FF/FF" # Base 07 - Bright White
+export base16_color16="EA/95/60" # Base 09
+export base16_color17="EC/5F/67" # Base 0F
+export base16_color18="2C/39/3F" # Base 01
+export base16_color19="37/47/4F" # Base 02
+export base16_color20="C9/CC/D3" # Base 04
+export base16_color21="D5/DB/E5" # Base 06
+export base16_color_foreground="CD/D3/DE" # Base 05
+export base16_color_background="26/32/38" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-material-darker.sh
+++ b/scripts/base16-material-darker.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Material Darker scheme by Nate Peterson
 
-color00="21/21/21" # Base 00 - Black
-color01="F0/71/78" # Base 08 - Red
-color02="C3/E8/8D" # Base 0B - Green
-color03="FF/CB/6B" # Base 0A - Yellow
-color04="82/AA/FF" # Base 0D - Blue
-color05="C7/92/EA" # Base 0E - Magenta
-color06="89/DD/FF" # Base 0C - Cyan
-color07="EE/FF/FF" # Base 05 - White
-color08="4A/4A/4A" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="F7/8C/6C" # Base 09
-color17="FF/53/70" # Base 0F
-color18="30/30/30" # Base 01
-color19="35/35/35" # Base 02
-color20="B2/CC/D6" # Base 04
-color21="EE/FF/FF" # Base 06
-color_foreground="EE/FF/FF" # Base 05
-color_background="21/21/21" # Base 00
+base16_color00="21/21/21" # Base 00 - Black
+base16_color01="F0/71/78" # Base 08 - Red
+base16_color02="C3/E8/8D" # Base 0B - Green
+base16_color03="FF/CB/6B" # Base 0A - Yellow
+base16_color04="82/AA/FF" # Base 0D - Blue
+base16_color05="C7/92/EA" # Base 0E - Magenta
+base16_color06="89/DD/FF" # Base 0C - Cyan
+base16_color07="EE/FF/FF" # Base 05 - White
+base16_color08="4A/4A/4A" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="FF/FF/FF" # Base 07 - Bright White
+base16_color16="F7/8C/6C" # Base 09
+base16_color17="FF/53/70" # Base 0F
+base16_color18="30/30/30" # Base 01
+base16_color19="35/35/35" # Base 02
+base16_color20="B2/CC/D6" # Base 04
+base16_color21="EE/FF/FF" # Base 06
+base16_color_foreground="EE/FF/FF" # Base 05
+base16_color_background="21/21/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl EEFFFF # cursor
   put_template_custom Pm 212121 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-material-darker.sh
+++ b/scripts/base16-material-darker.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Material Darker scheme by Nate Peterson
 
-base16_color00="21/21/21" # Base 00 - Black
-base16_color01="F0/71/78" # Base 08 - Red
-base16_color02="C3/E8/8D" # Base 0B - Green
-base16_color03="FF/CB/6B" # Base 0A - Yellow
-base16_color04="82/AA/FF" # Base 0D - Blue
-base16_color05="C7/92/EA" # Base 0E - Magenta
-base16_color06="89/DD/FF" # Base 0C - Cyan
-base16_color07="EE/FF/FF" # Base 05 - White
-base16_color08="4A/4A/4A" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="FF/FF/FF" # Base 07 - Bright White
-base16_color16="F7/8C/6C" # Base 09
-base16_color17="FF/53/70" # Base 0F
-base16_color18="30/30/30" # Base 01
-base16_color19="35/35/35" # Base 02
-base16_color20="B2/CC/D6" # Base 04
-base16_color21="EE/FF/FF" # Base 06
-base16_color_foreground="EE/FF/FF" # Base 05
-base16_color_background="21/21/21" # Base 00
+export base16_color00="21/21/21" # Base 00 - Black
+export base16_color01="F0/71/78" # Base 08 - Red
+export base16_color02="C3/E8/8D" # Base 0B - Green
+export base16_color03="FF/CB/6B" # Base 0A - Yellow
+export base16_color04="82/AA/FF" # Base 0D - Blue
+export base16_color05="C7/92/EA" # Base 0E - Magenta
+export base16_color06="89/DD/FF" # Base 0C - Cyan
+export base16_color07="EE/FF/FF" # Base 05 - White
+export base16_color08="4A/4A/4A" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="FF/FF/FF" # Base 07 - Bright White
+export base16_color16="F7/8C/6C" # Base 09
+export base16_color17="FF/53/70" # Base 0F
+export base16_color18="30/30/30" # Base 01
+export base16_color19="35/35/35" # Base 02
+export base16_color20="B2/CC/D6" # Base 04
+export base16_color21="EE/FF/FF" # Base 06
+export base16_color_foreground="EE/FF/FF" # Base 05
+export base16_color_background="21/21/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-material-lighter.sh
+++ b/scripts/base16-material-lighter.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Material Lighter scheme by Nate Peterson
 
-base16_color00="FA/FA/FA" # Base 00 - Black
-base16_color01="FF/53/70" # Base 08 - Red
-base16_color02="91/B8/59" # Base 0B - Green
-base16_color03="FF/B6/2C" # Base 0A - Yellow
-base16_color04="61/82/B8" # Base 0D - Blue
-base16_color05="7C/4D/FF" # Base 0E - Magenta
-base16_color06="39/AD/B5" # Base 0C - Cyan
-base16_color07="80/CB/C4" # Base 05 - White
-base16_color08="CC/D7/DA" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="FF/FF/FF" # Base 07 - Bright White
-base16_color16="F7/6D/47" # Base 09
-base16_color17="E5/39/35" # Base 0F
-base16_color18="E7/EA/EC" # Base 01
-base16_color19="CC/EA/E7" # Base 02
-base16_color20="87/96/B0" # Base 04
-base16_color21="80/CB/C4" # Base 06
-base16_color_foreground="80/CB/C4" # Base 05
-base16_color_background="FA/FA/FA" # Base 00
+export base16_color00="FA/FA/FA" # Base 00 - Black
+export base16_color01="FF/53/70" # Base 08 - Red
+export base16_color02="91/B8/59" # Base 0B - Green
+export base16_color03="FF/B6/2C" # Base 0A - Yellow
+export base16_color04="61/82/B8" # Base 0D - Blue
+export base16_color05="7C/4D/FF" # Base 0E - Magenta
+export base16_color06="39/AD/B5" # Base 0C - Cyan
+export base16_color07="80/CB/C4" # Base 05 - White
+export base16_color08="CC/D7/DA" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="FF/FF/FF" # Base 07 - Bright White
+export base16_color16="F7/6D/47" # Base 09
+export base16_color17="E5/39/35" # Base 0F
+export base16_color18="E7/EA/EC" # Base 01
+export base16_color19="CC/EA/E7" # Base 02
+export base16_color20="87/96/B0" # Base 04
+export base16_color21="80/CB/C4" # Base 06
+export base16_color_foreground="80/CB/C4" # Base 05
+export base16_color_background="FA/FA/FA" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-material-lighter.sh
+++ b/scripts/base16-material-lighter.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Material Lighter scheme by Nate Peterson
 
-color00="FA/FA/FA" # Base 00 - Black
-color01="FF/53/70" # Base 08 - Red
-color02="91/B8/59" # Base 0B - Green
-color03="FF/B6/2C" # Base 0A - Yellow
-color04="61/82/B8" # Base 0D - Blue
-color05="7C/4D/FF" # Base 0E - Magenta
-color06="39/AD/B5" # Base 0C - Cyan
-color07="80/CB/C4" # Base 05 - White
-color08="CC/D7/DA" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="F7/6D/47" # Base 09
-color17="E5/39/35" # Base 0F
-color18="E7/EA/EC" # Base 01
-color19="CC/EA/E7" # Base 02
-color20="87/96/B0" # Base 04
-color21="80/CB/C4" # Base 06
-color_foreground="80/CB/C4" # Base 05
-color_background="FA/FA/FA" # Base 00
+base16_color00="FA/FA/FA" # Base 00 - Black
+base16_color01="FF/53/70" # Base 08 - Red
+base16_color02="91/B8/59" # Base 0B - Green
+base16_color03="FF/B6/2C" # Base 0A - Yellow
+base16_color04="61/82/B8" # Base 0D - Blue
+base16_color05="7C/4D/FF" # Base 0E - Magenta
+base16_color06="39/AD/B5" # Base 0C - Cyan
+base16_color07="80/CB/C4" # Base 05 - White
+base16_color08="CC/D7/DA" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="FF/FF/FF" # Base 07 - Bright White
+base16_color16="F7/6D/47" # Base 09
+base16_color17="E5/39/35" # Base 0F
+base16_color18="E7/EA/EC" # Base 01
+base16_color19="CC/EA/E7" # Base 02
+base16_color20="87/96/B0" # Base 04
+base16_color21="80/CB/C4" # Base 06
+base16_color_foreground="80/CB/C4" # Base 05
+base16_color_background="FA/FA/FA" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 80CBC4 # cursor
   put_template_custom Pm FAFAFA # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-material-palenight.sh
+++ b/scripts/base16-material-palenight.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Material Palenight scheme by Nate Peterson
 
-color00="29/2D/3E" # Base 00 - Black
-color01="F0/71/78" # Base 08 - Red
-color02="C3/E8/8D" # Base 0B - Green
-color03="FF/CB/6B" # Base 0A - Yellow
-color04="82/AA/FF" # Base 0D - Blue
-color05="C7/92/EA" # Base 0E - Magenta
-color06="89/DD/FF" # Base 0C - Cyan
-color07="95/9D/CB" # Base 05 - White
-color08="67/6E/95" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="F7/8C/6C" # Base 09
-color17="FF/53/70" # Base 0F
-color18="44/42/67" # Base 01
-color19="32/37/4D" # Base 02
-color20="87/96/B0" # Base 04
-color21="95/9D/CB" # Base 06
-color_foreground="95/9D/CB" # Base 05
-color_background="29/2D/3E" # Base 00
+base16_color00="29/2D/3E" # Base 00 - Black
+base16_color01="F0/71/78" # Base 08 - Red
+base16_color02="C3/E8/8D" # Base 0B - Green
+base16_color03="FF/CB/6B" # Base 0A - Yellow
+base16_color04="82/AA/FF" # Base 0D - Blue
+base16_color05="C7/92/EA" # Base 0E - Magenta
+base16_color06="89/DD/FF" # Base 0C - Cyan
+base16_color07="95/9D/CB" # Base 05 - White
+base16_color08="67/6E/95" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="FF/FF/FF" # Base 07 - Bright White
+base16_color16="F7/8C/6C" # Base 09
+base16_color17="FF/53/70" # Base 0F
+base16_color18="44/42/67" # Base 01
+base16_color19="32/37/4D" # Base 02
+base16_color20="87/96/B0" # Base 04
+base16_color21="95/9D/CB" # Base 06
+base16_color_foreground="95/9D/CB" # Base 05
+base16_color_background="29/2D/3E" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 959DCB # cursor
   put_template_custom Pm 292D3E # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-material-palenight.sh
+++ b/scripts/base16-material-palenight.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Material Palenight scheme by Nate Peterson
 
-base16_color00="29/2D/3E" # Base 00 - Black
-base16_color01="F0/71/78" # Base 08 - Red
-base16_color02="C3/E8/8D" # Base 0B - Green
-base16_color03="FF/CB/6B" # Base 0A - Yellow
-base16_color04="82/AA/FF" # Base 0D - Blue
-base16_color05="C7/92/EA" # Base 0E - Magenta
-base16_color06="89/DD/FF" # Base 0C - Cyan
-base16_color07="95/9D/CB" # Base 05 - White
-base16_color08="67/6E/95" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="FF/FF/FF" # Base 07 - Bright White
-base16_color16="F7/8C/6C" # Base 09
-base16_color17="FF/53/70" # Base 0F
-base16_color18="44/42/67" # Base 01
-base16_color19="32/37/4D" # Base 02
-base16_color20="87/96/B0" # Base 04
-base16_color21="95/9D/CB" # Base 06
-base16_color_foreground="95/9D/CB" # Base 05
-base16_color_background="29/2D/3E" # Base 00
+export base16_color00="29/2D/3E" # Base 00 - Black
+export base16_color01="F0/71/78" # Base 08 - Red
+export base16_color02="C3/E8/8D" # Base 0B - Green
+export base16_color03="FF/CB/6B" # Base 0A - Yellow
+export base16_color04="82/AA/FF" # Base 0D - Blue
+export base16_color05="C7/92/EA" # Base 0E - Magenta
+export base16_color06="89/DD/FF" # Base 0C - Cyan
+export base16_color07="95/9D/CB" # Base 05 - White
+export base16_color08="67/6E/95" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="FF/FF/FF" # Base 07 - Bright White
+export base16_color16="F7/8C/6C" # Base 09
+export base16_color17="FF/53/70" # Base 0F
+export base16_color18="44/42/67" # Base 01
+export base16_color19="32/37/4D" # Base 02
+export base16_color20="87/96/B0" # Base 04
+export base16_color21="95/9D/CB" # Base 06
+export base16_color_foreground="95/9D/CB" # Base 05
+export base16_color_background="29/2D/3E" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-material-vivid.sh
+++ b/scripts/base16-material-vivid.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Material Vivid scheme by joshyrobot
 
-base16_color00="20/21/24" # Base 00 - Black
-base16_color01="f4/43/36" # Base 08 - Red
-base16_color02="00/e6/76" # Base 0B - Green
-base16_color03="ff/eb/3b" # Base 0A - Yellow
-base16_color04="21/96/f3" # Base 0D - Blue
-base16_color05="67/3a/b7" # Base 0E - Magenta
-base16_color06="00/bc/d4" # Base 0C - Cyan
-base16_color07="80/86/8b" # Base 05 - White
-base16_color08="44/46/4d" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="ff/98/00" # Base 09
-base16_color17="8d/6e/63" # Base 0F
-base16_color18="27/29/2c" # Base 01
-base16_color19="32/36/39" # Base 02
-base16_color20="67/6c/71" # Base 04
-base16_color21="9e/9e/9e" # Base 06
-base16_color_foreground="80/86/8b" # Base 05
-base16_color_background="20/21/24" # Base 00
+export base16_color00="20/21/24" # Base 00 - Black
+export base16_color01="f4/43/36" # Base 08 - Red
+export base16_color02="00/e6/76" # Base 0B - Green
+export base16_color03="ff/eb/3b" # Base 0A - Yellow
+export base16_color04="21/96/f3" # Base 0D - Blue
+export base16_color05="67/3a/b7" # Base 0E - Magenta
+export base16_color06="00/bc/d4" # Base 0C - Cyan
+export base16_color07="80/86/8b" # Base 05 - White
+export base16_color08="44/46/4d" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="ff/98/00" # Base 09
+export base16_color17="8d/6e/63" # Base 0F
+export base16_color18="27/29/2c" # Base 01
+export base16_color19="32/36/39" # Base 02
+export base16_color20="67/6c/71" # Base 04
+export base16_color21="9e/9e/9e" # Base 06
+export base16_color_foreground="80/86/8b" # Base 05
+export base16_color_background="20/21/24" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-material-vivid.sh
+++ b/scripts/base16-material-vivid.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Material Vivid scheme by joshyrobot
 
-color00="20/21/24" # Base 00 - Black
-color01="f4/43/36" # Base 08 - Red
-color02="00/e6/76" # Base 0B - Green
-color03="ff/eb/3b" # Base 0A - Yellow
-color04="21/96/f3" # Base 0D - Blue
-color05="67/3a/b7" # Base 0E - Magenta
-color06="00/bc/d4" # Base 0C - Cyan
-color07="80/86/8b" # Base 05 - White
-color08="44/46/4d" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="ff/98/00" # Base 09
-color17="8d/6e/63" # Base 0F
-color18="27/29/2c" # Base 01
-color19="32/36/39" # Base 02
-color20="67/6c/71" # Base 04
-color21="9e/9e/9e" # Base 06
-color_foreground="80/86/8b" # Base 05
-color_background="20/21/24" # Base 00
+base16_color00="20/21/24" # Base 00 - Black
+base16_color01="f4/43/36" # Base 08 - Red
+base16_color02="00/e6/76" # Base 0B - Green
+base16_color03="ff/eb/3b" # Base 0A - Yellow
+base16_color04="21/96/f3" # Base 0D - Blue
+base16_color05="67/3a/b7" # Base 0E - Magenta
+base16_color06="00/bc/d4" # Base 0C - Cyan
+base16_color07="80/86/8b" # Base 05 - White
+base16_color08="44/46/4d" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="ff/98/00" # Base 09
+base16_color17="8d/6e/63" # Base 0F
+base16_color18="27/29/2c" # Base 01
+base16_color19="32/36/39" # Base 02
+base16_color20="67/6c/71" # Base 04
+base16_color21="9e/9e/9e" # Base 06
+base16_color_foreground="80/86/8b" # Base 05
+base16_color_background="20/21/24" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 80868b # cursor
   put_template_custom Pm 202124 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-material.sh
+++ b/scripts/base16-material.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Material scheme by Nate Peterson
 
-base16_color00="26/32/38" # Base 00 - Black
-base16_color01="F0/71/78" # Base 08 - Red
-base16_color02="C3/E8/8D" # Base 0B - Green
-base16_color03="FF/CB/6B" # Base 0A - Yellow
-base16_color04="82/AA/FF" # Base 0D - Blue
-base16_color05="C7/92/EA" # Base 0E - Magenta
-base16_color06="89/DD/FF" # Base 0C - Cyan
-base16_color07="EE/FF/FF" # Base 05 - White
-base16_color08="54/6E/7A" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="FF/FF/FF" # Base 07 - Bright White
-base16_color16="F7/8C/6C" # Base 09
-base16_color17="FF/53/70" # Base 0F
-base16_color18="2E/3C/43" # Base 01
-base16_color19="31/45/49" # Base 02
-base16_color20="B2/CC/D6" # Base 04
-base16_color21="EE/FF/FF" # Base 06
-base16_color_foreground="EE/FF/FF" # Base 05
-base16_color_background="26/32/38" # Base 00
+export base16_color00="26/32/38" # Base 00 - Black
+export base16_color01="F0/71/78" # Base 08 - Red
+export base16_color02="C3/E8/8D" # Base 0B - Green
+export base16_color03="FF/CB/6B" # Base 0A - Yellow
+export base16_color04="82/AA/FF" # Base 0D - Blue
+export base16_color05="C7/92/EA" # Base 0E - Magenta
+export base16_color06="89/DD/FF" # Base 0C - Cyan
+export base16_color07="EE/FF/FF" # Base 05 - White
+export base16_color08="54/6E/7A" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="FF/FF/FF" # Base 07 - Bright White
+export base16_color16="F7/8C/6C" # Base 09
+export base16_color17="FF/53/70" # Base 0F
+export base16_color18="2E/3C/43" # Base 01
+export base16_color19="31/45/49" # Base 02
+export base16_color20="B2/CC/D6" # Base 04
+export base16_color21="EE/FF/FF" # Base 06
+export base16_color_foreground="EE/FF/FF" # Base 05
+export base16_color_background="26/32/38" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-material.sh
+++ b/scripts/base16-material.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Material scheme by Nate Peterson
 
-color00="26/32/38" # Base 00 - Black
-color01="F0/71/78" # Base 08 - Red
-color02="C3/E8/8D" # Base 0B - Green
-color03="FF/CB/6B" # Base 0A - Yellow
-color04="82/AA/FF" # Base 0D - Blue
-color05="C7/92/EA" # Base 0E - Magenta
-color06="89/DD/FF" # Base 0C - Cyan
-color07="EE/FF/FF" # Base 05 - White
-color08="54/6E/7A" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="F7/8C/6C" # Base 09
-color17="FF/53/70" # Base 0F
-color18="2E/3C/43" # Base 01
-color19="31/45/49" # Base 02
-color20="B2/CC/D6" # Base 04
-color21="EE/FF/FF" # Base 06
-color_foreground="EE/FF/FF" # Base 05
-color_background="26/32/38" # Base 00
+base16_color00="26/32/38" # Base 00 - Black
+base16_color01="F0/71/78" # Base 08 - Red
+base16_color02="C3/E8/8D" # Base 0B - Green
+base16_color03="FF/CB/6B" # Base 0A - Yellow
+base16_color04="82/AA/FF" # Base 0D - Blue
+base16_color05="C7/92/EA" # Base 0E - Magenta
+base16_color06="89/DD/FF" # Base 0C - Cyan
+base16_color07="EE/FF/FF" # Base 05 - White
+base16_color08="54/6E/7A" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="FF/FF/FF" # Base 07 - Bright White
+base16_color16="F7/8C/6C" # Base 09
+base16_color17="FF/53/70" # Base 0F
+base16_color18="2E/3C/43" # Base 01
+base16_color19="31/45/49" # Base 02
+base16_color20="B2/CC/D6" # Base 04
+base16_color21="EE/FF/FF" # Base 06
+base16_color_foreground="EE/FF/FF" # Base 05
+base16_color_background="26/32/38" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl EEFFFF # cursor
   put_template_custom Pm 263238 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-mellow-purple.sh
+++ b/scripts/base16-mellow-purple.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Mellow Purple scheme by gidsi
 
-color00="1e/05/28" # Base 00 - Black
-color01="00/d9/e9" # Base 08 - Red
-color02="05/cb/0d" # Base 0B - Green
-color03="95/5a/e7" # Base 0A - Yellow
-color04="55/00/68" # Base 0D - Blue
-color05="89/91/bb" # Base 0E - Magenta
-color06="b9/00/b1" # Base 0C - Cyan
-color07="ff/ee/ff" # Base 05 - White
-color08="32/0f/55" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/c0/ff" # Base 07 - Bright White
-color16="aa/00/a3" # Base 09
-color17="4d/6f/ff" # Base 0F
-color18="1A/09/2D" # Base 01
-color19="33/13/54" # Base 02
-color20="87/35/82" # Base 04
-color21="ff/ee/ff" # Base 06
-color_foreground="ff/ee/ff" # Base 05
-color_background="1e/05/28" # Base 00
+base16_color00="1e/05/28" # Base 00 - Black
+base16_color01="00/d9/e9" # Base 08 - Red
+base16_color02="05/cb/0d" # Base 0B - Green
+base16_color03="95/5a/e7" # Base 0A - Yellow
+base16_color04="55/00/68" # Base 0D - Blue
+base16_color05="89/91/bb" # Base 0E - Magenta
+base16_color06="b9/00/b1" # Base 0C - Cyan
+base16_color07="ff/ee/ff" # Base 05 - White
+base16_color08="32/0f/55" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f8/c0/ff" # Base 07 - Bright White
+base16_color16="aa/00/a3" # Base 09
+base16_color17="4d/6f/ff" # Base 0F
+base16_color18="1A/09/2D" # Base 01
+base16_color19="33/13/54" # Base 02
+base16_color20="87/35/82" # Base 04
+base16_color21="ff/ee/ff" # Base 06
+base16_color_foreground="ff/ee/ff" # Base 05
+base16_color_background="1e/05/28" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl ffeeff # cursor
   put_template_custom Pm 1e0528 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-mellow-purple.sh
+++ b/scripts/base16-mellow-purple.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Mellow Purple scheme by gidsi
 
-base16_color00="1e/05/28" # Base 00 - Black
-base16_color01="00/d9/e9" # Base 08 - Red
-base16_color02="05/cb/0d" # Base 0B - Green
-base16_color03="95/5a/e7" # Base 0A - Yellow
-base16_color04="55/00/68" # Base 0D - Blue
-base16_color05="89/91/bb" # Base 0E - Magenta
-base16_color06="b9/00/b1" # Base 0C - Cyan
-base16_color07="ff/ee/ff" # Base 05 - White
-base16_color08="32/0f/55" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f8/c0/ff" # Base 07 - Bright White
-base16_color16="aa/00/a3" # Base 09
-base16_color17="4d/6f/ff" # Base 0F
-base16_color18="1A/09/2D" # Base 01
-base16_color19="33/13/54" # Base 02
-base16_color20="87/35/82" # Base 04
-base16_color21="ff/ee/ff" # Base 06
-base16_color_foreground="ff/ee/ff" # Base 05
-base16_color_background="1e/05/28" # Base 00
+export base16_color00="1e/05/28" # Base 00 - Black
+export base16_color01="00/d9/e9" # Base 08 - Red
+export base16_color02="05/cb/0d" # Base 0B - Green
+export base16_color03="95/5a/e7" # Base 0A - Yellow
+export base16_color04="55/00/68" # Base 0D - Blue
+export base16_color05="89/91/bb" # Base 0E - Magenta
+export base16_color06="b9/00/b1" # Base 0C - Cyan
+export base16_color07="ff/ee/ff" # Base 05 - White
+export base16_color08="32/0f/55" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f8/c0/ff" # Base 07 - Bright White
+export base16_color16="aa/00/a3" # Base 09
+export base16_color17="4d/6f/ff" # Base 0F
+export base16_color18="1A/09/2D" # Base 01
+export base16_color19="33/13/54" # Base 02
+export base16_color20="87/35/82" # Base 04
+export base16_color21="ff/ee/ff" # Base 06
+export base16_color_foreground="ff/ee/ff" # Base 05
+export base16_color_background="1e/05/28" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-mexico-light.sh
+++ b/scripts/base16-mexico-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Mexico Light scheme by Sheldon Johnson
 
-base16_color00="f8/f8/f8" # Base 00 - Black
-base16_color01="ab/46/42" # Base 08 - Red
-base16_color02="53/89/47" # Base 0B - Green
-base16_color03="f7/9a/0e" # Base 0A - Yellow
-base16_color04="7c/af/c2" # Base 0D - Blue
-base16_color05="96/60/9e" # Base 0E - Magenta
-base16_color06="4b/80/93" # Base 0C - Cyan
-base16_color07="38/38/38" # Base 05 - White
-base16_color08="b8/b8/b8" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="18/18/18" # Base 07 - Bright White
-base16_color16="dc/96/56" # Base 09
-base16_color17="a1/69/46" # Base 0F
-base16_color18="e8/e8/e8" # Base 01
-base16_color19="d8/d8/d8" # Base 02
-base16_color20="58/58/58" # Base 04
-base16_color21="28/28/28" # Base 06
-base16_color_foreground="38/38/38" # Base 05
-base16_color_background="f8/f8/f8" # Base 00
+export base16_color00="f8/f8/f8" # Base 00 - Black
+export base16_color01="ab/46/42" # Base 08 - Red
+export base16_color02="53/89/47" # Base 0B - Green
+export base16_color03="f7/9a/0e" # Base 0A - Yellow
+export base16_color04="7c/af/c2" # Base 0D - Blue
+export base16_color05="96/60/9e" # Base 0E - Magenta
+export base16_color06="4b/80/93" # Base 0C - Cyan
+export base16_color07="38/38/38" # Base 05 - White
+export base16_color08="b8/b8/b8" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="18/18/18" # Base 07 - Bright White
+export base16_color16="dc/96/56" # Base 09
+export base16_color17="a1/69/46" # Base 0F
+export base16_color18="e8/e8/e8" # Base 01
+export base16_color19="d8/d8/d8" # Base 02
+export base16_color20="58/58/58" # Base 04
+export base16_color21="28/28/28" # Base 06
+export base16_color_foreground="38/38/38" # Base 05
+export base16_color_background="f8/f8/f8" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-mexico-light.sh
+++ b/scripts/base16-mexico-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Mexico Light scheme by Sheldon Johnson
 
-color00="f8/f8/f8" # Base 00 - Black
-color01="ab/46/42" # Base 08 - Red
-color02="53/89/47" # Base 0B - Green
-color03="f7/9a/0e" # Base 0A - Yellow
-color04="7c/af/c2" # Base 0D - Blue
-color05="96/60/9e" # Base 0E - Magenta
-color06="4b/80/93" # Base 0C - Cyan
-color07="38/38/38" # Base 05 - White
-color08="b8/b8/b8" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="18/18/18" # Base 07 - Bright White
-color16="dc/96/56" # Base 09
-color17="a1/69/46" # Base 0F
-color18="e8/e8/e8" # Base 01
-color19="d8/d8/d8" # Base 02
-color20="58/58/58" # Base 04
-color21="28/28/28" # Base 06
-color_foreground="38/38/38" # Base 05
-color_background="f8/f8/f8" # Base 00
+base16_color00="f8/f8/f8" # Base 00 - Black
+base16_color01="ab/46/42" # Base 08 - Red
+base16_color02="53/89/47" # Base 0B - Green
+base16_color03="f7/9a/0e" # Base 0A - Yellow
+base16_color04="7c/af/c2" # Base 0D - Blue
+base16_color05="96/60/9e" # Base 0E - Magenta
+base16_color06="4b/80/93" # Base 0C - Cyan
+base16_color07="38/38/38" # Base 05 - White
+base16_color08="b8/b8/b8" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="18/18/18" # Base 07 - Bright White
+base16_color16="dc/96/56" # Base 09
+base16_color17="a1/69/46" # Base 0F
+base16_color18="e8/e8/e8" # Base 01
+base16_color19="d8/d8/d8" # Base 02
+base16_color20="58/58/58" # Base 04
+base16_color21="28/28/28" # Base 06
+base16_color_foreground="38/38/38" # Base 05
+base16_color_background="f8/f8/f8" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 383838 # cursor
   put_template_custom Pm f8f8f8 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-mocha.sh
+++ b/scripts/base16-mocha.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Mocha scheme by Chris Kempson (http://chriskempson.com)
 
-color00="3B/32/28" # Base 00 - Black
-color01="cb/60/77" # Base 08 - Red
-color02="be/b5/5b" # Base 0B - Green
-color03="f4/bc/87" # Base 0A - Yellow
-color04="8a/b3/b5" # Base 0D - Blue
-color05="a8/9b/b9" # Base 0E - Magenta
-color06="7b/bd/a4" # Base 0C - Cyan
-color07="d0/c8/c6" # Base 05 - White
-color08="7e/70/5a" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f5/ee/eb" # Base 07 - Bright White
-color16="d2/8b/71" # Base 09
-color17="bb/95/84" # Base 0F
-color18="53/46/36" # Base 01
-color19="64/52/40" # Base 02
-color20="b8/af/ad" # Base 04
-color21="e9/e1/dd" # Base 06
-color_foreground="d0/c8/c6" # Base 05
-color_background="3B/32/28" # Base 00
+base16_color00="3B/32/28" # Base 00 - Black
+base16_color01="cb/60/77" # Base 08 - Red
+base16_color02="be/b5/5b" # Base 0B - Green
+base16_color03="f4/bc/87" # Base 0A - Yellow
+base16_color04="8a/b3/b5" # Base 0D - Blue
+base16_color05="a8/9b/b9" # Base 0E - Magenta
+base16_color06="7b/bd/a4" # Base 0C - Cyan
+base16_color07="d0/c8/c6" # Base 05 - White
+base16_color08="7e/70/5a" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f5/ee/eb" # Base 07 - Bright White
+base16_color16="d2/8b/71" # Base 09
+base16_color17="bb/95/84" # Base 0F
+base16_color18="53/46/36" # Base 01
+base16_color19="64/52/40" # Base 02
+base16_color20="b8/af/ad" # Base 04
+base16_color21="e9/e1/dd" # Base 06
+base16_color_foreground="d0/c8/c6" # Base 05
+base16_color_background="3B/32/28" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d0c8c6 # cursor
   put_template_custom Pm 3B3228 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-mocha.sh
+++ b/scripts/base16-mocha.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Mocha scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="3B/32/28" # Base 00 - Black
-base16_color01="cb/60/77" # Base 08 - Red
-base16_color02="be/b5/5b" # Base 0B - Green
-base16_color03="f4/bc/87" # Base 0A - Yellow
-base16_color04="8a/b3/b5" # Base 0D - Blue
-base16_color05="a8/9b/b9" # Base 0E - Magenta
-base16_color06="7b/bd/a4" # Base 0C - Cyan
-base16_color07="d0/c8/c6" # Base 05 - White
-base16_color08="7e/70/5a" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f5/ee/eb" # Base 07 - Bright White
-base16_color16="d2/8b/71" # Base 09
-base16_color17="bb/95/84" # Base 0F
-base16_color18="53/46/36" # Base 01
-base16_color19="64/52/40" # Base 02
-base16_color20="b8/af/ad" # Base 04
-base16_color21="e9/e1/dd" # Base 06
-base16_color_foreground="d0/c8/c6" # Base 05
-base16_color_background="3B/32/28" # Base 00
+export base16_color00="3B/32/28" # Base 00 - Black
+export base16_color01="cb/60/77" # Base 08 - Red
+export base16_color02="be/b5/5b" # Base 0B - Green
+export base16_color03="f4/bc/87" # Base 0A - Yellow
+export base16_color04="8a/b3/b5" # Base 0D - Blue
+export base16_color05="a8/9b/b9" # Base 0E - Magenta
+export base16_color06="7b/bd/a4" # Base 0C - Cyan
+export base16_color07="d0/c8/c6" # Base 05 - White
+export base16_color08="7e/70/5a" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f5/ee/eb" # Base 07 - Bright White
+export base16_color16="d2/8b/71" # Base 09
+export base16_color17="bb/95/84" # Base 0F
+export base16_color18="53/46/36" # Base 01
+export base16_color19="64/52/40" # Base 02
+export base16_color20="b8/af/ad" # Base 04
+export base16_color21="e9/e1/dd" # Base 06
+export base16_color_foreground="d0/c8/c6" # Base 05
+export base16_color_background="3B/32/28" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-monokai.sh
+++ b/scripts/base16-monokai.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Monokai scheme by Wimer Hazenberg (http://www.monokai.nl)
 
-color00="27/28/22" # Base 00 - Black
-color01="f9/26/72" # Base 08 - Red
-color02="a6/e2/2e" # Base 0B - Green
-color03="f4/bf/75" # Base 0A - Yellow
-color04="66/d9/ef" # Base 0D - Blue
-color05="ae/81/ff" # Base 0E - Magenta
-color06="a1/ef/e4" # Base 0C - Cyan
-color07="f8/f8/f2" # Base 05 - White
-color08="75/71/5e" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f9/f8/f5" # Base 07 - Bright White
-color16="fd/97/1f" # Base 09
-color17="cc/66/33" # Base 0F
-color18="38/38/30" # Base 01
-color19="49/48/3e" # Base 02
-color20="a5/9f/85" # Base 04
-color21="f5/f4/f1" # Base 06
-color_foreground="f8/f8/f2" # Base 05
-color_background="27/28/22" # Base 00
+base16_color00="27/28/22" # Base 00 - Black
+base16_color01="f9/26/72" # Base 08 - Red
+base16_color02="a6/e2/2e" # Base 0B - Green
+base16_color03="f4/bf/75" # Base 0A - Yellow
+base16_color04="66/d9/ef" # Base 0D - Blue
+base16_color05="ae/81/ff" # Base 0E - Magenta
+base16_color06="a1/ef/e4" # Base 0C - Cyan
+base16_color07="f8/f8/f2" # Base 05 - White
+base16_color08="75/71/5e" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f9/f8/f5" # Base 07 - Bright White
+base16_color16="fd/97/1f" # Base 09
+base16_color17="cc/66/33" # Base 0F
+base16_color18="38/38/30" # Base 01
+base16_color19="49/48/3e" # Base 02
+base16_color20="a5/9f/85" # Base 04
+base16_color21="f5/f4/f1" # Base 06
+base16_color_foreground="f8/f8/f2" # Base 05
+base16_color_background="27/28/22" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl f8f8f2 # cursor
   put_template_custom Pm 272822 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-monokai.sh
+++ b/scripts/base16-monokai.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Monokai scheme by Wimer Hazenberg (http://www.monokai.nl)
 
-base16_color00="27/28/22" # Base 00 - Black
-base16_color01="f9/26/72" # Base 08 - Red
-base16_color02="a6/e2/2e" # Base 0B - Green
-base16_color03="f4/bf/75" # Base 0A - Yellow
-base16_color04="66/d9/ef" # Base 0D - Blue
-base16_color05="ae/81/ff" # Base 0E - Magenta
-base16_color06="a1/ef/e4" # Base 0C - Cyan
-base16_color07="f8/f8/f2" # Base 05 - White
-base16_color08="75/71/5e" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f9/f8/f5" # Base 07 - Bright White
-base16_color16="fd/97/1f" # Base 09
-base16_color17="cc/66/33" # Base 0F
-base16_color18="38/38/30" # Base 01
-base16_color19="49/48/3e" # Base 02
-base16_color20="a5/9f/85" # Base 04
-base16_color21="f5/f4/f1" # Base 06
-base16_color_foreground="f8/f8/f2" # Base 05
-base16_color_background="27/28/22" # Base 00
+export base16_color00="27/28/22" # Base 00 - Black
+export base16_color01="f9/26/72" # Base 08 - Red
+export base16_color02="a6/e2/2e" # Base 0B - Green
+export base16_color03="f4/bf/75" # Base 0A - Yellow
+export base16_color04="66/d9/ef" # Base 0D - Blue
+export base16_color05="ae/81/ff" # Base 0E - Magenta
+export base16_color06="a1/ef/e4" # Base 0C - Cyan
+export base16_color07="f8/f8/f2" # Base 05 - White
+export base16_color08="75/71/5e" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f9/f8/f5" # Base 07 - Bright White
+export base16_color16="fd/97/1f" # Base 09
+export base16_color17="cc/66/33" # Base 0F
+export base16_color18="38/38/30" # Base 01
+export base16_color19="49/48/3e" # Base 02
+export base16_color20="a5/9f/85" # Base 04
+export base16_color21="f5/f4/f1" # Base 06
+export base16_color_foreground="f8/f8/f2" # Base 05
+export base16_color_background="27/28/22" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-nord.sh
+++ b/scripts/base16-nord.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Nord scheme by arcticicestudio
 
-base16_color00="2E/34/40" # Base 00 - Black
-base16_color01="88/C0/D0" # Base 08 - Red
-base16_color02="BF/61/6A" # Base 0B - Green
-base16_color03="5E/81/AC" # Base 0A - Yellow
-base16_color04="EB/CB/8B" # Base 0D - Blue
-base16_color05="A3/BE/8C" # Base 0E - Magenta
-base16_color06="D0/87/70" # Base 0C - Cyan
-base16_color07="E5/E9/F0" # Base 05 - White
-base16_color08="4C/56/6A" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="8F/BC/BB" # Base 07 - Bright White
-base16_color16="81/A1/C1" # Base 09
-base16_color17="B4/8E/AD" # Base 0F
-base16_color18="3B/42/52" # Base 01
-base16_color19="43/4C/5E" # Base 02
-base16_color20="D8/DE/E9" # Base 04
-base16_color21="EC/EF/F4" # Base 06
-base16_color_foreground="E5/E9/F0" # Base 05
-base16_color_background="2E/34/40" # Base 00
+export base16_color00="2E/34/40" # Base 00 - Black
+export base16_color01="88/C0/D0" # Base 08 - Red
+export base16_color02="BF/61/6A" # Base 0B - Green
+export base16_color03="5E/81/AC" # Base 0A - Yellow
+export base16_color04="EB/CB/8B" # Base 0D - Blue
+export base16_color05="A3/BE/8C" # Base 0E - Magenta
+export base16_color06="D0/87/70" # Base 0C - Cyan
+export base16_color07="E5/E9/F0" # Base 05 - White
+export base16_color08="4C/56/6A" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="8F/BC/BB" # Base 07 - Bright White
+export base16_color16="81/A1/C1" # Base 09
+export base16_color17="B4/8E/AD" # Base 0F
+export base16_color18="3B/42/52" # Base 01
+export base16_color19="43/4C/5E" # Base 02
+export base16_color20="D8/DE/E9" # Base 04
+export base16_color21="EC/EF/F4" # Base 06
+export base16_color_foreground="E5/E9/F0" # Base 05
+export base16_color_background="2E/34/40" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-nord.sh
+++ b/scripts/base16-nord.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Nord scheme by arcticicestudio
 
-color00="2E/34/40" # Base 00 - Black
-color01="88/C0/D0" # Base 08 - Red
-color02="BF/61/6A" # Base 0B - Green
-color03="5E/81/AC" # Base 0A - Yellow
-color04="EB/CB/8B" # Base 0D - Blue
-color05="A3/BE/8C" # Base 0E - Magenta
-color06="D0/87/70" # Base 0C - Cyan
-color07="E5/E9/F0" # Base 05 - White
-color08="4C/56/6A" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="8F/BC/BB" # Base 07 - Bright White
-color16="81/A1/C1" # Base 09
-color17="B4/8E/AD" # Base 0F
-color18="3B/42/52" # Base 01
-color19="43/4C/5E" # Base 02
-color20="D8/DE/E9" # Base 04
-color21="EC/EF/F4" # Base 06
-color_foreground="E5/E9/F0" # Base 05
-color_background="2E/34/40" # Base 00
+base16_color00="2E/34/40" # Base 00 - Black
+base16_color01="88/C0/D0" # Base 08 - Red
+base16_color02="BF/61/6A" # Base 0B - Green
+base16_color03="5E/81/AC" # Base 0A - Yellow
+base16_color04="EB/CB/8B" # Base 0D - Blue
+base16_color05="A3/BE/8C" # Base 0E - Magenta
+base16_color06="D0/87/70" # Base 0C - Cyan
+base16_color07="E5/E9/F0" # Base 05 - White
+base16_color08="4C/56/6A" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="8F/BC/BB" # Base 07 - Bright White
+base16_color16="81/A1/C1" # Base 09
+base16_color17="B4/8E/AD" # Base 0F
+base16_color18="3B/42/52" # Base 01
+base16_color19="43/4C/5E" # Base 02
+base16_color20="D8/DE/E9" # Base 04
+base16_color21="EC/EF/F4" # Base 06
+base16_color_foreground="E5/E9/F0" # Base 05
+base16_color_background="2E/34/40" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl E5E9F0 # cursor
   put_template_custom Pm 2E3440 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-ocean.sh
+++ b/scripts/base16-ocean.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Ocean scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="2b/30/3b" # Base 00 - Black
-base16_color01="bf/61/6a" # Base 08 - Red
-base16_color02="a3/be/8c" # Base 0B - Green
-base16_color03="eb/cb/8b" # Base 0A - Yellow
-base16_color04="8f/a1/b3" # Base 0D - Blue
-base16_color05="b4/8e/ad" # Base 0E - Magenta
-base16_color06="96/b5/b4" # Base 0C - Cyan
-base16_color07="c0/c5/ce" # Base 05 - White
-base16_color08="65/73/7e" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ef/f1/f5" # Base 07 - Bright White
-base16_color16="d0/87/70" # Base 09
-base16_color17="ab/79/67" # Base 0F
-base16_color18="34/3d/46" # Base 01
-base16_color19="4f/5b/66" # Base 02
-base16_color20="a7/ad/ba" # Base 04
-base16_color21="df/e1/e8" # Base 06
-base16_color_foreground="c0/c5/ce" # Base 05
-base16_color_background="2b/30/3b" # Base 00
+export base16_color00="2b/30/3b" # Base 00 - Black
+export base16_color01="bf/61/6a" # Base 08 - Red
+export base16_color02="a3/be/8c" # Base 0B - Green
+export base16_color03="eb/cb/8b" # Base 0A - Yellow
+export base16_color04="8f/a1/b3" # Base 0D - Blue
+export base16_color05="b4/8e/ad" # Base 0E - Magenta
+export base16_color06="96/b5/b4" # Base 0C - Cyan
+export base16_color07="c0/c5/ce" # Base 05 - White
+export base16_color08="65/73/7e" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ef/f1/f5" # Base 07 - Bright White
+export base16_color16="d0/87/70" # Base 09
+export base16_color17="ab/79/67" # Base 0F
+export base16_color18="34/3d/46" # Base 01
+export base16_color19="4f/5b/66" # Base 02
+export base16_color20="a7/ad/ba" # Base 04
+export base16_color21="df/e1/e8" # Base 06
+export base16_color_foreground="c0/c5/ce" # Base 05
+export base16_color_background="2b/30/3b" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-ocean.sh
+++ b/scripts/base16-ocean.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Ocean scheme by Chris Kempson (http://chriskempson.com)
 
-color00="2b/30/3b" # Base 00 - Black
-color01="bf/61/6a" # Base 08 - Red
-color02="a3/be/8c" # Base 0B - Green
-color03="eb/cb/8b" # Base 0A - Yellow
-color04="8f/a1/b3" # Base 0D - Blue
-color05="b4/8e/ad" # Base 0E - Magenta
-color06="96/b5/b4" # Base 0C - Cyan
-color07="c0/c5/ce" # Base 05 - White
-color08="65/73/7e" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ef/f1/f5" # Base 07 - Bright White
-color16="d0/87/70" # Base 09
-color17="ab/79/67" # Base 0F
-color18="34/3d/46" # Base 01
-color19="4f/5b/66" # Base 02
-color20="a7/ad/ba" # Base 04
-color21="df/e1/e8" # Base 06
-color_foreground="c0/c5/ce" # Base 05
-color_background="2b/30/3b" # Base 00
+base16_color00="2b/30/3b" # Base 00 - Black
+base16_color01="bf/61/6a" # Base 08 - Red
+base16_color02="a3/be/8c" # Base 0B - Green
+base16_color03="eb/cb/8b" # Base 0A - Yellow
+base16_color04="8f/a1/b3" # Base 0D - Blue
+base16_color05="b4/8e/ad" # Base 0E - Magenta
+base16_color06="96/b5/b4" # Base 0C - Cyan
+base16_color07="c0/c5/ce" # Base 05 - White
+base16_color08="65/73/7e" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ef/f1/f5" # Base 07 - Bright White
+base16_color16="d0/87/70" # Base 09
+base16_color17="ab/79/67" # Base 0F
+base16_color18="34/3d/46" # Base 01
+base16_color19="4f/5b/66" # Base 02
+base16_color20="a7/ad/ba" # Base 04
+base16_color21="df/e1/e8" # Base 06
+base16_color_foreground="c0/c5/ce" # Base 05
+base16_color_background="2b/30/3b" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c0c5ce # cursor
   put_template_custom Pm 2b303b # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-oceanicnext.sh
+++ b/scripts/base16-oceanicnext.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # OceanicNext scheme by https://github.com/voronianski/oceanic-next-color-scheme
 
-color00="1B/2B/34" # Base 00 - Black
-color01="EC/5f/67" # Base 08 - Red
-color02="99/C7/94" # Base 0B - Green
-color03="FA/C8/63" # Base 0A - Yellow
-color04="66/99/CC" # Base 0D - Blue
-color05="C5/94/C5" # Base 0E - Magenta
-color06="5F/B3/B3" # Base 0C - Cyan
-color07="C0/C5/CE" # Base 05 - White
-color08="65/73/7E" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="D8/DE/E9" # Base 07 - Bright White
-color16="F9/91/57" # Base 09
-color17="AB/79/67" # Base 0F
-color18="34/3D/46" # Base 01
-color19="4F/5B/66" # Base 02
-color20="A7/AD/BA" # Base 04
-color21="CD/D3/DE" # Base 06
-color_foreground="C0/C5/CE" # Base 05
-color_background="1B/2B/34" # Base 00
+base16_color00="1B/2B/34" # Base 00 - Black
+base16_color01="EC/5f/67" # Base 08 - Red
+base16_color02="99/C7/94" # Base 0B - Green
+base16_color03="FA/C8/63" # Base 0A - Yellow
+base16_color04="66/99/CC" # Base 0D - Blue
+base16_color05="C5/94/C5" # Base 0E - Magenta
+base16_color06="5F/B3/B3" # Base 0C - Cyan
+base16_color07="C0/C5/CE" # Base 05 - White
+base16_color08="65/73/7E" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="D8/DE/E9" # Base 07 - Bright White
+base16_color16="F9/91/57" # Base 09
+base16_color17="AB/79/67" # Base 0F
+base16_color18="34/3D/46" # Base 01
+base16_color19="4F/5B/66" # Base 02
+base16_color20="A7/AD/BA" # Base 04
+base16_color21="CD/D3/DE" # Base 06
+base16_color_foreground="C0/C5/CE" # Base 05
+base16_color_background="1B/2B/34" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl C0C5CE # cursor
   put_template_custom Pm 1B2B34 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-oceanicnext.sh
+++ b/scripts/base16-oceanicnext.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # OceanicNext scheme by https://github.com/voronianski/oceanic-next-color-scheme
 
-base16_color00="1B/2B/34" # Base 00 - Black
-base16_color01="EC/5f/67" # Base 08 - Red
-base16_color02="99/C7/94" # Base 0B - Green
-base16_color03="FA/C8/63" # Base 0A - Yellow
-base16_color04="66/99/CC" # Base 0D - Blue
-base16_color05="C5/94/C5" # Base 0E - Magenta
-base16_color06="5F/B3/B3" # Base 0C - Cyan
-base16_color07="C0/C5/CE" # Base 05 - White
-base16_color08="65/73/7E" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="D8/DE/E9" # Base 07 - Bright White
-base16_color16="F9/91/57" # Base 09
-base16_color17="AB/79/67" # Base 0F
-base16_color18="34/3D/46" # Base 01
-base16_color19="4F/5B/66" # Base 02
-base16_color20="A7/AD/BA" # Base 04
-base16_color21="CD/D3/DE" # Base 06
-base16_color_foreground="C0/C5/CE" # Base 05
-base16_color_background="1B/2B/34" # Base 00
+export base16_color00="1B/2B/34" # Base 00 - Black
+export base16_color01="EC/5f/67" # Base 08 - Red
+export base16_color02="99/C7/94" # Base 0B - Green
+export base16_color03="FA/C8/63" # Base 0A - Yellow
+export base16_color04="66/99/CC" # Base 0D - Blue
+export base16_color05="C5/94/C5" # Base 0E - Magenta
+export base16_color06="5F/B3/B3" # Base 0C - Cyan
+export base16_color07="C0/C5/CE" # Base 05 - White
+export base16_color08="65/73/7E" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="D8/DE/E9" # Base 07 - Bright White
+export base16_color16="F9/91/57" # Base 09
+export base16_color17="AB/79/67" # Base 0F
+export base16_color18="34/3D/46" # Base 01
+export base16_color19="4F/5B/66" # Base 02
+export base16_color20="A7/AD/BA" # Base 04
+export base16_color21="CD/D3/DE" # Base 06
+export base16_color_foreground="C0/C5/CE" # Base 05
+export base16_color_background="1B/2B/34" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-one-light.sh
+++ b/scripts/base16-one-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # One Light scheme by Daniel Pfeifer (http://github.com/purpleKarrot)
 
-color00="fa/fa/fa" # Base 00 - Black
-color01="ca/12/43" # Base 08 - Red
-color02="50/a1/4f" # Base 0B - Green
-color03="c1/84/01" # Base 0A - Yellow
-color04="40/78/f2" # Base 0D - Blue
-color05="a6/26/a4" # Base 0E - Magenta
-color06="01/84/bc" # Base 0C - Cyan
-color07="38/3a/42" # Base 05 - White
-color08="a0/a1/a7" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="09/0a/0b" # Base 07 - Bright White
-color16="d7/5f/00" # Base 09
-color17="98/68/01" # Base 0F
-color18="f0/f0/f1" # Base 01
-color19="e5/e5/e6" # Base 02
-color20="69/6c/77" # Base 04
-color21="20/22/27" # Base 06
-color_foreground="38/3a/42" # Base 05
-color_background="fa/fa/fa" # Base 00
+base16_color00="fa/fa/fa" # Base 00 - Black
+base16_color01="ca/12/43" # Base 08 - Red
+base16_color02="50/a1/4f" # Base 0B - Green
+base16_color03="c1/84/01" # Base 0A - Yellow
+base16_color04="40/78/f2" # Base 0D - Blue
+base16_color05="a6/26/a4" # Base 0E - Magenta
+base16_color06="01/84/bc" # Base 0C - Cyan
+base16_color07="38/3a/42" # Base 05 - White
+base16_color08="a0/a1/a7" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="09/0a/0b" # Base 07 - Bright White
+base16_color16="d7/5f/00" # Base 09
+base16_color17="98/68/01" # Base 0F
+base16_color18="f0/f0/f1" # Base 01
+base16_color19="e5/e5/e6" # Base 02
+base16_color20="69/6c/77" # Base 04
+base16_color21="20/22/27" # Base 06
+base16_color_foreground="38/3a/42" # Base 05
+base16_color_background="fa/fa/fa" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 383a42 # cursor
   put_template_custom Pm fafafa # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-one-light.sh
+++ b/scripts/base16-one-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # One Light scheme by Daniel Pfeifer (http://github.com/purpleKarrot)
 
-base16_color00="fa/fa/fa" # Base 00 - Black
-base16_color01="ca/12/43" # Base 08 - Red
-base16_color02="50/a1/4f" # Base 0B - Green
-base16_color03="c1/84/01" # Base 0A - Yellow
-base16_color04="40/78/f2" # Base 0D - Blue
-base16_color05="a6/26/a4" # Base 0E - Magenta
-base16_color06="01/84/bc" # Base 0C - Cyan
-base16_color07="38/3a/42" # Base 05 - White
-base16_color08="a0/a1/a7" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="09/0a/0b" # Base 07 - Bright White
-base16_color16="d7/5f/00" # Base 09
-base16_color17="98/68/01" # Base 0F
-base16_color18="f0/f0/f1" # Base 01
-base16_color19="e5/e5/e6" # Base 02
-base16_color20="69/6c/77" # Base 04
-base16_color21="20/22/27" # Base 06
-base16_color_foreground="38/3a/42" # Base 05
-base16_color_background="fa/fa/fa" # Base 00
+export base16_color00="fa/fa/fa" # Base 00 - Black
+export base16_color01="ca/12/43" # Base 08 - Red
+export base16_color02="50/a1/4f" # Base 0B - Green
+export base16_color03="c1/84/01" # Base 0A - Yellow
+export base16_color04="40/78/f2" # Base 0D - Blue
+export base16_color05="a6/26/a4" # Base 0E - Magenta
+export base16_color06="01/84/bc" # Base 0C - Cyan
+export base16_color07="38/3a/42" # Base 05 - White
+export base16_color08="a0/a1/a7" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="09/0a/0b" # Base 07 - Bright White
+export base16_color16="d7/5f/00" # Base 09
+export base16_color17="98/68/01" # Base 0F
+export base16_color18="f0/f0/f1" # Base 01
+export base16_color19="e5/e5/e6" # Base 02
+export base16_color20="69/6c/77" # Base 04
+export base16_color21="20/22/27" # Base 06
+export base16_color_foreground="38/3a/42" # Base 05
+export base16_color_background="fa/fa/fa" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-onedark.sh
+++ b/scripts/base16-onedark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # OneDark scheme by Lalit Magant (http://github.com/tilal6991)
 
-base16_color00="28/2c/34" # Base 00 - Black
-base16_color01="e0/6c/75" # Base 08 - Red
-base16_color02="98/c3/79" # Base 0B - Green
-base16_color03="e5/c0/7b" # Base 0A - Yellow
-base16_color04="61/af/ef" # Base 0D - Blue
-base16_color05="c6/78/dd" # Base 0E - Magenta
-base16_color06="56/b6/c2" # Base 0C - Cyan
-base16_color07="ab/b2/bf" # Base 05 - White
-base16_color08="54/58/62" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="c8/cc/d4" # Base 07 - Bright White
-base16_color16="d1/9a/66" # Base 09
-base16_color17="be/50/46" # Base 0F
-base16_color18="35/3b/45" # Base 01
-base16_color19="3e/44/51" # Base 02
-base16_color20="56/5c/64" # Base 04
-base16_color21="b6/bd/ca" # Base 06
-base16_color_foreground="ab/b2/bf" # Base 05
-base16_color_background="28/2c/34" # Base 00
+export base16_color00="28/2c/34" # Base 00 - Black
+export base16_color01="e0/6c/75" # Base 08 - Red
+export base16_color02="98/c3/79" # Base 0B - Green
+export base16_color03="e5/c0/7b" # Base 0A - Yellow
+export base16_color04="61/af/ef" # Base 0D - Blue
+export base16_color05="c6/78/dd" # Base 0E - Magenta
+export base16_color06="56/b6/c2" # Base 0C - Cyan
+export base16_color07="ab/b2/bf" # Base 05 - White
+export base16_color08="54/58/62" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="c8/cc/d4" # Base 07 - Bright White
+export base16_color16="d1/9a/66" # Base 09
+export base16_color17="be/50/46" # Base 0F
+export base16_color18="35/3b/45" # Base 01
+export base16_color19="3e/44/51" # Base 02
+export base16_color20="56/5c/64" # Base 04
+export base16_color21="b6/bd/ca" # Base 06
+export base16_color_foreground="ab/b2/bf" # Base 05
+export base16_color_background="28/2c/34" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-onedark.sh
+++ b/scripts/base16-onedark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # OneDark scheme by Lalit Magant (http://github.com/tilal6991)
 
-color00="28/2c/34" # Base 00 - Black
-color01="e0/6c/75" # Base 08 - Red
-color02="98/c3/79" # Base 0B - Green
-color03="e5/c0/7b" # Base 0A - Yellow
-color04="61/af/ef" # Base 0D - Blue
-color05="c6/78/dd" # Base 0E - Magenta
-color06="56/b6/c2" # Base 0C - Cyan
-color07="ab/b2/bf" # Base 05 - White
-color08="54/58/62" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="c8/cc/d4" # Base 07 - Bright White
-color16="d1/9a/66" # Base 09
-color17="be/50/46" # Base 0F
-color18="35/3b/45" # Base 01
-color19="3e/44/51" # Base 02
-color20="56/5c/64" # Base 04
-color21="b6/bd/ca" # Base 06
-color_foreground="ab/b2/bf" # Base 05
-color_background="28/2c/34" # Base 00
+base16_color00="28/2c/34" # Base 00 - Black
+base16_color01="e0/6c/75" # Base 08 - Red
+base16_color02="98/c3/79" # Base 0B - Green
+base16_color03="e5/c0/7b" # Base 0A - Yellow
+base16_color04="61/af/ef" # Base 0D - Blue
+base16_color05="c6/78/dd" # Base 0E - Magenta
+base16_color06="56/b6/c2" # Base 0C - Cyan
+base16_color07="ab/b2/bf" # Base 05 - White
+base16_color08="54/58/62" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="c8/cc/d4" # Base 07 - Bright White
+base16_color16="d1/9a/66" # Base 09
+base16_color17="be/50/46" # Base 0F
+base16_color18="35/3b/45" # Base 01
+base16_color19="3e/44/51" # Base 02
+base16_color20="56/5c/64" # Base 04
+base16_color21="b6/bd/ca" # Base 06
+base16_color_foreground="ab/b2/bf" # Base 05
+base16_color_background="28/2c/34" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl abb2bf # cursor
   put_template_custom Pm 282c34 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-outrun-dark.sh
+++ b/scripts/base16-outrun-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Outrun Dark scheme by Hugo Delahousse (http://github.com/hugodelahousse/)
 
-color00="00/00/2A" # Base 00 - Black
-color01="FF/42/42" # Base 08 - Red
-color02="59/F1/76" # Base 0B - Green
-color03="F3/E8/77" # Base 0A - Yellow
-color04="66/B0/FF" # Base 0D - Blue
-color05="F1/05/96" # Base 0E - Magenta
-color06="0E/F0/F0" # Base 0C - Cyan
-color07="D0/D0/FA" # Base 05 - White
-color08="50/50/7A" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="F5/F5/FF" # Base 07 - Bright White
-color16="FC/8D/28" # Base 09
-color17="F0/03/EF" # Base 0F
-color18="20/20/4A" # Base 01
-color19="30/30/5A" # Base 02
-color20="B0/B0/DA" # Base 04
-color21="E0/E0/FF" # Base 06
-color_foreground="D0/D0/FA" # Base 05
-color_background="00/00/2A" # Base 00
+base16_color00="00/00/2A" # Base 00 - Black
+base16_color01="FF/42/42" # Base 08 - Red
+base16_color02="59/F1/76" # Base 0B - Green
+base16_color03="F3/E8/77" # Base 0A - Yellow
+base16_color04="66/B0/FF" # Base 0D - Blue
+base16_color05="F1/05/96" # Base 0E - Magenta
+base16_color06="0E/F0/F0" # Base 0C - Cyan
+base16_color07="D0/D0/FA" # Base 05 - White
+base16_color08="50/50/7A" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="F5/F5/FF" # Base 07 - Bright White
+base16_color16="FC/8D/28" # Base 09
+base16_color17="F0/03/EF" # Base 0F
+base16_color18="20/20/4A" # Base 01
+base16_color19="30/30/5A" # Base 02
+base16_color20="B0/B0/DA" # Base 04
+base16_color21="E0/E0/FF" # Base 06
+base16_color_foreground="D0/D0/FA" # Base 05
+base16_color_background="00/00/2A" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl D0D0FA # cursor
   put_template_custom Pm 00002A # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-outrun-dark.sh
+++ b/scripts/base16-outrun-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Outrun Dark scheme by Hugo Delahousse (http://github.com/hugodelahousse/)
 
-base16_color00="00/00/2A" # Base 00 - Black
-base16_color01="FF/42/42" # Base 08 - Red
-base16_color02="59/F1/76" # Base 0B - Green
-base16_color03="F3/E8/77" # Base 0A - Yellow
-base16_color04="66/B0/FF" # Base 0D - Blue
-base16_color05="F1/05/96" # Base 0E - Magenta
-base16_color06="0E/F0/F0" # Base 0C - Cyan
-base16_color07="D0/D0/FA" # Base 05 - White
-base16_color08="50/50/7A" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="F5/F5/FF" # Base 07 - Bright White
-base16_color16="FC/8D/28" # Base 09
-base16_color17="F0/03/EF" # Base 0F
-base16_color18="20/20/4A" # Base 01
-base16_color19="30/30/5A" # Base 02
-base16_color20="B0/B0/DA" # Base 04
-base16_color21="E0/E0/FF" # Base 06
-base16_color_foreground="D0/D0/FA" # Base 05
-base16_color_background="00/00/2A" # Base 00
+export base16_color00="00/00/2A" # Base 00 - Black
+export base16_color01="FF/42/42" # Base 08 - Red
+export base16_color02="59/F1/76" # Base 0B - Green
+export base16_color03="F3/E8/77" # Base 0A - Yellow
+export base16_color04="66/B0/FF" # Base 0D - Blue
+export base16_color05="F1/05/96" # Base 0E - Magenta
+export base16_color06="0E/F0/F0" # Base 0C - Cyan
+export base16_color07="D0/D0/FA" # Base 05 - White
+export base16_color08="50/50/7A" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="F5/F5/FF" # Base 07 - Bright White
+export base16_color16="FC/8D/28" # Base 09
+export base16_color17="F0/03/EF" # Base 0F
+export base16_color18="20/20/4A" # Base 01
+export base16_color19="30/30/5A" # Base 02
+export base16_color20="B0/B0/DA" # Base 04
+export base16_color21="E0/E0/FF" # Base 06
+export base16_color_foreground="D0/D0/FA" # Base 05
+export base16_color_background="00/00/2A" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-papercolor-dark.sh
+++ b/scripts/base16-papercolor-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # PaperColor Dark scheme by Jon Leopard (http://github.com/jonleopard) based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 
-color00="1c/1c/1c" # Base 00 - Black
-color01="58/58/58" # Base 08 - Red
-color02="af/87/d7" # Base 0B - Green
-color03="af/d7/00" # Base 0A - Yellow
-color04="ff/5f/af" # Base 0D - Blue
-color05="00/af/af" # Base 0E - Magenta
-color06="ff/af/00" # Base 0C - Cyan
-color07="80/80/80" # Base 05 - White
-color08="d7/af/5f" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="d0/d0/d0" # Base 07 - Bright White
-color16="5f/af/5f" # Base 09
-color17="5f/87/87" # Base 0F
-color18="af/00/5f" # Base 01
-color19="5f/af/00" # Base 02
-color20="5f/af/d7" # Base 04
-color21="d7/87/5f" # Base 06
-color_foreground="80/80/80" # Base 05
-color_background="1c/1c/1c" # Base 00
+base16_color00="1c/1c/1c" # Base 00 - Black
+base16_color01="58/58/58" # Base 08 - Red
+base16_color02="af/87/d7" # Base 0B - Green
+base16_color03="af/d7/00" # Base 0A - Yellow
+base16_color04="ff/5f/af" # Base 0D - Blue
+base16_color05="00/af/af" # Base 0E - Magenta
+base16_color06="ff/af/00" # Base 0C - Cyan
+base16_color07="80/80/80" # Base 05 - White
+base16_color08="d7/af/5f" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="d0/d0/d0" # Base 07 - Bright White
+base16_color16="5f/af/5f" # Base 09
+base16_color17="5f/87/87" # Base 0F
+base16_color18="af/00/5f" # Base 01
+base16_color19="5f/af/00" # Base 02
+base16_color20="5f/af/d7" # Base 04
+base16_color21="d7/87/5f" # Base 06
+base16_color_foreground="80/80/80" # Base 05
+base16_color_background="1c/1c/1c" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 808080 # cursor
   put_template_custom Pm 1c1c1c # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-papercolor-dark.sh
+++ b/scripts/base16-papercolor-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # PaperColor Dark scheme by Jon Leopard (http://github.com/jonleopard) based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 
-base16_color00="1c/1c/1c" # Base 00 - Black
-base16_color01="58/58/58" # Base 08 - Red
-base16_color02="af/87/d7" # Base 0B - Green
-base16_color03="af/d7/00" # Base 0A - Yellow
-base16_color04="ff/5f/af" # Base 0D - Blue
-base16_color05="00/af/af" # Base 0E - Magenta
-base16_color06="ff/af/00" # Base 0C - Cyan
-base16_color07="80/80/80" # Base 05 - White
-base16_color08="d7/af/5f" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="d0/d0/d0" # Base 07 - Bright White
-base16_color16="5f/af/5f" # Base 09
-base16_color17="5f/87/87" # Base 0F
-base16_color18="af/00/5f" # Base 01
-base16_color19="5f/af/00" # Base 02
-base16_color20="5f/af/d7" # Base 04
-base16_color21="d7/87/5f" # Base 06
-base16_color_foreground="80/80/80" # Base 05
-base16_color_background="1c/1c/1c" # Base 00
+export base16_color00="1c/1c/1c" # Base 00 - Black
+export base16_color01="58/58/58" # Base 08 - Red
+export base16_color02="af/87/d7" # Base 0B - Green
+export base16_color03="af/d7/00" # Base 0A - Yellow
+export base16_color04="ff/5f/af" # Base 0D - Blue
+export base16_color05="00/af/af" # Base 0E - Magenta
+export base16_color06="ff/af/00" # Base 0C - Cyan
+export base16_color07="80/80/80" # Base 05 - White
+export base16_color08="d7/af/5f" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="d0/d0/d0" # Base 07 - Bright White
+export base16_color16="5f/af/5f" # Base 09
+export base16_color17="5f/87/87" # Base 0F
+export base16_color18="af/00/5f" # Base 01
+export base16_color19="5f/af/00" # Base 02
+export base16_color20="5f/af/d7" # Base 04
+export base16_color21="d7/87/5f" # Base 06
+export base16_color_foreground="80/80/80" # Base 05
+export base16_color_background="1c/1c/1c" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-papercolor-light.sh
+++ b/scripts/base16-papercolor-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # PaperColor Light scheme by Jon Leopard (http://github.com/jonleopard) based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 
-color00="ee/ee/ee" # Base 00 - Black
-color01="bc/bc/bc" # Base 08 - Red
-color02="87/00/af" # Base 0B - Green
-color03="d7/00/87" # Base 0A - Yellow
-color04="d7/5f/00" # Base 0D - Blue
-color05="00/5f/af" # Base 0E - Magenta
-color06="d7/5f/00" # Base 0C - Cyan
-color07="87/87/87" # Base 05 - White
-color08="5f/87/00" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="44/44/44" # Base 07 - Bright White
-color16="d7/00/00" # Base 09
-color17="00/5f/87" # Base 0F
-color18="af/00/00" # Base 01
-color19="00/87/00" # Base 02
-color20="00/87/af" # Base 04
-color21="00/5f/87" # Base 06
-color_foreground="87/87/87" # Base 05
-color_background="ee/ee/ee" # Base 00
+base16_color00="ee/ee/ee" # Base 00 - Black
+base16_color01="bc/bc/bc" # Base 08 - Red
+base16_color02="87/00/af" # Base 0B - Green
+base16_color03="d7/00/87" # Base 0A - Yellow
+base16_color04="d7/5f/00" # Base 0D - Blue
+base16_color05="00/5f/af" # Base 0E - Magenta
+base16_color06="d7/5f/00" # Base 0C - Cyan
+base16_color07="87/87/87" # Base 05 - White
+base16_color08="5f/87/00" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="44/44/44" # Base 07 - Bright White
+base16_color16="d7/00/00" # Base 09
+base16_color17="00/5f/87" # Base 0F
+base16_color18="af/00/00" # Base 01
+base16_color19="00/87/00" # Base 02
+base16_color20="00/87/af" # Base 04
+base16_color21="00/5f/87" # Base 06
+base16_color_foreground="87/87/87" # Base 05
+base16_color_background="ee/ee/ee" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 878787 # cursor
   put_template_custom Pm eeeeee # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-papercolor-light.sh
+++ b/scripts/base16-papercolor-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # PaperColor Light scheme by Jon Leopard (http://github.com/jonleopard) based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 
-base16_color00="ee/ee/ee" # Base 00 - Black
-base16_color01="bc/bc/bc" # Base 08 - Red
-base16_color02="87/00/af" # Base 0B - Green
-base16_color03="d7/00/87" # Base 0A - Yellow
-base16_color04="d7/5f/00" # Base 0D - Blue
-base16_color05="00/5f/af" # Base 0E - Magenta
-base16_color06="d7/5f/00" # Base 0C - Cyan
-base16_color07="87/87/87" # Base 05 - White
-base16_color08="5f/87/00" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="44/44/44" # Base 07 - Bright White
-base16_color16="d7/00/00" # Base 09
-base16_color17="00/5f/87" # Base 0F
-base16_color18="af/00/00" # Base 01
-base16_color19="00/87/00" # Base 02
-base16_color20="00/87/af" # Base 04
-base16_color21="00/5f/87" # Base 06
-base16_color_foreground="87/87/87" # Base 05
-base16_color_background="ee/ee/ee" # Base 00
+export base16_color00="ee/ee/ee" # Base 00 - Black
+export base16_color01="bc/bc/bc" # Base 08 - Red
+export base16_color02="87/00/af" # Base 0B - Green
+export base16_color03="d7/00/87" # Base 0A - Yellow
+export base16_color04="d7/5f/00" # Base 0D - Blue
+export base16_color05="00/5f/af" # Base 0E - Magenta
+export base16_color06="d7/5f/00" # Base 0C - Cyan
+export base16_color07="87/87/87" # Base 05 - White
+export base16_color08="5f/87/00" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="44/44/44" # Base 07 - Bright White
+export base16_color16="d7/00/00" # Base 09
+export base16_color17="00/5f/87" # Base 0F
+export base16_color18="af/00/00" # Base 01
+export base16_color19="00/87/00" # Base 02
+export base16_color20="00/87/af" # Base 04
+export base16_color21="00/5f/87" # Base 06
+export base16_color_foreground="87/87/87" # Base 05
+export base16_color_background="ee/ee/ee" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-paraiso.sh
+++ b/scripts/base16-paraiso.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Paraiso scheme by Jan T. Sott
 
-base16_color00="2f/1e/2e" # Base 00 - Black
-base16_color01="ef/61/55" # Base 08 - Red
-base16_color02="48/b6/85" # Base 0B - Green
-base16_color03="fe/c4/18" # Base 0A - Yellow
-base16_color04="06/b6/ef" # Base 0D - Blue
-base16_color05="81/5b/a4" # Base 0E - Magenta
-base16_color06="5b/c4/bf" # Base 0C - Cyan
-base16_color07="a3/9e/9b" # Base 05 - White
-base16_color08="77/6e/71" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="e7/e9/db" # Base 07 - Bright White
-base16_color16="f9/9b/15" # Base 09
-base16_color17="e9/6b/a8" # Base 0F
-base16_color18="41/32/3f" # Base 01
-base16_color19="4f/42/4c" # Base 02
-base16_color20="8d/86/87" # Base 04
-base16_color21="b9/b6/b0" # Base 06
-base16_color_foreground="a3/9e/9b" # Base 05
-base16_color_background="2f/1e/2e" # Base 00
+export base16_color00="2f/1e/2e" # Base 00 - Black
+export base16_color01="ef/61/55" # Base 08 - Red
+export base16_color02="48/b6/85" # Base 0B - Green
+export base16_color03="fe/c4/18" # Base 0A - Yellow
+export base16_color04="06/b6/ef" # Base 0D - Blue
+export base16_color05="81/5b/a4" # Base 0E - Magenta
+export base16_color06="5b/c4/bf" # Base 0C - Cyan
+export base16_color07="a3/9e/9b" # Base 05 - White
+export base16_color08="77/6e/71" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="e7/e9/db" # Base 07 - Bright White
+export base16_color16="f9/9b/15" # Base 09
+export base16_color17="e9/6b/a8" # Base 0F
+export base16_color18="41/32/3f" # Base 01
+export base16_color19="4f/42/4c" # Base 02
+export base16_color20="8d/86/87" # Base 04
+export base16_color21="b9/b6/b0" # Base 06
+export base16_color_foreground="a3/9e/9b" # Base 05
+export base16_color_background="2f/1e/2e" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-paraiso.sh
+++ b/scripts/base16-paraiso.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Paraiso scheme by Jan T. Sott
 
-color00="2f/1e/2e" # Base 00 - Black
-color01="ef/61/55" # Base 08 - Red
-color02="48/b6/85" # Base 0B - Green
-color03="fe/c4/18" # Base 0A - Yellow
-color04="06/b6/ef" # Base 0D - Blue
-color05="81/5b/a4" # Base 0E - Magenta
-color06="5b/c4/bf" # Base 0C - Cyan
-color07="a3/9e/9b" # Base 05 - White
-color08="77/6e/71" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="e7/e9/db" # Base 07 - Bright White
-color16="f9/9b/15" # Base 09
-color17="e9/6b/a8" # Base 0F
-color18="41/32/3f" # Base 01
-color19="4f/42/4c" # Base 02
-color20="8d/86/87" # Base 04
-color21="b9/b6/b0" # Base 06
-color_foreground="a3/9e/9b" # Base 05
-color_background="2f/1e/2e" # Base 00
+base16_color00="2f/1e/2e" # Base 00 - Black
+base16_color01="ef/61/55" # Base 08 - Red
+base16_color02="48/b6/85" # Base 0B - Green
+base16_color03="fe/c4/18" # Base 0A - Yellow
+base16_color04="06/b6/ef" # Base 0D - Blue
+base16_color05="81/5b/a4" # Base 0E - Magenta
+base16_color06="5b/c4/bf" # Base 0C - Cyan
+base16_color07="a3/9e/9b" # Base 05 - White
+base16_color08="77/6e/71" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="e7/e9/db" # Base 07 - Bright White
+base16_color16="f9/9b/15" # Base 09
+base16_color17="e9/6b/a8" # Base 0F
+base16_color18="41/32/3f" # Base 01
+base16_color19="4f/42/4c" # Base 02
+base16_color20="8d/86/87" # Base 04
+base16_color21="b9/b6/b0" # Base 06
+base16_color_foreground="a3/9e/9b" # Base 05
+base16_color_background="2f/1e/2e" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl a39e9b # cursor
   put_template_custom Pm 2f1e2e # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-phd.sh
+++ b/scripts/base16-phd.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # PhD scheme by Hennig Hasemann (http://leetless.de/vim.html)
 
-color00="06/12/29" # Base 00 - Black
-color01="d0/73/46" # Base 08 - Red
-color02="99/bf/52" # Base 0B - Green
-color03="fb/d4/61" # Base 0A - Yellow
-color04="52/99/bf" # Base 0D - Blue
-color05="99/89/cc" # Base 0E - Magenta
-color06="72/b9/bf" # Base 0C - Cyan
-color07="b8/bb/c2" # Base 05 - White
-color08="71/78/85" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="f0/a0/00" # Base 09
-color17="b0/80/60" # Base 0F
-color18="2a/34/48" # Base 01
-color19="4d/56/66" # Base 02
-color20="9a/99/a3" # Base 04
-color21="db/dd/e0" # Base 06
-color_foreground="b8/bb/c2" # Base 05
-color_background="06/12/29" # Base 00
+base16_color00="06/12/29" # Base 00 - Black
+base16_color01="d0/73/46" # Base 08 - Red
+base16_color02="99/bf/52" # Base 0B - Green
+base16_color03="fb/d4/61" # Base 0A - Yellow
+base16_color04="52/99/bf" # Base 0D - Blue
+base16_color05="99/89/cc" # Base 0E - Magenta
+base16_color06="72/b9/bf" # Base 0C - Cyan
+base16_color07="b8/bb/c2" # Base 05 - White
+base16_color08="71/78/85" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="f0/a0/00" # Base 09
+base16_color17="b0/80/60" # Base 0F
+base16_color18="2a/34/48" # Base 01
+base16_color19="4d/56/66" # Base 02
+base16_color20="9a/99/a3" # Base 04
+base16_color21="db/dd/e0" # Base 06
+base16_color_foreground="b8/bb/c2" # Base 05
+base16_color_background="06/12/29" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl b8bbc2 # cursor
   put_template_custom Pm 061229 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-phd.sh
+++ b/scripts/base16-phd.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # PhD scheme by Hennig Hasemann (http://leetless.de/vim.html)
 
-base16_color00="06/12/29" # Base 00 - Black
-base16_color01="d0/73/46" # Base 08 - Red
-base16_color02="99/bf/52" # Base 0B - Green
-base16_color03="fb/d4/61" # Base 0A - Yellow
-base16_color04="52/99/bf" # Base 0D - Blue
-base16_color05="99/89/cc" # Base 0E - Magenta
-base16_color06="72/b9/bf" # Base 0C - Cyan
-base16_color07="b8/bb/c2" # Base 05 - White
-base16_color08="71/78/85" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="f0/a0/00" # Base 09
-base16_color17="b0/80/60" # Base 0F
-base16_color18="2a/34/48" # Base 01
-base16_color19="4d/56/66" # Base 02
-base16_color20="9a/99/a3" # Base 04
-base16_color21="db/dd/e0" # Base 06
-base16_color_foreground="b8/bb/c2" # Base 05
-base16_color_background="06/12/29" # Base 00
+export base16_color00="06/12/29" # Base 00 - Black
+export base16_color01="d0/73/46" # Base 08 - Red
+export base16_color02="99/bf/52" # Base 0B - Green
+export base16_color03="fb/d4/61" # Base 0A - Yellow
+export base16_color04="52/99/bf" # Base 0D - Blue
+export base16_color05="99/89/cc" # Base 0E - Magenta
+export base16_color06="72/b9/bf" # Base 0C - Cyan
+export base16_color07="b8/bb/c2" # Base 05 - White
+export base16_color08="71/78/85" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="f0/a0/00" # Base 09
+export base16_color17="b0/80/60" # Base 0F
+export base16_color18="2a/34/48" # Base 01
+export base16_color19="4d/56/66" # Base 02
+export base16_color20="9a/99/a3" # Base 04
+export base16_color21="db/dd/e0" # Base 06
+export base16_color_foreground="b8/bb/c2" # Base 05
+export base16_color_background="06/12/29" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-pico.sh
+++ b/scripts/base16-pico.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Pico scheme by PICO-8 (http://www.lexaloffle.com/pico-8.php)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="ff/00/4d" # Base 08 - Red
-base16_color02="00/e7/56" # Base 0B - Green
-base16_color03="ff/f0/24" # Base 0A - Yellow
-base16_color04="83/76/9c" # Base 0D - Blue
-base16_color05="ff/77/a8" # Base 0E - Magenta
-base16_color06="29/ad/ff" # Base 0C - Cyan
-base16_color07="5f/57/4f" # Base 05 - White
-base16_color08="00/87/51" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/f1/e8" # Base 07 - Bright White
-base16_color16="ff/a3/00" # Base 09
-base16_color17="ff/cc/aa" # Base 0F
-base16_color18="1d/2b/53" # Base 01
-base16_color19="7e/25/53" # Base 02
-base16_color20="ab/52/36" # Base 04
-base16_color21="c2/c3/c7" # Base 06
-base16_color_foreground="5f/57/4f" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="ff/00/4d" # Base 08 - Red
+export base16_color02="00/e7/56" # Base 0B - Green
+export base16_color03="ff/f0/24" # Base 0A - Yellow
+export base16_color04="83/76/9c" # Base 0D - Blue
+export base16_color05="ff/77/a8" # Base 0E - Magenta
+export base16_color06="29/ad/ff" # Base 0C - Cyan
+export base16_color07="5f/57/4f" # Base 05 - White
+export base16_color08="00/87/51" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/f1/e8" # Base 07 - Bright White
+export base16_color16="ff/a3/00" # Base 09
+export base16_color17="ff/cc/aa" # Base 0F
+export base16_color18="1d/2b/53" # Base 01
+export base16_color19="7e/25/53" # Base 02
+export base16_color20="ab/52/36" # Base 04
+export base16_color21="c2/c3/c7" # Base 06
+export base16_color_foreground="5f/57/4f" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-pico.sh
+++ b/scripts/base16-pico.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Pico scheme by PICO-8 (http://www.lexaloffle.com/pico-8.php)
 
-color00="00/00/00" # Base 00 - Black
-color01="ff/00/4d" # Base 08 - Red
-color02="00/e7/56" # Base 0B - Green
-color03="ff/f0/24" # Base 0A - Yellow
-color04="83/76/9c" # Base 0D - Blue
-color05="ff/77/a8" # Base 0E - Magenta
-color06="29/ad/ff" # Base 0C - Cyan
-color07="5f/57/4f" # Base 05 - White
-color08="00/87/51" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/f1/e8" # Base 07 - Bright White
-color16="ff/a3/00" # Base 09
-color17="ff/cc/aa" # Base 0F
-color18="1d/2b/53" # Base 01
-color19="7e/25/53" # Base 02
-color20="ab/52/36" # Base 04
-color21="c2/c3/c7" # Base 06
-color_foreground="5f/57/4f" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="ff/00/4d" # Base 08 - Red
+base16_color02="00/e7/56" # Base 0B - Green
+base16_color03="ff/f0/24" # Base 0A - Yellow
+base16_color04="83/76/9c" # Base 0D - Blue
+base16_color05="ff/77/a8" # Base 0E - Magenta
+base16_color06="29/ad/ff" # Base 0C - Cyan
+base16_color07="5f/57/4f" # Base 05 - White
+base16_color08="00/87/51" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/f1/e8" # Base 07 - Bright White
+base16_color16="ff/a3/00" # Base 09
+base16_color17="ff/cc/aa" # Base 0F
+base16_color18="1d/2b/53" # Base 01
+base16_color19="7e/25/53" # Base 02
+base16_color20="ab/52/36" # Base 04
+base16_color21="c2/c3/c7" # Base 06
+base16_color_foreground="5f/57/4f" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 5f574f # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-pop.sh
+++ b/scripts/base16-pop.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Pop scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="00/00/00" # Base 00 - Black
-base16_color01="eb/00/8a" # Base 08 - Red
-base16_color02="37/b3/49" # Base 0B - Green
-base16_color03="f8/ca/12" # Base 0A - Yellow
-base16_color04="0e/5a/94" # Base 0D - Blue
-base16_color05="b3/1e/8d" # Base 0E - Magenta
-base16_color06="00/aa/bb" # Base 0C - Cyan
-base16_color07="d0/d0/d0" # Base 05 - White
-base16_color08="50/50/50" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="f2/93/33" # Base 09
-base16_color17="7a/2d/00" # Base 0F
-base16_color18="20/20/20" # Base 01
-base16_color19="30/30/30" # Base 02
-base16_color20="b0/b0/b0" # Base 04
-base16_color21="e0/e0/e0" # Base 06
-base16_color_foreground="d0/d0/d0" # Base 05
-base16_color_background="00/00/00" # Base 00
+export base16_color00="00/00/00" # Base 00 - Black
+export base16_color01="eb/00/8a" # Base 08 - Red
+export base16_color02="37/b3/49" # Base 0B - Green
+export base16_color03="f8/ca/12" # Base 0A - Yellow
+export base16_color04="0e/5a/94" # Base 0D - Blue
+export base16_color05="b3/1e/8d" # Base 0E - Magenta
+export base16_color06="00/aa/bb" # Base 0C - Cyan
+export base16_color07="d0/d0/d0" # Base 05 - White
+export base16_color08="50/50/50" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="f2/93/33" # Base 09
+export base16_color17="7a/2d/00" # Base 0F
+export base16_color18="20/20/20" # Base 01
+export base16_color19="30/30/30" # Base 02
+export base16_color20="b0/b0/b0" # Base 04
+export base16_color21="e0/e0/e0" # Base 06
+export base16_color_foreground="d0/d0/d0" # Base 05
+export base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-pop.sh
+++ b/scripts/base16-pop.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Pop scheme by Chris Kempson (http://chriskempson.com)
 
-color00="00/00/00" # Base 00 - Black
-color01="eb/00/8a" # Base 08 - Red
-color02="37/b3/49" # Base 0B - Green
-color03="f8/ca/12" # Base 0A - Yellow
-color04="0e/5a/94" # Base 0D - Blue
-color05="b3/1e/8d" # Base 0E - Magenta
-color06="00/aa/bb" # Base 0C - Cyan
-color07="d0/d0/d0" # Base 05 - White
-color08="50/50/50" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="f2/93/33" # Base 09
-color17="7a/2d/00" # Base 0F
-color18="20/20/20" # Base 01
-color19="30/30/30" # Base 02
-color20="b0/b0/b0" # Base 04
-color21="e0/e0/e0" # Base 06
-color_foreground="d0/d0/d0" # Base 05
-color_background="00/00/00" # Base 00
+base16_color00="00/00/00" # Base 00 - Black
+base16_color01="eb/00/8a" # Base 08 - Red
+base16_color02="37/b3/49" # Base 0B - Green
+base16_color03="f8/ca/12" # Base 0A - Yellow
+base16_color04="0e/5a/94" # Base 0D - Blue
+base16_color05="b3/1e/8d" # Base 0E - Magenta
+base16_color06="00/aa/bb" # Base 0C - Cyan
+base16_color07="d0/d0/d0" # Base 05 - White
+base16_color08="50/50/50" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="f2/93/33" # Base 09
+base16_color17="7a/2d/00" # Base 0F
+base16_color18="20/20/20" # Base 01
+base16_color19="30/30/30" # Base 02
+base16_color20="b0/b0/b0" # Base 04
+base16_color21="e0/e0/e0" # Base 06
+base16_color_foreground="d0/d0/d0" # Base 05
+base16_color_background="00/00/00" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d0d0d0 # cursor
   put_template_custom Pm 000000 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-porple.sh
+++ b/scripts/base16-porple.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Porple scheme by Niek den Breeje (https://github.com/AuditeMarlow)
 
-base16_color00="29/2c/36" # Base 00 - Black
-base16_color01="f8/45/47" # Base 08 - Red
-base16_color02="95/c7/6f" # Base 0B - Green
-base16_color03="ef/a1/6b" # Base 0A - Yellow
-base16_color04="84/85/ce" # Base 0D - Blue
-base16_color05="b7/49/89" # Base 0E - Magenta
-base16_color06="64/87/8f" # Base 0C - Cyan
-base16_color07="d8/d8/d8" # Base 05 - White
-base16_color08="65/56/8a" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f8/f8/f8" # Base 07 - Bright White
-base16_color16="d2/8e/5d" # Base 09
-base16_color17="98/68/41" # Base 0F
-base16_color18="33/33/44" # Base 01
-base16_color19="47/41/60" # Base 02
-base16_color20="b8/b8/b8" # Base 04
-base16_color21="e8/e8/e8" # Base 06
-base16_color_foreground="d8/d8/d8" # Base 05
-base16_color_background="29/2c/36" # Base 00
+export base16_color00="29/2c/36" # Base 00 - Black
+export base16_color01="f8/45/47" # Base 08 - Red
+export base16_color02="95/c7/6f" # Base 0B - Green
+export base16_color03="ef/a1/6b" # Base 0A - Yellow
+export base16_color04="84/85/ce" # Base 0D - Blue
+export base16_color05="b7/49/89" # Base 0E - Magenta
+export base16_color06="64/87/8f" # Base 0C - Cyan
+export base16_color07="d8/d8/d8" # Base 05 - White
+export base16_color08="65/56/8a" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f8/f8/f8" # Base 07 - Bright White
+export base16_color16="d2/8e/5d" # Base 09
+export base16_color17="98/68/41" # Base 0F
+export base16_color18="33/33/44" # Base 01
+export base16_color19="47/41/60" # Base 02
+export base16_color20="b8/b8/b8" # Base 04
+export base16_color21="e8/e8/e8" # Base 06
+export base16_color_foreground="d8/d8/d8" # Base 05
+export base16_color_background="29/2c/36" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-porple.sh
+++ b/scripts/base16-porple.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Porple scheme by Niek den Breeje (https://github.com/AuditeMarlow)
 
-color00="29/2c/36" # Base 00 - Black
-color01="f8/45/47" # Base 08 - Red
-color02="95/c7/6f" # Base 0B - Green
-color03="ef/a1/6b" # Base 0A - Yellow
-color04="84/85/ce" # Base 0D - Blue
-color05="b7/49/89" # Base 0E - Magenta
-color06="64/87/8f" # Base 0C - Cyan
-color07="d8/d8/d8" # Base 05 - White
-color08="65/56/8a" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/f8/f8" # Base 07 - Bright White
-color16="d2/8e/5d" # Base 09
-color17="98/68/41" # Base 0F
-color18="33/33/44" # Base 01
-color19="47/41/60" # Base 02
-color20="b8/b8/b8" # Base 04
-color21="e8/e8/e8" # Base 06
-color_foreground="d8/d8/d8" # Base 05
-color_background="29/2c/36" # Base 00
+base16_color00="29/2c/36" # Base 00 - Black
+base16_color01="f8/45/47" # Base 08 - Red
+base16_color02="95/c7/6f" # Base 0B - Green
+base16_color03="ef/a1/6b" # Base 0A - Yellow
+base16_color04="84/85/ce" # Base 0D - Blue
+base16_color05="b7/49/89" # Base 0E - Magenta
+base16_color06="64/87/8f" # Base 0C - Cyan
+base16_color07="d8/d8/d8" # Base 05 - White
+base16_color08="65/56/8a" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f8/f8/f8" # Base 07 - Bright White
+base16_color16="d2/8e/5d" # Base 09
+base16_color17="98/68/41" # Base 0F
+base16_color18="33/33/44" # Base 01
+base16_color19="47/41/60" # Base 02
+base16_color20="b8/b8/b8" # Base 04
+base16_color21="e8/e8/e8" # Base 06
+base16_color_foreground="d8/d8/d8" # Base 05
+base16_color_background="29/2c/36" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d8d8d8 # cursor
   put_template_custom Pm 292c36 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-railscasts.sh
+++ b/scripts/base16-railscasts.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Railscasts scheme by Ryan Bates (http://railscasts.com)
 
-base16_color00="2b/2b/2b" # Base 00 - Black
-base16_color01="da/49/39" # Base 08 - Red
-base16_color02="a5/c2/61" # Base 0B - Green
-base16_color03="ff/c6/6d" # Base 0A - Yellow
-base16_color04="6d/9c/be" # Base 0D - Blue
-base16_color05="b6/b3/eb" # Base 0E - Magenta
-base16_color06="51/9f/50" # Base 0C - Cyan
-base16_color07="e6/e1/dc" # Base 05 - White
-base16_color08="5a/64/7e" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f9/f7/f3" # Base 07 - Bright White
-base16_color16="cc/78/33" # Base 09
-base16_color17="bc/94/58" # Base 0F
-base16_color18="27/29/35" # Base 01
-base16_color19="3a/40/55" # Base 02
-base16_color20="d4/cf/c9" # Base 04
-base16_color21="f4/f1/ed" # Base 06
-base16_color_foreground="e6/e1/dc" # Base 05
-base16_color_background="2b/2b/2b" # Base 00
+export base16_color00="2b/2b/2b" # Base 00 - Black
+export base16_color01="da/49/39" # Base 08 - Red
+export base16_color02="a5/c2/61" # Base 0B - Green
+export base16_color03="ff/c6/6d" # Base 0A - Yellow
+export base16_color04="6d/9c/be" # Base 0D - Blue
+export base16_color05="b6/b3/eb" # Base 0E - Magenta
+export base16_color06="51/9f/50" # Base 0C - Cyan
+export base16_color07="e6/e1/dc" # Base 05 - White
+export base16_color08="5a/64/7e" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f9/f7/f3" # Base 07 - Bright White
+export base16_color16="cc/78/33" # Base 09
+export base16_color17="bc/94/58" # Base 0F
+export base16_color18="27/29/35" # Base 01
+export base16_color19="3a/40/55" # Base 02
+export base16_color20="d4/cf/c9" # Base 04
+export base16_color21="f4/f1/ed" # Base 06
+export base16_color_foreground="e6/e1/dc" # Base 05
+export base16_color_background="2b/2b/2b" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-railscasts.sh
+++ b/scripts/base16-railscasts.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Railscasts scheme by Ryan Bates (http://railscasts.com)
 
-color00="2b/2b/2b" # Base 00 - Black
-color01="da/49/39" # Base 08 - Red
-color02="a5/c2/61" # Base 0B - Green
-color03="ff/c6/6d" # Base 0A - Yellow
-color04="6d/9c/be" # Base 0D - Blue
-color05="b6/b3/eb" # Base 0E - Magenta
-color06="51/9f/50" # Base 0C - Cyan
-color07="e6/e1/dc" # Base 05 - White
-color08="5a/64/7e" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f9/f7/f3" # Base 07 - Bright White
-color16="cc/78/33" # Base 09
-color17="bc/94/58" # Base 0F
-color18="27/29/35" # Base 01
-color19="3a/40/55" # Base 02
-color20="d4/cf/c9" # Base 04
-color21="f4/f1/ed" # Base 06
-color_foreground="e6/e1/dc" # Base 05
-color_background="2b/2b/2b" # Base 00
+base16_color00="2b/2b/2b" # Base 00 - Black
+base16_color01="da/49/39" # Base 08 - Red
+base16_color02="a5/c2/61" # Base 0B - Green
+base16_color03="ff/c6/6d" # Base 0A - Yellow
+base16_color04="6d/9c/be" # Base 0D - Blue
+base16_color05="b6/b3/eb" # Base 0E - Magenta
+base16_color06="51/9f/50" # Base 0C - Cyan
+base16_color07="e6/e1/dc" # Base 05 - White
+base16_color08="5a/64/7e" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f9/f7/f3" # Base 07 - Bright White
+base16_color16="cc/78/33" # Base 09
+base16_color17="bc/94/58" # Base 0F
+base16_color18="27/29/35" # Base 01
+base16_color19="3a/40/55" # Base 02
+base16_color20="d4/cf/c9" # Base 04
+base16_color21="f4/f1/ed" # Base 06
+base16_color_foreground="e6/e1/dc" # Base 05
+base16_color_background="2b/2b/2b" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl e6e1dc # cursor
   put_template_custom Pm 2b2b2b # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-rebecca.sh
+++ b/scripts/base16-rebecca.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Rebecca scheme by Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme)
 
-base16_color00="29/2a/44" # Base 00 - Black
-base16_color01="a0/a0/c5" # Base 08 - Red
-base16_color02="6d/fe/df" # Base 0B - Green
-base16_color03="ae/81/ff" # Base 0A - Yellow
-base16_color04="2d/e0/a7" # Base 0D - Blue
-base16_color05="7a/a5/ff" # Base 0E - Magenta
-base16_color06="8e/ae/e0" # Base 0C - Cyan
-base16_color07="f1/ef/f8" # Base 05 - White
-base16_color08="66/66/99" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="53/49/5d" # Base 07 - Bright White
-base16_color16="ef/e4/a1" # Base 09
-base16_color17="ff/79/c6" # Base 0F
-base16_color18="66/33/99" # Base 01
-base16_color19="38/3a/62" # Base 02
-base16_color20="a0/a0/c5" # Base 04
-base16_color21="cc/cc/ff" # Base 06
-base16_color_foreground="f1/ef/f8" # Base 05
-base16_color_background="29/2a/44" # Base 00
+export base16_color00="29/2a/44" # Base 00 - Black
+export base16_color01="a0/a0/c5" # Base 08 - Red
+export base16_color02="6d/fe/df" # Base 0B - Green
+export base16_color03="ae/81/ff" # Base 0A - Yellow
+export base16_color04="2d/e0/a7" # Base 0D - Blue
+export base16_color05="7a/a5/ff" # Base 0E - Magenta
+export base16_color06="8e/ae/e0" # Base 0C - Cyan
+export base16_color07="f1/ef/f8" # Base 05 - White
+export base16_color08="66/66/99" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="53/49/5d" # Base 07 - Bright White
+export base16_color16="ef/e4/a1" # Base 09
+export base16_color17="ff/79/c6" # Base 0F
+export base16_color18="66/33/99" # Base 01
+export base16_color19="38/3a/62" # Base 02
+export base16_color20="a0/a0/c5" # Base 04
+export base16_color21="cc/cc/ff" # Base 06
+export base16_color_foreground="f1/ef/f8" # Base 05
+export base16_color_background="29/2a/44" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-rebecca.sh
+++ b/scripts/base16-rebecca.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Rebecca scheme by Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme)
 
-color00="29/2a/44" # Base 00 - Black
-color01="a0/a0/c5" # Base 08 - Red
-color02="6d/fe/df" # Base 0B - Green
-color03="ae/81/ff" # Base 0A - Yellow
-color04="2d/e0/a7" # Base 0D - Blue
-color05="7a/a5/ff" # Base 0E - Magenta
-color06="8e/ae/e0" # Base 0C - Cyan
-color07="f1/ef/f8" # Base 05 - White
-color08="66/66/99" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="53/49/5d" # Base 07 - Bright White
-color16="ef/e4/a1" # Base 09
-color17="ff/79/c6" # Base 0F
-color18="66/33/99" # Base 01
-color19="38/3a/62" # Base 02
-color20="a0/a0/c5" # Base 04
-color21="cc/cc/ff" # Base 06
-color_foreground="f1/ef/f8" # Base 05
-color_background="29/2a/44" # Base 00
+base16_color00="29/2a/44" # Base 00 - Black
+base16_color01="a0/a0/c5" # Base 08 - Red
+base16_color02="6d/fe/df" # Base 0B - Green
+base16_color03="ae/81/ff" # Base 0A - Yellow
+base16_color04="2d/e0/a7" # Base 0D - Blue
+base16_color05="7a/a5/ff" # Base 0E - Magenta
+base16_color06="8e/ae/e0" # Base 0C - Cyan
+base16_color07="f1/ef/f8" # Base 05 - White
+base16_color08="66/66/99" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="53/49/5d" # Base 07 - Bright White
+base16_color16="ef/e4/a1" # Base 09
+base16_color17="ff/79/c6" # Base 0F
+base16_color18="66/33/99" # Base 01
+base16_color19="38/3a/62" # Base 02
+base16_color20="a0/a0/c5" # Base 04
+base16_color21="cc/cc/ff" # Base 06
+base16_color_foreground="f1/ef/f8" # Base 05
+base16_color_background="29/2a/44" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl f1eff8 # cursor
   put_template_custom Pm 292a44 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-seti.sh
+++ b/scripts/base16-seti.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Seti UI scheme by 
 
-color00="15/17/18" # Base 00 - Black
-color01="Cd/3f/45" # Base 08 - Red
-color02="9f/ca/56" # Base 0B - Green
-color03="e6/cd/69" # Base 0A - Yellow
-color04="55/b5/db" # Base 0D - Blue
-color05="a0/74/c4" # Base 0E - Magenta
-color06="55/db/be" # Base 0C - Cyan
-color07="d6/d6/d6" # Base 05 - White
-color08="41/53/5B" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="db/7b/55" # Base 09
-color17="8a/55/3f" # Base 0F
-color18="28/2a/2b" # Base 01
-color19="3B/75/8C" # Base 02
-color20="43/a5/d5" # Base 04
-color21="ee/ee/ee" # Base 06
-color_foreground="d6/d6/d6" # Base 05
-color_background="15/17/18" # Base 00
+base16_color00="15/17/18" # Base 00 - Black
+base16_color01="Cd/3f/45" # Base 08 - Red
+base16_color02="9f/ca/56" # Base 0B - Green
+base16_color03="e6/cd/69" # Base 0A - Yellow
+base16_color04="55/b5/db" # Base 0D - Blue
+base16_color05="a0/74/c4" # Base 0E - Magenta
+base16_color06="55/db/be" # Base 0C - Cyan
+base16_color07="d6/d6/d6" # Base 05 - White
+base16_color08="41/53/5B" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="db/7b/55" # Base 09
+base16_color17="8a/55/3f" # Base 0F
+base16_color18="28/2a/2b" # Base 01
+base16_color19="3B/75/8C" # Base 02
+base16_color20="43/a5/d5" # Base 04
+base16_color21="ee/ee/ee" # Base 06
+base16_color_foreground="d6/d6/d6" # Base 05
+base16_color_background="15/17/18" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d6d6d6 # cursor
   put_template_custom Pm 151718 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-seti.sh
+++ b/scripts/base16-seti.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Seti UI scheme by 
 
-base16_color00="15/17/18" # Base 00 - Black
-base16_color01="Cd/3f/45" # Base 08 - Red
-base16_color02="9f/ca/56" # Base 0B - Green
-base16_color03="e6/cd/69" # Base 0A - Yellow
-base16_color04="55/b5/db" # Base 0D - Blue
-base16_color05="a0/74/c4" # Base 0E - Magenta
-base16_color06="55/db/be" # Base 0C - Cyan
-base16_color07="d6/d6/d6" # Base 05 - White
-base16_color08="41/53/5B" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="db/7b/55" # Base 09
-base16_color17="8a/55/3f" # Base 0F
-base16_color18="28/2a/2b" # Base 01
-base16_color19="3B/75/8C" # Base 02
-base16_color20="43/a5/d5" # Base 04
-base16_color21="ee/ee/ee" # Base 06
-base16_color_foreground="d6/d6/d6" # Base 05
-base16_color_background="15/17/18" # Base 00
+export base16_color00="15/17/18" # Base 00 - Black
+export base16_color01="Cd/3f/45" # Base 08 - Red
+export base16_color02="9f/ca/56" # Base 0B - Green
+export base16_color03="e6/cd/69" # Base 0A - Yellow
+export base16_color04="55/b5/db" # Base 0D - Blue
+export base16_color05="a0/74/c4" # Base 0E - Magenta
+export base16_color06="55/db/be" # Base 0C - Cyan
+export base16_color07="d6/d6/d6" # Base 05 - White
+export base16_color08="41/53/5B" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="db/7b/55" # Base 09
+export base16_color17="8a/55/3f" # Base 0F
+export base16_color18="28/2a/2b" # Base 01
+export base16_color19="3B/75/8C" # Base 02
+export base16_color20="43/a5/d5" # Base 04
+export base16_color21="ee/ee/ee" # Base 06
+export base16_color_foreground="d6/d6/d6" # Base 05
+export base16_color_background="15/17/18" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-shapeshifter.sh
+++ b/scripts/base16-shapeshifter.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Shapeshifter scheme by Tyler Benziger (http://tybenz.com)
 
-color00="f9/f9/f9" # Base 00 - Black
-color01="e9/2f/2f" # Base 08 - Red
-color02="0e/d8/39" # Base 0B - Green
-color03="dd/dd/13" # Base 0A - Yellow
-color04="3b/48/e3" # Base 0D - Blue
-color05="f9/96/e2" # Base 0E - Magenta
-color06="23/ed/da" # Base 0C - Cyan
-color07="10/20/15" # Base 05 - White
-color08="55/55/55" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="00/00/00" # Base 07 - Bright White
-color16="e0/94/48" # Base 09
-color17="69/54/2d" # Base 0F
-color18="e0/e0/e0" # Base 01
-color19="ab/ab/ab" # Base 02
-color20="34/34/34" # Base 04
-color21="04/04/04" # Base 06
-color_foreground="10/20/15" # Base 05
-color_background="f9/f9/f9" # Base 00
+base16_color00="f9/f9/f9" # Base 00 - Black
+base16_color01="e9/2f/2f" # Base 08 - Red
+base16_color02="0e/d8/39" # Base 0B - Green
+base16_color03="dd/dd/13" # Base 0A - Yellow
+base16_color04="3b/48/e3" # Base 0D - Blue
+base16_color05="f9/96/e2" # Base 0E - Magenta
+base16_color06="23/ed/da" # Base 0C - Cyan
+base16_color07="10/20/15" # Base 05 - White
+base16_color08="55/55/55" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="00/00/00" # Base 07 - Bright White
+base16_color16="e0/94/48" # Base 09
+base16_color17="69/54/2d" # Base 0F
+base16_color18="e0/e0/e0" # Base 01
+base16_color19="ab/ab/ab" # Base 02
+base16_color20="34/34/34" # Base 04
+base16_color21="04/04/04" # Base 06
+base16_color_foreground="10/20/15" # Base 05
+base16_color_background="f9/f9/f9" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 102015 # cursor
   put_template_custom Pm f9f9f9 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-shapeshifter.sh
+++ b/scripts/base16-shapeshifter.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Shapeshifter scheme by Tyler Benziger (http://tybenz.com)
 
-base16_color00="f9/f9/f9" # Base 00 - Black
-base16_color01="e9/2f/2f" # Base 08 - Red
-base16_color02="0e/d8/39" # Base 0B - Green
-base16_color03="dd/dd/13" # Base 0A - Yellow
-base16_color04="3b/48/e3" # Base 0D - Blue
-base16_color05="f9/96/e2" # Base 0E - Magenta
-base16_color06="23/ed/da" # Base 0C - Cyan
-base16_color07="10/20/15" # Base 05 - White
-base16_color08="55/55/55" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="00/00/00" # Base 07 - Bright White
-base16_color16="e0/94/48" # Base 09
-base16_color17="69/54/2d" # Base 0F
-base16_color18="e0/e0/e0" # Base 01
-base16_color19="ab/ab/ab" # Base 02
-base16_color20="34/34/34" # Base 04
-base16_color21="04/04/04" # Base 06
-base16_color_foreground="10/20/15" # Base 05
-base16_color_background="f9/f9/f9" # Base 00
+export base16_color00="f9/f9/f9" # Base 00 - Black
+export base16_color01="e9/2f/2f" # Base 08 - Red
+export base16_color02="0e/d8/39" # Base 0B - Green
+export base16_color03="dd/dd/13" # Base 0A - Yellow
+export base16_color04="3b/48/e3" # Base 0D - Blue
+export base16_color05="f9/96/e2" # Base 0E - Magenta
+export base16_color06="23/ed/da" # Base 0C - Cyan
+export base16_color07="10/20/15" # Base 05 - White
+export base16_color08="55/55/55" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="00/00/00" # Base 07 - Bright White
+export base16_color16="e0/94/48" # Base 09
+export base16_color17="69/54/2d" # Base 0F
+export base16_color18="e0/e0/e0" # Base 01
+export base16_color19="ab/ab/ab" # Base 02
+export base16_color20="34/34/34" # Base 04
+export base16_color21="04/04/04" # Base 06
+export base16_color_foreground="10/20/15" # Base 05
+export base16_color_background="f9/f9/f9" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-snazzy.sh
+++ b/scripts/base16-snazzy.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Snazzy scheme by Chawye Hsu (https://github.com/h404bi) based on Hyper Snazzy Theme (https://github.com/sindresorhus/hyper-snazzy)
 
-base16_color00="28/2a/36" # Base 00 - Black
-base16_color01="ff/5c/57" # Base 08 - Red
-base16_color02="5a/f7/8e" # Base 0B - Green
-base16_color03="f3/f9/9d" # Base 0A - Yellow
-base16_color04="57/c7/ff" # Base 0D - Blue
-base16_color05="ff/6a/c1" # Base 0E - Magenta
-base16_color06="9a/ed/fe" # Base 0C - Cyan
-base16_color07="e2/e4/e5" # Base 05 - White
-base16_color08="78/78/7e" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f1/f1/f0" # Base 07 - Bright White
-base16_color16="ff/9f/43" # Base 09
-base16_color17="b2/64/3c" # Base 0F
-base16_color18="34/35/3e" # Base 01
-base16_color19="43/45/4f" # Base 02
-base16_color20="a5/a5/a9" # Base 04
-base16_color21="ef/f0/eb" # Base 06
-base16_color_foreground="e2/e4/e5" # Base 05
-base16_color_background="28/2a/36" # Base 00
+export base16_color00="28/2a/36" # Base 00 - Black
+export base16_color01="ff/5c/57" # Base 08 - Red
+export base16_color02="5a/f7/8e" # Base 0B - Green
+export base16_color03="f3/f9/9d" # Base 0A - Yellow
+export base16_color04="57/c7/ff" # Base 0D - Blue
+export base16_color05="ff/6a/c1" # Base 0E - Magenta
+export base16_color06="9a/ed/fe" # Base 0C - Cyan
+export base16_color07="e2/e4/e5" # Base 05 - White
+export base16_color08="78/78/7e" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f1/f1/f0" # Base 07 - Bright White
+export base16_color16="ff/9f/43" # Base 09
+export base16_color17="b2/64/3c" # Base 0F
+export base16_color18="34/35/3e" # Base 01
+export base16_color19="43/45/4f" # Base 02
+export base16_color20="a5/a5/a9" # Base 04
+export base16_color21="ef/f0/eb" # Base 06
+export base16_color_foreground="e2/e4/e5" # Base 05
+export base16_color_background="28/2a/36" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-snazzy.sh
+++ b/scripts/base16-snazzy.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Snazzy scheme by Chawye Hsu (https://github.com/h404bi) based on Hyper Snazzy Theme (https://github.com/sindresorhus/hyper-snazzy)
 
-color00="28/2a/36" # Base 00 - Black
-color01="ff/5c/57" # Base 08 - Red
-color02="5a/f7/8e" # Base 0B - Green
-color03="f3/f9/9d" # Base 0A - Yellow
-color04="57/c7/ff" # Base 0D - Blue
-color05="ff/6a/c1" # Base 0E - Magenta
-color06="9a/ed/fe" # Base 0C - Cyan
-color07="e2/e4/e5" # Base 05 - White
-color08="78/78/7e" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f1/f1/f0" # Base 07 - Bright White
-color16="ff/9f/43" # Base 09
-color17="b2/64/3c" # Base 0F
-color18="34/35/3e" # Base 01
-color19="43/45/4f" # Base 02
-color20="a5/a5/a9" # Base 04
-color21="ef/f0/eb" # Base 06
-color_foreground="e2/e4/e5" # Base 05
-color_background="28/2a/36" # Base 00
+base16_color00="28/2a/36" # Base 00 - Black
+base16_color01="ff/5c/57" # Base 08 - Red
+base16_color02="5a/f7/8e" # Base 0B - Green
+base16_color03="f3/f9/9d" # Base 0A - Yellow
+base16_color04="57/c7/ff" # Base 0D - Blue
+base16_color05="ff/6a/c1" # Base 0E - Magenta
+base16_color06="9a/ed/fe" # Base 0C - Cyan
+base16_color07="e2/e4/e5" # Base 05 - White
+base16_color08="78/78/7e" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f1/f1/f0" # Base 07 - Bright White
+base16_color16="ff/9f/43" # Base 09
+base16_color17="b2/64/3c" # Base 0F
+base16_color18="34/35/3e" # Base 01
+base16_color19="43/45/4f" # Base 02
+base16_color20="a5/a5/a9" # Base 04
+base16_color21="ef/f0/eb" # Base 06
+base16_color_foreground="e2/e4/e5" # Base 05
+base16_color_background="28/2a/36" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl e2e4e5 # cursor
   put_template_custom Pm 282a36 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-solarflare.sh
+++ b/scripts/base16-solarflare.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Solar Flare scheme by Chuck Harmston (https://chuck.harmston.ch)
 
-base16_color00="18/26/2F" # Base 00 - Black
-base16_color01="EF/52/53" # Base 08 - Red
-base16_color02="7C/C8/44" # Base 0B - Green
-base16_color03="E4/B5/1C" # Base 0A - Yellow
-base16_color04="33/B5/E1" # Base 0D - Blue
-base16_color05="A3/63/D5" # Base 0E - Magenta
-base16_color06="52/CB/B0" # Base 0C - Cyan
-base16_color07="A6/AF/B8" # Base 05 - White
-base16_color08="66/75/81" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="F5/F7/FA" # Base 07 - Bright White
-base16_color16="E6/6B/2B" # Base 09
-base16_color17="D7/3C/9A" # Base 0F
-base16_color18="22/2E/38" # Base 01
-base16_color19="58/68/75" # Base 02
-base16_color20="85/93/9E" # Base 04
-base16_color21="E8/E9/ED" # Base 06
-base16_color_foreground="A6/AF/B8" # Base 05
-base16_color_background="18/26/2F" # Base 00
+export base16_color00="18/26/2F" # Base 00 - Black
+export base16_color01="EF/52/53" # Base 08 - Red
+export base16_color02="7C/C8/44" # Base 0B - Green
+export base16_color03="E4/B5/1C" # Base 0A - Yellow
+export base16_color04="33/B5/E1" # Base 0D - Blue
+export base16_color05="A3/63/D5" # Base 0E - Magenta
+export base16_color06="52/CB/B0" # Base 0C - Cyan
+export base16_color07="A6/AF/B8" # Base 05 - White
+export base16_color08="66/75/81" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="F5/F7/FA" # Base 07 - Bright White
+export base16_color16="E6/6B/2B" # Base 09
+export base16_color17="D7/3C/9A" # Base 0F
+export base16_color18="22/2E/38" # Base 01
+export base16_color19="58/68/75" # Base 02
+export base16_color20="85/93/9E" # Base 04
+export base16_color21="E8/E9/ED" # Base 06
+export base16_color_foreground="A6/AF/B8" # Base 05
+export base16_color_background="18/26/2F" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-solarflare.sh
+++ b/scripts/base16-solarflare.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Solar Flare scheme by Chuck Harmston (https://chuck.harmston.ch)
 
-color00="18/26/2F" # Base 00 - Black
-color01="EF/52/53" # Base 08 - Red
-color02="7C/C8/44" # Base 0B - Green
-color03="E4/B5/1C" # Base 0A - Yellow
-color04="33/B5/E1" # Base 0D - Blue
-color05="A3/63/D5" # Base 0E - Magenta
-color06="52/CB/B0" # Base 0C - Cyan
-color07="A6/AF/B8" # Base 05 - White
-color08="66/75/81" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="F5/F7/FA" # Base 07 - Bright White
-color16="E6/6B/2B" # Base 09
-color17="D7/3C/9A" # Base 0F
-color18="22/2E/38" # Base 01
-color19="58/68/75" # Base 02
-color20="85/93/9E" # Base 04
-color21="E8/E9/ED" # Base 06
-color_foreground="A6/AF/B8" # Base 05
-color_background="18/26/2F" # Base 00
+base16_color00="18/26/2F" # Base 00 - Black
+base16_color01="EF/52/53" # Base 08 - Red
+base16_color02="7C/C8/44" # Base 0B - Green
+base16_color03="E4/B5/1C" # Base 0A - Yellow
+base16_color04="33/B5/E1" # Base 0D - Blue
+base16_color05="A3/63/D5" # Base 0E - Magenta
+base16_color06="52/CB/B0" # Base 0C - Cyan
+base16_color07="A6/AF/B8" # Base 05 - White
+base16_color08="66/75/81" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="F5/F7/FA" # Base 07 - Bright White
+base16_color16="E6/6B/2B" # Base 09
+base16_color17="D7/3C/9A" # Base 0F
+base16_color18="22/2E/38" # Base 01
+base16_color19="58/68/75" # Base 02
+base16_color20="85/93/9E" # Base 04
+base16_color21="E8/E9/ED" # Base 06
+base16_color_foreground="A6/AF/B8" # Base 05
+base16_color_background="18/26/2F" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl A6AFB8 # cursor
   put_template_custom Pm 18262F # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-solarized-dark.sh
+++ b/scripts/base16-solarized-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Solarized Dark scheme by Ethan Schoonover (modified by aramisgithub)
 
-base16_color00="00/2b/36" # Base 00 - Black
-base16_color01="dc/32/2f" # Base 08 - Red
-base16_color02="85/99/00" # Base 0B - Green
-base16_color03="b5/89/00" # Base 0A - Yellow
-base16_color04="26/8b/d2" # Base 0D - Blue
-base16_color05="6c/71/c4" # Base 0E - Magenta
-base16_color06="2a/a1/98" # Base 0C - Cyan
-base16_color07="93/a1/a1" # Base 05 - White
-base16_color08="65/7b/83" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="fd/f6/e3" # Base 07 - Bright White
-base16_color16="cb/4b/16" # Base 09
-base16_color17="d3/36/82" # Base 0F
-base16_color18="07/36/42" # Base 01
-base16_color19="58/6e/75" # Base 02
-base16_color20="83/94/96" # Base 04
-base16_color21="ee/e8/d5" # Base 06
-base16_color_foreground="93/a1/a1" # Base 05
-base16_color_background="00/2b/36" # Base 00
+export base16_color00="00/2b/36" # Base 00 - Black
+export base16_color01="dc/32/2f" # Base 08 - Red
+export base16_color02="85/99/00" # Base 0B - Green
+export base16_color03="b5/89/00" # Base 0A - Yellow
+export base16_color04="26/8b/d2" # Base 0D - Blue
+export base16_color05="6c/71/c4" # Base 0E - Magenta
+export base16_color06="2a/a1/98" # Base 0C - Cyan
+export base16_color07="93/a1/a1" # Base 05 - White
+export base16_color08="65/7b/83" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="fd/f6/e3" # Base 07 - Bright White
+export base16_color16="cb/4b/16" # Base 09
+export base16_color17="d3/36/82" # Base 0F
+export base16_color18="07/36/42" # Base 01
+export base16_color19="58/6e/75" # Base 02
+export base16_color20="83/94/96" # Base 04
+export base16_color21="ee/e8/d5" # Base 06
+export base16_color_foreground="93/a1/a1" # Base 05
+export base16_color_background="00/2b/36" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-solarized-dark.sh
+++ b/scripts/base16-solarized-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Solarized Dark scheme by Ethan Schoonover (modified by aramisgithub)
 
-color00="00/2b/36" # Base 00 - Black
-color01="dc/32/2f" # Base 08 - Red
-color02="85/99/00" # Base 0B - Green
-color03="b5/89/00" # Base 0A - Yellow
-color04="26/8b/d2" # Base 0D - Blue
-color05="6c/71/c4" # Base 0E - Magenta
-color06="2a/a1/98" # Base 0C - Cyan
-color07="93/a1/a1" # Base 05 - White
-color08="65/7b/83" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="fd/f6/e3" # Base 07 - Bright White
-color16="cb/4b/16" # Base 09
-color17="d3/36/82" # Base 0F
-color18="07/36/42" # Base 01
-color19="58/6e/75" # Base 02
-color20="83/94/96" # Base 04
-color21="ee/e8/d5" # Base 06
-color_foreground="93/a1/a1" # Base 05
-color_background="00/2b/36" # Base 00
+base16_color00="00/2b/36" # Base 00 - Black
+base16_color01="dc/32/2f" # Base 08 - Red
+base16_color02="85/99/00" # Base 0B - Green
+base16_color03="b5/89/00" # Base 0A - Yellow
+base16_color04="26/8b/d2" # Base 0D - Blue
+base16_color05="6c/71/c4" # Base 0E - Magenta
+base16_color06="2a/a1/98" # Base 0C - Cyan
+base16_color07="93/a1/a1" # Base 05 - White
+base16_color08="65/7b/83" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="fd/f6/e3" # Base 07 - Bright White
+base16_color16="cb/4b/16" # Base 09
+base16_color17="d3/36/82" # Base 0F
+base16_color18="07/36/42" # Base 01
+base16_color19="58/6e/75" # Base 02
+base16_color20="83/94/96" # Base 04
+base16_color21="ee/e8/d5" # Base 06
+base16_color_foreground="93/a1/a1" # Base 05
+base16_color_background="00/2b/36" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 93a1a1 # cursor
   put_template_custom Pm 002b36 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-solarized-light.sh
+++ b/scripts/base16-solarized-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Solarized Light scheme by Ethan Schoonover (modified by aramisgithub)
 
-color00="fd/f6/e3" # Base 00 - Black
-color01="dc/32/2f" # Base 08 - Red
-color02="85/99/00" # Base 0B - Green
-color03="b5/89/00" # Base 0A - Yellow
-color04="26/8b/d2" # Base 0D - Blue
-color05="6c/71/c4" # Base 0E - Magenta
-color06="2a/a1/98" # Base 0C - Cyan
-color07="58/6e/75" # Base 05 - White
-color08="83/94/96" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="00/2b/36" # Base 07 - Bright White
-color16="cb/4b/16" # Base 09
-color17="d3/36/82" # Base 0F
-color18="ee/e8/d5" # Base 01
-color19="93/a1/a1" # Base 02
-color20="65/7b/83" # Base 04
-color21="07/36/42" # Base 06
-color_foreground="58/6e/75" # Base 05
-color_background="fd/f6/e3" # Base 00
+base16_color00="fd/f6/e3" # Base 00 - Black
+base16_color01="dc/32/2f" # Base 08 - Red
+base16_color02="85/99/00" # Base 0B - Green
+base16_color03="b5/89/00" # Base 0A - Yellow
+base16_color04="26/8b/d2" # Base 0D - Blue
+base16_color05="6c/71/c4" # Base 0E - Magenta
+base16_color06="2a/a1/98" # Base 0C - Cyan
+base16_color07="58/6e/75" # Base 05 - White
+base16_color08="83/94/96" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="00/2b/36" # Base 07 - Bright White
+base16_color16="cb/4b/16" # Base 09
+base16_color17="d3/36/82" # Base 0F
+base16_color18="ee/e8/d5" # Base 01
+base16_color19="93/a1/a1" # Base 02
+base16_color20="65/7b/83" # Base 04
+base16_color21="07/36/42" # Base 06
+base16_color_foreground="58/6e/75" # Base 05
+base16_color_background="fd/f6/e3" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 586e75 # cursor
   put_template_custom Pm fdf6e3 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-solarized-light.sh
+++ b/scripts/base16-solarized-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Solarized Light scheme by Ethan Schoonover (modified by aramisgithub)
 
-base16_color00="fd/f6/e3" # Base 00 - Black
-base16_color01="dc/32/2f" # Base 08 - Red
-base16_color02="85/99/00" # Base 0B - Green
-base16_color03="b5/89/00" # Base 0A - Yellow
-base16_color04="26/8b/d2" # Base 0D - Blue
-base16_color05="6c/71/c4" # Base 0E - Magenta
-base16_color06="2a/a1/98" # Base 0C - Cyan
-base16_color07="58/6e/75" # Base 05 - White
-base16_color08="83/94/96" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="00/2b/36" # Base 07 - Bright White
-base16_color16="cb/4b/16" # Base 09
-base16_color17="d3/36/82" # Base 0F
-base16_color18="ee/e8/d5" # Base 01
-base16_color19="93/a1/a1" # Base 02
-base16_color20="65/7b/83" # Base 04
-base16_color21="07/36/42" # Base 06
-base16_color_foreground="58/6e/75" # Base 05
-base16_color_background="fd/f6/e3" # Base 00
+export base16_color00="fd/f6/e3" # Base 00 - Black
+export base16_color01="dc/32/2f" # Base 08 - Red
+export base16_color02="85/99/00" # Base 0B - Green
+export base16_color03="b5/89/00" # Base 0A - Yellow
+export base16_color04="26/8b/d2" # Base 0D - Blue
+export base16_color05="6c/71/c4" # Base 0E - Magenta
+export base16_color06="2a/a1/98" # Base 0C - Cyan
+export base16_color07="58/6e/75" # Base 05 - White
+export base16_color08="83/94/96" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="00/2b/36" # Base 07 - Bright White
+export base16_color16="cb/4b/16" # Base 09
+export base16_color17="d3/36/82" # Base 0F
+export base16_color18="ee/e8/d5" # Base 01
+export base16_color19="93/a1/a1" # Base 02
+export base16_color20="65/7b/83" # Base 04
+export base16_color21="07/36/42" # Base 06
+export base16_color_foreground="58/6e/75" # Base 05
+export base16_color_background="fd/f6/e3" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-spacemacs.sh
+++ b/scripts/base16-spacemacs.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Spacemacs scheme by Nasser Alshammari (https://github.com/nashamri/spacemacs-theme)
 
-color00="1f/20/22" # Base 00 - Black
-color01="f2/24/1f" # Base 08 - Red
-color02="67/b1/1d" # Base 0B - Green
-color03="b1/95/1d" # Base 0A - Yellow
-color04="4f/97/d7" # Base 0D - Blue
-color05="a3/1d/b1" # Base 0E - Magenta
-color06="2d/95/74" # Base 0C - Cyan
-color07="a3/a3/a3" # Base 05 - White
-color08="58/58/58" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f8/f8/f8" # Base 07 - Bright White
-color16="ff/a5/00" # Base 09
-color17="b0/30/60" # Base 0F
-color18="28/28/28" # Base 01
-color19="44/41/55" # Base 02
-color20="b8/b8/b8" # Base 04
-color21="e8/e8/e8" # Base 06
-color_foreground="a3/a3/a3" # Base 05
-color_background="1f/20/22" # Base 00
+base16_color00="1f/20/22" # Base 00 - Black
+base16_color01="f2/24/1f" # Base 08 - Red
+base16_color02="67/b1/1d" # Base 0B - Green
+base16_color03="b1/95/1d" # Base 0A - Yellow
+base16_color04="4f/97/d7" # Base 0D - Blue
+base16_color05="a3/1d/b1" # Base 0E - Magenta
+base16_color06="2d/95/74" # Base 0C - Cyan
+base16_color07="a3/a3/a3" # Base 05 - White
+base16_color08="58/58/58" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f8/f8/f8" # Base 07 - Bright White
+base16_color16="ff/a5/00" # Base 09
+base16_color17="b0/30/60" # Base 0F
+base16_color18="28/28/28" # Base 01
+base16_color19="44/41/55" # Base 02
+base16_color20="b8/b8/b8" # Base 04
+base16_color21="e8/e8/e8" # Base 06
+base16_color_foreground="a3/a3/a3" # Base 05
+base16_color_background="1f/20/22" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl a3a3a3 # cursor
   put_template_custom Pm 1f2022 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-spacemacs.sh
+++ b/scripts/base16-spacemacs.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Spacemacs scheme by Nasser Alshammari (https://github.com/nashamri/spacemacs-theme)
 
-base16_color00="1f/20/22" # Base 00 - Black
-base16_color01="f2/24/1f" # Base 08 - Red
-base16_color02="67/b1/1d" # Base 0B - Green
-base16_color03="b1/95/1d" # Base 0A - Yellow
-base16_color04="4f/97/d7" # Base 0D - Blue
-base16_color05="a3/1d/b1" # Base 0E - Magenta
-base16_color06="2d/95/74" # Base 0C - Cyan
-base16_color07="a3/a3/a3" # Base 05 - White
-base16_color08="58/58/58" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f8/f8/f8" # Base 07 - Bright White
-base16_color16="ff/a5/00" # Base 09
-base16_color17="b0/30/60" # Base 0F
-base16_color18="28/28/28" # Base 01
-base16_color19="44/41/55" # Base 02
-base16_color20="b8/b8/b8" # Base 04
-base16_color21="e8/e8/e8" # Base 06
-base16_color_foreground="a3/a3/a3" # Base 05
-base16_color_background="1f/20/22" # Base 00
+export base16_color00="1f/20/22" # Base 00 - Black
+export base16_color01="f2/24/1f" # Base 08 - Red
+export base16_color02="67/b1/1d" # Base 0B - Green
+export base16_color03="b1/95/1d" # Base 0A - Yellow
+export base16_color04="4f/97/d7" # Base 0D - Blue
+export base16_color05="a3/1d/b1" # Base 0E - Magenta
+export base16_color06="2d/95/74" # Base 0C - Cyan
+export base16_color07="a3/a3/a3" # Base 05 - White
+export base16_color08="58/58/58" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f8/f8/f8" # Base 07 - Bright White
+export base16_color16="ff/a5/00" # Base 09
+export base16_color17="b0/30/60" # Base 0F
+export base16_color18="28/28/28" # Base 01
+export base16_color19="44/41/55" # Base 02
+export base16_color20="b8/b8/b8" # Base 04
+export base16_color21="e8/e8/e8" # Base 06
+export base16_color_foreground="a3/a3/a3" # Base 05
+export base16_color_background="1f/20/22" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-summerfruit-dark.sh
+++ b/scripts/base16-summerfruit-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Summerfruit Dark scheme by Christopher Corley (http://christop.club/)
 
-color00="15/15/15" # Base 00 - Black
-color01="FF/00/86" # Base 08 - Red
-color02="00/C9/18" # Base 0B - Green
-color03="AB/A8/00" # Base 0A - Yellow
-color04="37/77/E6" # Base 0D - Blue
-color05="AD/00/A1" # Base 0E - Magenta
-color06="1F/AA/AA" # Base 0C - Cyan
-color07="D0/D0/D0" # Base 05 - White
-color08="50/50/50" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FF/FF" # Base 07 - Bright White
-color16="FD/89/00" # Base 09
-color17="CC/66/33" # Base 0F
-color18="20/20/20" # Base 01
-color19="30/30/30" # Base 02
-color20="B0/B0/B0" # Base 04
-color21="E0/E0/E0" # Base 06
-color_foreground="D0/D0/D0" # Base 05
-color_background="15/15/15" # Base 00
+base16_color00="15/15/15" # Base 00 - Black
+base16_color01="FF/00/86" # Base 08 - Red
+base16_color02="00/C9/18" # Base 0B - Green
+base16_color03="AB/A8/00" # Base 0A - Yellow
+base16_color04="37/77/E6" # Base 0D - Blue
+base16_color05="AD/00/A1" # Base 0E - Magenta
+base16_color06="1F/AA/AA" # Base 0C - Cyan
+base16_color07="D0/D0/D0" # Base 05 - White
+base16_color08="50/50/50" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="FF/FF/FF" # Base 07 - Bright White
+base16_color16="FD/89/00" # Base 09
+base16_color17="CC/66/33" # Base 0F
+base16_color18="20/20/20" # Base 01
+base16_color19="30/30/30" # Base 02
+base16_color20="B0/B0/B0" # Base 04
+base16_color21="E0/E0/E0" # Base 06
+base16_color_foreground="D0/D0/D0" # Base 05
+base16_color_background="15/15/15" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl D0D0D0 # cursor
   put_template_custom Pm 151515 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-summerfruit-dark.sh
+++ b/scripts/base16-summerfruit-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Summerfruit Dark scheme by Christopher Corley (http://christop.club/)
 
-base16_color00="15/15/15" # Base 00 - Black
-base16_color01="FF/00/86" # Base 08 - Red
-base16_color02="00/C9/18" # Base 0B - Green
-base16_color03="AB/A8/00" # Base 0A - Yellow
-base16_color04="37/77/E6" # Base 0D - Blue
-base16_color05="AD/00/A1" # Base 0E - Magenta
-base16_color06="1F/AA/AA" # Base 0C - Cyan
-base16_color07="D0/D0/D0" # Base 05 - White
-base16_color08="50/50/50" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="FF/FF/FF" # Base 07 - Bright White
-base16_color16="FD/89/00" # Base 09
-base16_color17="CC/66/33" # Base 0F
-base16_color18="20/20/20" # Base 01
-base16_color19="30/30/30" # Base 02
-base16_color20="B0/B0/B0" # Base 04
-base16_color21="E0/E0/E0" # Base 06
-base16_color_foreground="D0/D0/D0" # Base 05
-base16_color_background="15/15/15" # Base 00
+export base16_color00="15/15/15" # Base 00 - Black
+export base16_color01="FF/00/86" # Base 08 - Red
+export base16_color02="00/C9/18" # Base 0B - Green
+export base16_color03="AB/A8/00" # Base 0A - Yellow
+export base16_color04="37/77/E6" # Base 0D - Blue
+export base16_color05="AD/00/A1" # Base 0E - Magenta
+export base16_color06="1F/AA/AA" # Base 0C - Cyan
+export base16_color07="D0/D0/D0" # Base 05 - White
+export base16_color08="50/50/50" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="FF/FF/FF" # Base 07 - Bright White
+export base16_color16="FD/89/00" # Base 09
+export base16_color17="CC/66/33" # Base 0F
+export base16_color18="20/20/20" # Base 01
+export base16_color19="30/30/30" # Base 02
+export base16_color20="B0/B0/B0" # Base 04
+export base16_color21="E0/E0/E0" # Base 06
+export base16_color_foreground="D0/D0/D0" # Base 05
+export base16_color_background="15/15/15" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-summerfruit-light.sh
+++ b/scripts/base16-summerfruit-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Summerfruit Light scheme by Christopher Corley (http://christop.club/)
 
-color00="FF/FF/FF" # Base 00 - Black
-color01="FF/00/86" # Base 08 - Red
-color02="00/C9/18" # Base 0B - Green
-color03="AB/A8/00" # Base 0A - Yellow
-color04="37/77/E6" # Base 0D - Blue
-color05="AD/00/A1" # Base 0E - Magenta
-color06="1F/AA/AA" # Base 0C - Cyan
-color07="10/10/10" # Base 05 - White
-color08="B0/B0/B0" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="20/20/20" # Base 07 - Bright White
-color16="FD/89/00" # Base 09
-color17="CC/66/33" # Base 0F
-color18="E0/E0/E0" # Base 01
-color19="D0/D0/D0" # Base 02
-color20="00/00/00" # Base 04
-color21="15/15/15" # Base 06
-color_foreground="10/10/10" # Base 05
-color_background="FF/FF/FF" # Base 00
+base16_color00="FF/FF/FF" # Base 00 - Black
+base16_color01="FF/00/86" # Base 08 - Red
+base16_color02="00/C9/18" # Base 0B - Green
+base16_color03="AB/A8/00" # Base 0A - Yellow
+base16_color04="37/77/E6" # Base 0D - Blue
+base16_color05="AD/00/A1" # Base 0E - Magenta
+base16_color06="1F/AA/AA" # Base 0C - Cyan
+base16_color07="10/10/10" # Base 05 - White
+base16_color08="B0/B0/B0" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="20/20/20" # Base 07 - Bright White
+base16_color16="FD/89/00" # Base 09
+base16_color17="CC/66/33" # Base 0F
+base16_color18="E0/E0/E0" # Base 01
+base16_color19="D0/D0/D0" # Base 02
+base16_color20="00/00/00" # Base 04
+base16_color21="15/15/15" # Base 06
+base16_color_foreground="10/10/10" # Base 05
+base16_color_background="FF/FF/FF" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 101010 # cursor
   put_template_custom Pm FFFFFF # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-summerfruit-light.sh
+++ b/scripts/base16-summerfruit-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Summerfruit Light scheme by Christopher Corley (http://christop.club/)
 
-base16_color00="FF/FF/FF" # Base 00 - Black
-base16_color01="FF/00/86" # Base 08 - Red
-base16_color02="00/C9/18" # Base 0B - Green
-base16_color03="AB/A8/00" # Base 0A - Yellow
-base16_color04="37/77/E6" # Base 0D - Blue
-base16_color05="AD/00/A1" # Base 0E - Magenta
-base16_color06="1F/AA/AA" # Base 0C - Cyan
-base16_color07="10/10/10" # Base 05 - White
-base16_color08="B0/B0/B0" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="20/20/20" # Base 07 - Bright White
-base16_color16="FD/89/00" # Base 09
-base16_color17="CC/66/33" # Base 0F
-base16_color18="E0/E0/E0" # Base 01
-base16_color19="D0/D0/D0" # Base 02
-base16_color20="00/00/00" # Base 04
-base16_color21="15/15/15" # Base 06
-base16_color_foreground="10/10/10" # Base 05
-base16_color_background="FF/FF/FF" # Base 00
+export base16_color00="FF/FF/FF" # Base 00 - Black
+export base16_color01="FF/00/86" # Base 08 - Red
+export base16_color02="00/C9/18" # Base 0B - Green
+export base16_color03="AB/A8/00" # Base 0A - Yellow
+export base16_color04="37/77/E6" # Base 0D - Blue
+export base16_color05="AD/00/A1" # Base 0E - Magenta
+export base16_color06="1F/AA/AA" # Base 0C - Cyan
+export base16_color07="10/10/10" # Base 05 - White
+export base16_color08="B0/B0/B0" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="20/20/20" # Base 07 - Bright White
+export base16_color16="FD/89/00" # Base 09
+export base16_color17="CC/66/33" # Base 0F
+export base16_color18="E0/E0/E0" # Base 01
+export base16_color19="D0/D0/D0" # Base 02
+export base16_color20="00/00/00" # Base 04
+export base16_color21="15/15/15" # Base 06
+export base16_color_foreground="10/10/10" # Base 05
+export base16_color_background="FF/FF/FF" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-synth-midnight-dark.sh
+++ b/scripts/base16-synth-midnight-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Synth Midnight Dark scheme by Michaël Ball (http://github.com/michael-ball/)
 
-color00="04/04/04" # Base 00 - Black
-color01="B5/3B/50" # Base 08 - Red
-color02="06/EA/61" # Base 0B - Green
-color03="DA/E8/4D" # Base 0A - Yellow
-color04="03/AE/FF" # Base 0D - Blue
-color05="EA/5C/E2" # Base 0E - Magenta
-color06="7C/ED/E9" # Base 0C - Cyan
-color07="DF/DB/DF" # Base 05 - White
-color08="61/50/7A" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="FF/FB/FF" # Base 07 - Bright White
-color16="E4/60/0E" # Base 09
-color17="9D/4D/0E" # Base 0F
-color18="14/14/14" # Base 01
-color19="24/24/24" # Base 02
-color20="BF/BB/BF" # Base 04
-color21="EF/EB/EF" # Base 06
-color_foreground="DF/DB/DF" # Base 05
-color_background="04/04/04" # Base 00
+base16_color00="04/04/04" # Base 00 - Black
+base16_color01="B5/3B/50" # Base 08 - Red
+base16_color02="06/EA/61" # Base 0B - Green
+base16_color03="DA/E8/4D" # Base 0A - Yellow
+base16_color04="03/AE/FF" # Base 0D - Blue
+base16_color05="EA/5C/E2" # Base 0E - Magenta
+base16_color06="7C/ED/E9" # Base 0C - Cyan
+base16_color07="DF/DB/DF" # Base 05 - White
+base16_color08="61/50/7A" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="FF/FB/FF" # Base 07 - Bright White
+base16_color16="E4/60/0E" # Base 09
+base16_color17="9D/4D/0E" # Base 0F
+base16_color18="14/14/14" # Base 01
+base16_color19="24/24/24" # Base 02
+base16_color20="BF/BB/BF" # Base 04
+base16_color21="EF/EB/EF" # Base 06
+base16_color_foreground="DF/DB/DF" # Base 05
+base16_color_background="04/04/04" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl DFDBDF # cursor
   put_template_custom Pm 040404 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-synth-midnight-dark.sh
+++ b/scripts/base16-synth-midnight-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Synth Midnight Dark scheme by Michaël Ball (http://github.com/michael-ball/)
 
-base16_color00="04/04/04" # Base 00 - Black
-base16_color01="B5/3B/50" # Base 08 - Red
-base16_color02="06/EA/61" # Base 0B - Green
-base16_color03="DA/E8/4D" # Base 0A - Yellow
-base16_color04="03/AE/FF" # Base 0D - Blue
-base16_color05="EA/5C/E2" # Base 0E - Magenta
-base16_color06="7C/ED/E9" # Base 0C - Cyan
-base16_color07="DF/DB/DF" # Base 05 - White
-base16_color08="61/50/7A" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="FF/FB/FF" # Base 07 - Bright White
-base16_color16="E4/60/0E" # Base 09
-base16_color17="9D/4D/0E" # Base 0F
-base16_color18="14/14/14" # Base 01
-base16_color19="24/24/24" # Base 02
-base16_color20="BF/BB/BF" # Base 04
-base16_color21="EF/EB/EF" # Base 06
-base16_color_foreground="DF/DB/DF" # Base 05
-base16_color_background="04/04/04" # Base 00
+export base16_color00="04/04/04" # Base 00 - Black
+export base16_color01="B5/3B/50" # Base 08 - Red
+export base16_color02="06/EA/61" # Base 0B - Green
+export base16_color03="DA/E8/4D" # Base 0A - Yellow
+export base16_color04="03/AE/FF" # Base 0D - Blue
+export base16_color05="EA/5C/E2" # Base 0E - Magenta
+export base16_color06="7C/ED/E9" # Base 0C - Cyan
+export base16_color07="DF/DB/DF" # Base 05 - White
+export base16_color08="61/50/7A" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="FF/FB/FF" # Base 07 - Bright White
+export base16_color16="E4/60/0E" # Base 09
+export base16_color17="9D/4D/0E" # Base 0F
+export base16_color18="14/14/14" # Base 01
+export base16_color19="24/24/24" # Base 02
+export base16_color20="BF/BB/BF" # Base 04
+export base16_color21="EF/EB/EF" # Base 06
+export base16_color_foreground="DF/DB/DF" # Base 05
+export base16_color_background="04/04/04" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-tomorrow-night-eighties.sh
+++ b/scripts/base16-tomorrow-night-eighties.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Tomorrow Night scheme by Chris Kempson (http://chriskempson.com)
 
-color00="2d/2d/2d" # Base 00 - Black
-color01="f2/77/7a" # Base 08 - Red
-color02="99/cc/99" # Base 0B - Green
-color03="ff/cc/66" # Base 0A - Yellow
-color04="66/99/cc" # Base 0D - Blue
-color05="cc/99/cc" # Base 0E - Magenta
-color06="66/cc/cc" # Base 0C - Cyan
-color07="cc/cc/cc" # Base 05 - White
-color08="99/99/99" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="f9/91/57" # Base 09
-color17="a3/68/5a" # Base 0F
-color18="39/39/39" # Base 01
-color19="51/51/51" # Base 02
-color20="b4/b7/b4" # Base 04
-color21="e0/e0/e0" # Base 06
-color_foreground="cc/cc/cc" # Base 05
-color_background="2d/2d/2d" # Base 00
+base16_color00="2d/2d/2d" # Base 00 - Black
+base16_color01="f2/77/7a" # Base 08 - Red
+base16_color02="99/cc/99" # Base 0B - Green
+base16_color03="ff/cc/66" # Base 0A - Yellow
+base16_color04="66/99/cc" # Base 0D - Blue
+base16_color05="cc/99/cc" # Base 0E - Magenta
+base16_color06="66/cc/cc" # Base 0C - Cyan
+base16_color07="cc/cc/cc" # Base 05 - White
+base16_color08="99/99/99" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="f9/91/57" # Base 09
+base16_color17="a3/68/5a" # Base 0F
+base16_color18="39/39/39" # Base 01
+base16_color19="51/51/51" # Base 02
+base16_color20="b4/b7/b4" # Base 04
+base16_color21="e0/e0/e0" # Base 06
+base16_color_foreground="cc/cc/cc" # Base 05
+base16_color_background="2d/2d/2d" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl cccccc # cursor
   put_template_custom Pm 2d2d2d # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-tomorrow-night-eighties.sh
+++ b/scripts/base16-tomorrow-night-eighties.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Tomorrow Night scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="2d/2d/2d" # Base 00 - Black
-base16_color01="f2/77/7a" # Base 08 - Red
-base16_color02="99/cc/99" # Base 0B - Green
-base16_color03="ff/cc/66" # Base 0A - Yellow
-base16_color04="66/99/cc" # Base 0D - Blue
-base16_color05="cc/99/cc" # Base 0E - Magenta
-base16_color06="66/cc/cc" # Base 0C - Cyan
-base16_color07="cc/cc/cc" # Base 05 - White
-base16_color08="99/99/99" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="f9/91/57" # Base 09
-base16_color17="a3/68/5a" # Base 0F
-base16_color18="39/39/39" # Base 01
-base16_color19="51/51/51" # Base 02
-base16_color20="b4/b7/b4" # Base 04
-base16_color21="e0/e0/e0" # Base 06
-base16_color_foreground="cc/cc/cc" # Base 05
-base16_color_background="2d/2d/2d" # Base 00
+export base16_color00="2d/2d/2d" # Base 00 - Black
+export base16_color01="f2/77/7a" # Base 08 - Red
+export base16_color02="99/cc/99" # Base 0B - Green
+export base16_color03="ff/cc/66" # Base 0A - Yellow
+export base16_color04="66/99/cc" # Base 0D - Blue
+export base16_color05="cc/99/cc" # Base 0E - Magenta
+export base16_color06="66/cc/cc" # Base 0C - Cyan
+export base16_color07="cc/cc/cc" # Base 05 - White
+export base16_color08="99/99/99" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="f9/91/57" # Base 09
+export base16_color17="a3/68/5a" # Base 0F
+export base16_color18="39/39/39" # Base 01
+export base16_color19="51/51/51" # Base 02
+export base16_color20="b4/b7/b4" # Base 04
+export base16_color21="e0/e0/e0" # Base 06
+export base16_color_foreground="cc/cc/cc" # Base 05
+export base16_color_background="2d/2d/2d" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-tomorrow-night.sh
+++ b/scripts/base16-tomorrow-night.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Tomorrow Night scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="1d/1f/21" # Base 00 - Black
-base16_color01="cc/66/66" # Base 08 - Red
-base16_color02="b5/bd/68" # Base 0B - Green
-base16_color03="f0/c6/74" # Base 0A - Yellow
-base16_color04="81/a2/be" # Base 0D - Blue
-base16_color05="b2/94/bb" # Base 0E - Magenta
-base16_color06="8a/be/b7" # Base 0C - Cyan
-base16_color07="c5/c8/c6" # Base 05 - White
-base16_color08="96/98/96" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="de/93/5f" # Base 09
-base16_color17="a3/68/5a" # Base 0F
-base16_color18="28/2a/2e" # Base 01
-base16_color19="37/3b/41" # Base 02
-base16_color20="b4/b7/b4" # Base 04
-base16_color21="e0/e0/e0" # Base 06
-base16_color_foreground="c5/c8/c6" # Base 05
-base16_color_background="1d/1f/21" # Base 00
+export base16_color00="1d/1f/21" # Base 00 - Black
+export base16_color01="cc/66/66" # Base 08 - Red
+export base16_color02="b5/bd/68" # Base 0B - Green
+export base16_color03="f0/c6/74" # Base 0A - Yellow
+export base16_color04="81/a2/be" # Base 0D - Blue
+export base16_color05="b2/94/bb" # Base 0E - Magenta
+export base16_color06="8a/be/b7" # Base 0C - Cyan
+export base16_color07="c5/c8/c6" # Base 05 - White
+export base16_color08="96/98/96" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="de/93/5f" # Base 09
+export base16_color17="a3/68/5a" # Base 0F
+export base16_color18="28/2a/2e" # Base 01
+export base16_color19="37/3b/41" # Base 02
+export base16_color20="b4/b7/b4" # Base 04
+export base16_color21="e0/e0/e0" # Base 06
+export base16_color_foreground="c5/c8/c6" # Base 05
+export base16_color_background="1d/1f/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-tomorrow-night.sh
+++ b/scripts/base16-tomorrow-night.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Tomorrow Night scheme by Chris Kempson (http://chriskempson.com)
 
-color00="1d/1f/21" # Base 00 - Black
-color01="cc/66/66" # Base 08 - Red
-color02="b5/bd/68" # Base 0B - Green
-color03="f0/c6/74" # Base 0A - Yellow
-color04="81/a2/be" # Base 0D - Blue
-color05="b2/94/bb" # Base 0E - Magenta
-color06="8a/be/b7" # Base 0C - Cyan
-color07="c5/c8/c6" # Base 05 - White
-color08="96/98/96" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="de/93/5f" # Base 09
-color17="a3/68/5a" # Base 0F
-color18="28/2a/2e" # Base 01
-color19="37/3b/41" # Base 02
-color20="b4/b7/b4" # Base 04
-color21="e0/e0/e0" # Base 06
-color_foreground="c5/c8/c6" # Base 05
-color_background="1d/1f/21" # Base 00
+base16_color00="1d/1f/21" # Base 00 - Black
+base16_color01="cc/66/66" # Base 08 - Red
+base16_color02="b5/bd/68" # Base 0B - Green
+base16_color03="f0/c6/74" # Base 0A - Yellow
+base16_color04="81/a2/be" # Base 0D - Blue
+base16_color05="b2/94/bb" # Base 0E - Magenta
+base16_color06="8a/be/b7" # Base 0C - Cyan
+base16_color07="c5/c8/c6" # Base 05 - White
+base16_color08="96/98/96" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="de/93/5f" # Base 09
+base16_color17="a3/68/5a" # Base 0F
+base16_color18="28/2a/2e" # Base 01
+base16_color19="37/3b/41" # Base 02
+base16_color20="b4/b7/b4" # Base 04
+base16_color21="e0/e0/e0" # Base 06
+base16_color_foreground="c5/c8/c6" # Base 05
+base16_color_background="1d/1f/21" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl c5c8c6 # cursor
   put_template_custom Pm 1d1f21 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-tomorrow.sh
+++ b/scripts/base16-tomorrow.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Tomorrow scheme by Chris Kempson (http://chriskempson.com)
 
-base16_color00="ff/ff/ff" # Base 00 - Black
-base16_color01="c8/28/29" # Base 08 - Red
-base16_color02="71/8c/00" # Base 0B - Green
-base16_color03="ea/b7/00" # Base 0A - Yellow
-base16_color04="42/71/ae" # Base 0D - Blue
-base16_color05="89/59/a8" # Base 0E - Magenta
-base16_color06="3e/99/9f" # Base 0C - Cyan
-base16_color07="4d/4d/4c" # Base 05 - White
-base16_color08="8e/90/8c" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="1d/1f/21" # Base 07 - Bright White
-base16_color16="f5/87/1f" # Base 09
-base16_color17="a3/68/5a" # Base 0F
-base16_color18="e0/e0/e0" # Base 01
-base16_color19="d6/d6/d6" # Base 02
-base16_color20="96/98/96" # Base 04
-base16_color21="28/2a/2e" # Base 06
-base16_color_foreground="4d/4d/4c" # Base 05
-base16_color_background="ff/ff/ff" # Base 00
+export base16_color00="ff/ff/ff" # Base 00 - Black
+export base16_color01="c8/28/29" # Base 08 - Red
+export base16_color02="71/8c/00" # Base 0B - Green
+export base16_color03="ea/b7/00" # Base 0A - Yellow
+export base16_color04="42/71/ae" # Base 0D - Blue
+export base16_color05="89/59/a8" # Base 0E - Magenta
+export base16_color06="3e/99/9f" # Base 0C - Cyan
+export base16_color07="4d/4d/4c" # Base 05 - White
+export base16_color08="8e/90/8c" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="1d/1f/21" # Base 07 - Bright White
+export base16_color16="f5/87/1f" # Base 09
+export base16_color17="a3/68/5a" # Base 0F
+export base16_color18="e0/e0/e0" # Base 01
+export base16_color19="d6/d6/d6" # Base 02
+export base16_color20="96/98/96" # Base 04
+export base16_color21="28/2a/2e" # Base 06
+export base16_color_foreground="4d/4d/4c" # Base 05
+export base16_color_background="ff/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-tomorrow.sh
+++ b/scripts/base16-tomorrow.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Tomorrow scheme by Chris Kempson (http://chriskempson.com)
 
-color00="ff/ff/ff" # Base 00 - Black
-color01="c8/28/29" # Base 08 - Red
-color02="71/8c/00" # Base 0B - Green
-color03="ea/b7/00" # Base 0A - Yellow
-color04="42/71/ae" # Base 0D - Blue
-color05="89/59/a8" # Base 0E - Magenta
-color06="3e/99/9f" # Base 0C - Cyan
-color07="4d/4d/4c" # Base 05 - White
-color08="8e/90/8c" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="1d/1f/21" # Base 07 - Bright White
-color16="f5/87/1f" # Base 09
-color17="a3/68/5a" # Base 0F
-color18="e0/e0/e0" # Base 01
-color19="d6/d6/d6" # Base 02
-color20="96/98/96" # Base 04
-color21="28/2a/2e" # Base 06
-color_foreground="4d/4d/4c" # Base 05
-color_background="ff/ff/ff" # Base 00
+base16_color00="ff/ff/ff" # Base 00 - Black
+base16_color01="c8/28/29" # Base 08 - Red
+base16_color02="71/8c/00" # Base 0B - Green
+base16_color03="ea/b7/00" # Base 0A - Yellow
+base16_color04="42/71/ae" # Base 0D - Blue
+base16_color05="89/59/a8" # Base 0E - Magenta
+base16_color06="3e/99/9f" # Base 0C - Cyan
+base16_color07="4d/4d/4c" # Base 05 - White
+base16_color08="8e/90/8c" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="1d/1f/21" # Base 07 - Bright White
+base16_color16="f5/87/1f" # Base 09
+base16_color17="a3/68/5a" # Base 0F
+base16_color18="e0/e0/e0" # Base 01
+base16_color19="d6/d6/d6" # Base 02
+base16_color20="96/98/96" # Base 04
+base16_color21="28/2a/2e" # Base 06
+base16_color_foreground="4d/4d/4c" # Base 05
+base16_color_background="ff/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 4d4d4c # cursor
   put_template_custom Pm ffffff # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-tube.sh
+++ b/scripts/base16-tube.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # London Tube scheme by Jan T. Sott
 
-base16_color00="23/1f/20" # Base 00 - Black
-base16_color01="ee/2e/24" # Base 08 - Red
-base16_color02="00/85/3e" # Base 0B - Green
-base16_color03="ff/d2/04" # Base 0A - Yellow
-base16_color04="00/9d/dc" # Base 0D - Blue
-base16_color05="98/00/5d" # Base 0E - Magenta
-base16_color06="85/ce/bc" # Base 0C - Cyan
-base16_color07="d9/d8/d8" # Base 05 - White
-base16_color08="73/71/71" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="f3/86/a1" # Base 09
-base16_color17="b0/61/10" # Base 0F
-base16_color18="1c/3f/95" # Base 01
-base16_color19="5a/57/58" # Base 02
-base16_color20="95/9c/a1" # Base 04
-base16_color21="e7/e7/e8" # Base 06
-base16_color_foreground="d9/d8/d8" # Base 05
-base16_color_background="23/1f/20" # Base 00
+export base16_color00="23/1f/20" # Base 00 - Black
+export base16_color01="ee/2e/24" # Base 08 - Red
+export base16_color02="00/85/3e" # Base 0B - Green
+export base16_color03="ff/d2/04" # Base 0A - Yellow
+export base16_color04="00/9d/dc" # Base 0D - Blue
+export base16_color05="98/00/5d" # Base 0E - Magenta
+export base16_color06="85/ce/bc" # Base 0C - Cyan
+export base16_color07="d9/d8/d8" # Base 05 - White
+export base16_color08="73/71/71" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="f3/86/a1" # Base 09
+export base16_color17="b0/61/10" # Base 0F
+export base16_color18="1c/3f/95" # Base 01
+export base16_color19="5a/57/58" # Base 02
+export base16_color20="95/9c/a1" # Base 04
+export base16_color21="e7/e7/e8" # Base 06
+export base16_color_foreground="d9/d8/d8" # Base 05
+export base16_color_background="23/1f/20" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-tube.sh
+++ b/scripts/base16-tube.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # London Tube scheme by Jan T. Sott
 
-color00="23/1f/20" # Base 00 - Black
-color01="ee/2e/24" # Base 08 - Red
-color02="00/85/3e" # Base 0B - Green
-color03="ff/d2/04" # Base 0A - Yellow
-color04="00/9d/dc" # Base 0D - Blue
-color05="98/00/5d" # Base 0E - Magenta
-color06="85/ce/bc" # Base 0C - Cyan
-color07="d9/d8/d8" # Base 05 - White
-color08="73/71/71" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="f3/86/a1" # Base 09
-color17="b0/61/10" # Base 0F
-color18="1c/3f/95" # Base 01
-color19="5a/57/58" # Base 02
-color20="95/9c/a1" # Base 04
-color21="e7/e7/e8" # Base 06
-color_foreground="d9/d8/d8" # Base 05
-color_background="23/1f/20" # Base 00
+base16_color00="23/1f/20" # Base 00 - Black
+base16_color01="ee/2e/24" # Base 08 - Red
+base16_color02="00/85/3e" # Base 0B - Green
+base16_color03="ff/d2/04" # Base 0A - Yellow
+base16_color04="00/9d/dc" # Base 0D - Blue
+base16_color05="98/00/5d" # Base 0E - Magenta
+base16_color06="85/ce/bc" # Base 0C - Cyan
+base16_color07="d9/d8/d8" # Base 05 - White
+base16_color08="73/71/71" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="f3/86/a1" # Base 09
+base16_color17="b0/61/10" # Base 0F
+base16_color18="1c/3f/95" # Base 01
+base16_color19="5a/57/58" # Base 02
+base16_color20="95/9c/a1" # Base 04
+base16_color21="e7/e7/e8" # Base 06
+base16_color_foreground="d9/d8/d8" # Base 05
+base16_color_background="23/1f/20" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl d9d8d8 # cursor
   put_template_custom Pm 231f20 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-twilight.sh
+++ b/scripts/base16-twilight.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Twilight scheme by David Hart (https://github.com/hartbit)
 
-color00="1e/1e/1e" # Base 00 - Black
-color01="cf/6a/4c" # Base 08 - Red
-color02="8f/9d/6a" # Base 0B - Green
-color03="f9/ee/98" # Base 0A - Yellow
-color04="75/87/a6" # Base 0D - Blue
-color05="9b/85/9d" # Base 0E - Magenta
-color06="af/c4/db" # Base 0C - Cyan
-color07="a7/a7/a7" # Base 05 - White
-color08="5f/5a/60" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="cd/a8/69" # Base 09
-color17="9b/70/3f" # Base 0F
-color18="32/35/37" # Base 01
-color19="46/4b/50" # Base 02
-color20="83/81/84" # Base 04
-color21="c3/c3/c3" # Base 06
-color_foreground="a7/a7/a7" # Base 05
-color_background="1e/1e/1e" # Base 00
+base16_color00="1e/1e/1e" # Base 00 - Black
+base16_color01="cf/6a/4c" # Base 08 - Red
+base16_color02="8f/9d/6a" # Base 0B - Green
+base16_color03="f9/ee/98" # Base 0A - Yellow
+base16_color04="75/87/a6" # Base 0D - Blue
+base16_color05="9b/85/9d" # Base 0E - Magenta
+base16_color06="af/c4/db" # Base 0C - Cyan
+base16_color07="a7/a7/a7" # Base 05 - White
+base16_color08="5f/5a/60" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="cd/a8/69" # Base 09
+base16_color17="9b/70/3f" # Base 0F
+base16_color18="32/35/37" # Base 01
+base16_color19="46/4b/50" # Base 02
+base16_color20="83/81/84" # Base 04
+base16_color21="c3/c3/c3" # Base 06
+base16_color_foreground="a7/a7/a7" # Base 05
+base16_color_background="1e/1e/1e" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl a7a7a7 # cursor
   put_template_custom Pm 1e1e1e # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-twilight.sh
+++ b/scripts/base16-twilight.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Twilight scheme by David Hart (https://github.com/hartbit)
 
-base16_color00="1e/1e/1e" # Base 00 - Black
-base16_color01="cf/6a/4c" # Base 08 - Red
-base16_color02="8f/9d/6a" # Base 0B - Green
-base16_color03="f9/ee/98" # Base 0A - Yellow
-base16_color04="75/87/a6" # Base 0D - Blue
-base16_color05="9b/85/9d" # Base 0E - Magenta
-base16_color06="af/c4/db" # Base 0C - Cyan
-base16_color07="a7/a7/a7" # Base 05 - White
-base16_color08="5f/5a/60" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="cd/a8/69" # Base 09
-base16_color17="9b/70/3f" # Base 0F
-base16_color18="32/35/37" # Base 01
-base16_color19="46/4b/50" # Base 02
-base16_color20="83/81/84" # Base 04
-base16_color21="c3/c3/c3" # Base 06
-base16_color_foreground="a7/a7/a7" # Base 05
-base16_color_background="1e/1e/1e" # Base 00
+export base16_color00="1e/1e/1e" # Base 00 - Black
+export base16_color01="cf/6a/4c" # Base 08 - Red
+export base16_color02="8f/9d/6a" # Base 0B - Green
+export base16_color03="f9/ee/98" # Base 0A - Yellow
+export base16_color04="75/87/a6" # Base 0D - Blue
+export base16_color05="9b/85/9d" # Base 0E - Magenta
+export base16_color06="af/c4/db" # Base 0C - Cyan
+export base16_color07="a7/a7/a7" # Base 05 - White
+export base16_color08="5f/5a/60" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="cd/a8/69" # Base 09
+export base16_color17="9b/70/3f" # Base 0F
+export base16_color18="32/35/37" # Base 01
+export base16_color19="46/4b/50" # Base 02
+export base16_color20="83/81/84" # Base 04
+export base16_color21="c3/c3/c3" # Base 06
+export base16_color_foreground="a7/a7/a7" # Base 05
+export base16_color_background="1e/1e/1e" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-unikitty-dark.sh
+++ b/scripts/base16-unikitty-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Unikitty Dark scheme by Josh W Lewis (@joshwlewis)
 
-base16_color00="2e/2a/31" # Base 00 - Black
-base16_color01="d8/13/7f" # Base 08 - Red
-base16_color02="17/ad/98" # Base 0B - Green
-base16_color03="dc/8a/0e" # Base 0A - Yellow
-base16_color04="79/6a/f5" # Base 0D - Blue
-base16_color05="bb/60/ea" # Base 0E - Magenta
-base16_color06="14/9b/da" # Base 0C - Cyan
-base16_color07="bc/ba/be" # Base 05 - White
-base16_color08="83/80/85" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="f5/f4/f7" # Base 07 - Bright White
-base16_color16="d6/54/07" # Base 09
-base16_color17="c7/20/ca" # Base 0F
-base16_color18="4a/46/4d" # Base 01
-base16_color19="66/63/69" # Base 02
-base16_color20="9f/9d/a2" # Base 04
-base16_color21="d8/d7/da" # Base 06
-base16_color_foreground="bc/ba/be" # Base 05
-base16_color_background="2e/2a/31" # Base 00
+export base16_color00="2e/2a/31" # Base 00 - Black
+export base16_color01="d8/13/7f" # Base 08 - Red
+export base16_color02="17/ad/98" # Base 0B - Green
+export base16_color03="dc/8a/0e" # Base 0A - Yellow
+export base16_color04="79/6a/f5" # Base 0D - Blue
+export base16_color05="bb/60/ea" # Base 0E - Magenta
+export base16_color06="14/9b/da" # Base 0C - Cyan
+export base16_color07="bc/ba/be" # Base 05 - White
+export base16_color08="83/80/85" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="f5/f4/f7" # Base 07 - Bright White
+export base16_color16="d6/54/07" # Base 09
+export base16_color17="c7/20/ca" # Base 0F
+export base16_color18="4a/46/4d" # Base 01
+export base16_color19="66/63/69" # Base 02
+export base16_color20="9f/9d/a2" # Base 04
+export base16_color21="d8/d7/da" # Base 06
+export base16_color_foreground="bc/ba/be" # Base 05
+export base16_color_background="2e/2a/31" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-unikitty-dark.sh
+++ b/scripts/base16-unikitty-dark.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Unikitty Dark scheme by Josh W Lewis (@joshwlewis)
 
-color00="2e/2a/31" # Base 00 - Black
-color01="d8/13/7f" # Base 08 - Red
-color02="17/ad/98" # Base 0B - Green
-color03="dc/8a/0e" # Base 0A - Yellow
-color04="79/6a/f5" # Base 0D - Blue
-color05="bb/60/ea" # Base 0E - Magenta
-color06="14/9b/da" # Base 0C - Cyan
-color07="bc/ba/be" # Base 05 - White
-color08="83/80/85" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="f5/f4/f7" # Base 07 - Bright White
-color16="d6/54/07" # Base 09
-color17="c7/20/ca" # Base 0F
-color18="4a/46/4d" # Base 01
-color19="66/63/69" # Base 02
-color20="9f/9d/a2" # Base 04
-color21="d8/d7/da" # Base 06
-color_foreground="bc/ba/be" # Base 05
-color_background="2e/2a/31" # Base 00
+base16_color00="2e/2a/31" # Base 00 - Black
+base16_color01="d8/13/7f" # Base 08 - Red
+base16_color02="17/ad/98" # Base 0B - Green
+base16_color03="dc/8a/0e" # Base 0A - Yellow
+base16_color04="79/6a/f5" # Base 0D - Blue
+base16_color05="bb/60/ea" # Base 0E - Magenta
+base16_color06="14/9b/da" # Base 0C - Cyan
+base16_color07="bc/ba/be" # Base 05 - White
+base16_color08="83/80/85" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="f5/f4/f7" # Base 07 - Bright White
+base16_color16="d6/54/07" # Base 09
+base16_color17="c7/20/ca" # Base 0F
+base16_color18="4a/46/4d" # Base 01
+base16_color19="66/63/69" # Base 02
+base16_color20="9f/9d/a2" # Base 04
+base16_color21="d8/d7/da" # Base 06
+base16_color_foreground="bc/ba/be" # Base 05
+base16_color_background="2e/2a/31" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl bcbabe # cursor
   put_template_custom Pm 2e2a31 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-unikitty-light.sh
+++ b/scripts/base16-unikitty-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Unikitty Light scheme by Josh W Lewis (@joshwlewis)
 
-base16_color00="ff/ff/ff" # Base 00 - Black
-base16_color01="d8/13/7f" # Base 08 - Red
-base16_color02="17/ad/98" # Base 0B - Green
-base16_color03="dc/8a/0e" # Base 0A - Yellow
-base16_color04="77/5d/ff" # Base 0D - Blue
-base16_color05="aa/17/e6" # Base 0E - Magenta
-base16_color06="14/9b/da" # Base 0C - Cyan
-base16_color07="6c/69/6e" # Base 05 - White
-base16_color08="a7/a5/a8" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="32/2d/34" # Base 07 - Bright White
-base16_color16="d6/54/07" # Base 09
-base16_color17="e0/13/d0" # Base 0F
-base16_color18="e1/e1/e2" # Base 01
-base16_color19="c4/c3/c5" # Base 02
-base16_color20="89/87/8b" # Base 04
-base16_color21="4f/4b/51" # Base 06
-base16_color_foreground="6c/69/6e" # Base 05
-base16_color_background="ff/ff/ff" # Base 00
+export base16_color00="ff/ff/ff" # Base 00 - Black
+export base16_color01="d8/13/7f" # Base 08 - Red
+export base16_color02="17/ad/98" # Base 0B - Green
+export base16_color03="dc/8a/0e" # Base 0A - Yellow
+export base16_color04="77/5d/ff" # Base 0D - Blue
+export base16_color05="aa/17/e6" # Base 0E - Magenta
+export base16_color06="14/9b/da" # Base 0C - Cyan
+export base16_color07="6c/69/6e" # Base 05 - White
+export base16_color08="a7/a5/a8" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="32/2d/34" # Base 07 - Bright White
+export base16_color16="d6/54/07" # Base 09
+export base16_color17="e0/13/d0" # Base 0F
+export base16_color18="e1/e1/e2" # Base 01
+export base16_color19="c4/c3/c5" # Base 02
+export base16_color20="89/87/8b" # Base 04
+export base16_color21="4f/4b/51" # Base 06
+export base16_color_foreground="6c/69/6e" # Base 05
+export base16_color_background="ff/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-unikitty-light.sh
+++ b/scripts/base16-unikitty-light.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Unikitty Light scheme by Josh W Lewis (@joshwlewis)
 
-color00="ff/ff/ff" # Base 00 - Black
-color01="d8/13/7f" # Base 08 - Red
-color02="17/ad/98" # Base 0B - Green
-color03="dc/8a/0e" # Base 0A - Yellow
-color04="77/5d/ff" # Base 0D - Blue
-color05="aa/17/e6" # Base 0E - Magenta
-color06="14/9b/da" # Base 0C - Cyan
-color07="6c/69/6e" # Base 05 - White
-color08="a7/a5/a8" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="32/2d/34" # Base 07 - Bright White
-color16="d6/54/07" # Base 09
-color17="e0/13/d0" # Base 0F
-color18="e1/e1/e2" # Base 01
-color19="c4/c3/c5" # Base 02
-color20="89/87/8b" # Base 04
-color21="4f/4b/51" # Base 06
-color_foreground="6c/69/6e" # Base 05
-color_background="ff/ff/ff" # Base 00
+base16_color00="ff/ff/ff" # Base 00 - Black
+base16_color01="d8/13/7f" # Base 08 - Red
+base16_color02="17/ad/98" # Base 0B - Green
+base16_color03="dc/8a/0e" # Base 0A - Yellow
+base16_color04="77/5d/ff" # Base 0D - Blue
+base16_color05="aa/17/e6" # Base 0E - Magenta
+base16_color06="14/9b/da" # Base 0C - Cyan
+base16_color07="6c/69/6e" # Base 05 - White
+base16_color08="a7/a5/a8" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="32/2d/34" # Base 07 - Bright White
+base16_color16="d6/54/07" # Base 09
+base16_color17="e0/13/d0" # Base 0F
+base16_color18="e1/e1/e2" # Base 01
+base16_color19="c4/c3/c5" # Base 02
+base16_color20="89/87/8b" # Base 04
+base16_color21="4f/4b/51" # Base 06
+base16_color_foreground="6c/69/6e" # Base 05
+base16_color_background="ff/ff/ff" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 6c696e # cursor
   put_template_custom Pm ffffff # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-woodland.sh
+++ b/scripts/base16-woodland.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Woodland scheme by Jay Cornwall (https://jcornwall.com)
 
-base16_color00="23/1e/18" # Base 00 - Black
-base16_color01="d3/5c/5c" # Base 08 - Red
-base16_color02="b7/ba/53" # Base 0B - Green
-base16_color03="e0/ac/16" # Base 0A - Yellow
-base16_color04="88/a4/d3" # Base 0D - Blue
-base16_color05="bb/90/e2" # Base 0E - Magenta
-base16_color06="6e/b9/58" # Base 0C - Cyan
-base16_color07="ca/bc/b1" # Base 05 - White
-base16_color08="9d/8b/70" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="e4/d4/c8" # Base 07 - Bright White
-base16_color16="ca/7f/32" # Base 09
-base16_color17="b4/93/68" # Base 0F
-base16_color18="30/2b/25" # Base 01
-base16_color19="48/41/3a" # Base 02
-base16_color20="b4/a4/90" # Base 04
-base16_color21="d7/c8/bc" # Base 06
-base16_color_foreground="ca/bc/b1" # Base 05
-base16_color_background="23/1e/18" # Base 00
+export base16_color00="23/1e/18" # Base 00 - Black
+export base16_color01="d3/5c/5c" # Base 08 - Red
+export base16_color02="b7/ba/53" # Base 0B - Green
+export base16_color03="e0/ac/16" # Base 0A - Yellow
+export base16_color04="88/a4/d3" # Base 0D - Blue
+export base16_color05="bb/90/e2" # Base 0E - Magenta
+export base16_color06="6e/b9/58" # Base 0C - Cyan
+export base16_color07="ca/bc/b1" # Base 05 - White
+export base16_color08="9d/8b/70" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="e4/d4/c8" # Base 07 - Bright White
+export base16_color16="ca/7f/32" # Base 09
+export base16_color17="b4/93/68" # Base 0F
+export base16_color18="30/2b/25" # Base 01
+export base16_color19="48/41/3a" # Base 02
+export base16_color20="b4/a4/90" # Base 04
+export base16_color21="d7/c8/bc" # Base 06
+export base16_color_foreground="ca/bc/b1" # Base 05
+export base16_color_background="23/1e/18" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-woodland.sh
+++ b/scripts/base16-woodland.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Woodland scheme by Jay Cornwall (https://jcornwall.com)
 
-color00="23/1e/18" # Base 00 - Black
-color01="d3/5c/5c" # Base 08 - Red
-color02="b7/ba/53" # Base 0B - Green
-color03="e0/ac/16" # Base 0A - Yellow
-color04="88/a4/d3" # Base 0D - Blue
-color05="bb/90/e2" # Base 0E - Magenta
-color06="6e/b9/58" # Base 0C - Cyan
-color07="ca/bc/b1" # Base 05 - White
-color08="9d/8b/70" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="e4/d4/c8" # Base 07 - Bright White
-color16="ca/7f/32" # Base 09
-color17="b4/93/68" # Base 0F
-color18="30/2b/25" # Base 01
-color19="48/41/3a" # Base 02
-color20="b4/a4/90" # Base 04
-color21="d7/c8/bc" # Base 06
-color_foreground="ca/bc/b1" # Base 05
-color_background="23/1e/18" # Base 00
+base16_color00="23/1e/18" # Base 00 - Black
+base16_color01="d3/5c/5c" # Base 08 - Red
+base16_color02="b7/ba/53" # Base 0B - Green
+base16_color03="e0/ac/16" # Base 0A - Yellow
+base16_color04="88/a4/d3" # Base 0D - Blue
+base16_color05="bb/90/e2" # Base 0E - Magenta
+base16_color06="6e/b9/58" # Base 0C - Cyan
+base16_color07="ca/bc/b1" # Base 05 - White
+base16_color08="9d/8b/70" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="e4/d4/c8" # Base 07 - Bright White
+base16_color16="ca/7f/32" # Base 09
+base16_color17="b4/93/68" # Base 0F
+base16_color18="30/2b/25" # Base 01
+base16_color19="48/41/3a" # Base 02
+base16_color20="b4/a4/90" # Base 04
+base16_color21="d7/c8/bc" # Base 06
+base16_color_foreground="ca/bc/b1" # Base 05
+base16_color_background="23/1e/18" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl cabcb1 # cursor
   put_template_custom Pm 231e18 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-xcode-dusk.sh
+++ b/scripts/base16-xcode-dusk.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # XCode Dusk scheme by Elsa Gonsiorowski (https://github.com/gonsie)
 
-base16_color00="28/2B/35" # Base 00 - Black
-base16_color01="B2/18/89" # Base 08 - Red
-base16_color02="DF/00/02" # Base 0B - Green
-base16_color03="43/82/88" # Base 0A - Yellow
-base16_color04="79/0E/AD" # Base 0D - Blue
-base16_color05="B2/18/89" # Base 0E - Magenta
-base16_color06="00/A0/BE" # Base 0C - Cyan
-base16_color07="93/95/99" # Base 05 - White
-base16_color08="68/6A/71" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="BE/BF/C2" # Base 07 - Bright White
-base16_color16="78/6D/C5" # Base 09
-base16_color17="C7/7C/48" # Base 0F
-base16_color18="3D/40/48" # Base 01
-base16_color19="53/55/5D" # Base 02
-base16_color20="7E/80/86" # Base 04
-base16_color21="A9/AA/AE" # Base 06
-base16_color_foreground="93/95/99" # Base 05
-base16_color_background="28/2B/35" # Base 00
+export base16_color00="28/2B/35" # Base 00 - Black
+export base16_color01="B2/18/89" # Base 08 - Red
+export base16_color02="DF/00/02" # Base 0B - Green
+export base16_color03="43/82/88" # Base 0A - Yellow
+export base16_color04="79/0E/AD" # Base 0D - Blue
+export base16_color05="B2/18/89" # Base 0E - Magenta
+export base16_color06="00/A0/BE" # Base 0C - Cyan
+export base16_color07="93/95/99" # Base 05 - White
+export base16_color08="68/6A/71" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="BE/BF/C2" # Base 07 - Bright White
+export base16_color16="78/6D/C5" # Base 09
+export base16_color17="C7/7C/48" # Base 0F
+export base16_color18="3D/40/48" # Base 01
+export base16_color19="53/55/5D" # Base 02
+export base16_color20="7E/80/86" # Base 04
+export base16_color21="A9/AA/AE" # Base 06
+export base16_color_foreground="93/95/99" # Base 05
+export base16_color_background="28/2B/35" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background

--- a/scripts/base16-xcode-dusk.sh
+++ b/scripts/base16-xcode-dusk.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # XCode Dusk scheme by Elsa Gonsiorowski (https://github.com/gonsie)
 
-color00="28/2B/35" # Base 00 - Black
-color01="B2/18/89" # Base 08 - Red
-color02="DF/00/02" # Base 0B - Green
-color03="43/82/88" # Base 0A - Yellow
-color04="79/0E/AD" # Base 0D - Blue
-color05="B2/18/89" # Base 0E - Magenta
-color06="00/A0/BE" # Base 0C - Cyan
-color07="93/95/99" # Base 05 - White
-color08="68/6A/71" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="BE/BF/C2" # Base 07 - Bright White
-color16="78/6D/C5" # Base 09
-color17="C7/7C/48" # Base 0F
-color18="3D/40/48" # Base 01
-color19="53/55/5D" # Base 02
-color20="7E/80/86" # Base 04
-color21="A9/AA/AE" # Base 06
-color_foreground="93/95/99" # Base 05
-color_background="28/2B/35" # Base 00
+base16_color00="28/2B/35" # Base 00 - Black
+base16_color01="B2/18/89" # Base 08 - Red
+base16_color02="DF/00/02" # Base 0B - Green
+base16_color03="43/82/88" # Base 0A - Yellow
+base16_color04="79/0E/AD" # Base 0D - Blue
+base16_color05="B2/18/89" # Base 0E - Magenta
+base16_color06="00/A0/BE" # Base 0C - Cyan
+base16_color07="93/95/99" # Base 05 - White
+base16_color08="68/6A/71" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="BE/BF/C2" # Base 07 - Bright White
+base16_color16="78/6D/C5" # Base 09
+base16_color17="C7/7C/48" # Base 0F
+base16_color18="3D/40/48" # Base 01
+base16_color19="53/55/5D" # Base 02
+base16_color20="7E/80/86" # Base 04
+base16_color21="A9/AA/AE" # Base 06
+base16_color_foreground="93/95/99" # Base 05
+base16_color_background="28/2B/35" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl 939599 # cursor
   put_template_custom Pm 282B35 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-zenburn.sh
+++ b/scripts/base16-zenburn.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Zenburn scheme by elnawe
 
-color00="38/38/38" # Base 00 - Black
-color01="dc/a3/a3" # Base 08 - Red
-color02="5f/7f/5f" # Base 0B - Green
-color03="e0/cf/9f" # Base 0A - Yellow
-color04="7c/b8/bb" # Base 0D - Blue
-color05="dc/8c/c3" # Base 0E - Magenta
-color06="93/e0/e3" # Base 0C - Cyan
-color07="dc/dc/cc" # Base 05 - White
-color08="6f/6f/6f" # Base 03 - Bright Black
-color09=$color01 # Base 08 - Bright Red
-color10=$color02 # Base 0B - Bright Green
-color11=$color03 # Base 0A - Bright Yellow
-color12=$color04 # Base 0D - Bright Blue
-color13=$color05 # Base 0E - Bright Magenta
-color14=$color06 # Base 0C - Bright Cyan
-color15="ff/ff/ff" # Base 07 - Bright White
-color16="df/af/8f" # Base 09
-color17="00/00/00" # Base 0F
-color18="40/40/40" # Base 01
-color19="60/60/60" # Base 02
-color20="80/80/80" # Base 04
-color21="c0/c0/c0" # Base 06
-color_foreground="dc/dc/cc" # Base 05
-color_background="38/38/38" # Base 00
+base16_color00="38/38/38" # Base 00 - Black
+base16_color01="dc/a3/a3" # Base 08 - Red
+base16_color02="5f/7f/5f" # Base 0B - Green
+base16_color03="e0/cf/9f" # Base 0A - Yellow
+base16_color04="7c/b8/bb" # Base 0D - Blue
+base16_color05="dc/8c/c3" # Base 0E - Magenta
+base16_color06="93/e0/e3" # Base 0C - Cyan
+base16_color07="dc/dc/cc" # Base 05 - White
+base16_color08="6f/6f/6f" # Base 03 - Bright Black
+base16_color09=$base16_color01 # Base 08 - Bright Red
+base16_color10=$base16_color02 # Base 0B - Bright Green
+base16_color11=$base16_color03 # Base 0A - Bright Yellow
+base16_color12=$base16_color04 # Base 0D - Bright Blue
+base16_color13=$base16_color05 # Base 0E - Bright Magenta
+base16_color14=$base16_color06 # Base 0C - Bright Cyan
+base16_color15="ff/ff/ff" # Base 07 - Bright White
+base16_color16="df/af/8f" # Base 09
+base16_color17="00/00/00" # Base 0F
+base16_color18="40/40/40" # Base 01
+base16_color19="60/60/60" # Base 02
+base16_color20="80/80/80" # Base 04
+base16_color21="c0/c0/c0" # Base 06
+base16_color_foreground="dc/dc/cc" # Base 05
+base16_color_background="38/38/38" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -50,30 +50,30 @@ else
 fi
 
 # 16 color space
-put_template 0  $color00
-put_template 1  $color01
-put_template 2  $color02
-put_template 3  $color03
-put_template 4  $color04
-put_template 5  $color05
-put_template 6  $color06
-put_template 7  $color07
-put_template 8  $color08
-put_template 9  $color09
-put_template 10 $color10
-put_template 11 $color11
-put_template 12 $color12
-put_template 13 $color13
-put_template 14 $color14
-put_template 15 $color15
+put_template 0  $base16_color00
+put_template 1  $base16_color01
+put_template 2  $base16_color02
+put_template 3  $base16_color03
+put_template 4  $base16_color04
+put_template 5  $base16_color05
+put_template 6  $base16_color06
+put_template 7  $base16_color07
+put_template 8  $base16_color08
+put_template 9  $base16_color09
+put_template 10 $base16_color10
+put_template 11 $base16_color11
+put_template 12 $base16_color12
+put_template 13 $base16_color13
+put_template 14 $base16_color14
+put_template 15 $base16_color15
 
 # 256 color space
-put_template 16 $color16
-put_template 17 $color17
-put_template 18 $color18
-put_template 19 $color19
-put_template 20 $color20
-put_template 21 $color21
+put_template 16 $base16_color16
+put_template 17 $base16_color17
+put_template 18 $base16_color18
+put_template 19 $base16_color19
+put_template 20 $base16_color20
+put_template 21 $base16_color21
 
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
@@ -86,11 +86,11 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pl dcdccc # cursor
   put_template_custom Pm 383838 # cursor text
 else
-  put_template_var 10 $color_foreground
+  put_template_var 10 $base16_color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
-    put_template_var 11 $color_background
+    put_template_var 11 $base16_color_background
     if [ "${TERM%%-*}" = "rxvt" ]; then
-      put_template_var 708 $color_background # internal border (rxvt)
+      put_template_var 708 $base16_color_background # internal border (rxvt)
     fi
   fi
   put_template_custom 12 ";7" # cursor (reverse video)
@@ -100,27 +100,27 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset color00
-unset color01
-unset color02
-unset color03
-unset color04
-unset color05
-unset color06
-unset color07
-unset color08
-unset color09
-unset color10
-unset color11
-unset color12
-unset color13
-unset color14
-unset color15
-unset color16
-unset color17
-unset color18
-unset color19
-unset color20
-unset color21
-unset color_foreground
-unset color_background
+unset base16_color00
+unset base16_color01
+unset base16_color02
+unset base16_color03
+unset base16_color04
+unset base16_color05
+unset base16_color06
+unset base16_color07
+unset base16_color08
+unset base16_color09
+unset base16_color10
+unset base16_color11
+unset base16_color12
+unset base16_color13
+unset base16_color14
+unset base16_color15
+unset base16_color16
+unset base16_color17
+unset base16_color18
+unset base16_color19
+unset base16_color20
+unset base16_color21
+unset base16_color_foreground
+unset base16_color_background

--- a/scripts/base16-zenburn.sh
+++ b/scripts/base16-zenburn.sh
@@ -3,30 +3,30 @@
 # Base16 Shell template by Chris Kempson (http://chriskempson.com)
 # Zenburn scheme by elnawe
 
-base16_color00="38/38/38" # Base 00 - Black
-base16_color01="dc/a3/a3" # Base 08 - Red
-base16_color02="5f/7f/5f" # Base 0B - Green
-base16_color03="e0/cf/9f" # Base 0A - Yellow
-base16_color04="7c/b8/bb" # Base 0D - Blue
-base16_color05="dc/8c/c3" # Base 0E - Magenta
-base16_color06="93/e0/e3" # Base 0C - Cyan
-base16_color07="dc/dc/cc" # Base 05 - White
-base16_color08="6f/6f/6f" # Base 03 - Bright Black
-base16_color09=$base16_color01 # Base 08 - Bright Red
-base16_color10=$base16_color02 # Base 0B - Bright Green
-base16_color11=$base16_color03 # Base 0A - Bright Yellow
-base16_color12=$base16_color04 # Base 0D - Bright Blue
-base16_color13=$base16_color05 # Base 0E - Bright Magenta
-base16_color14=$base16_color06 # Base 0C - Bright Cyan
-base16_color15="ff/ff/ff" # Base 07 - Bright White
-base16_color16="df/af/8f" # Base 09
-base16_color17="00/00/00" # Base 0F
-base16_color18="40/40/40" # Base 01
-base16_color19="60/60/60" # Base 02
-base16_color20="80/80/80" # Base 04
-base16_color21="c0/c0/c0" # Base 06
-base16_color_foreground="dc/dc/cc" # Base 05
-base16_color_background="38/38/38" # Base 00
+export base16_color00="38/38/38" # Base 00 - Black
+export base16_color01="dc/a3/a3" # Base 08 - Red
+export base16_color02="5f/7f/5f" # Base 0B - Green
+export base16_color03="e0/cf/9f" # Base 0A - Yellow
+export base16_color04="7c/b8/bb" # Base 0D - Blue
+export base16_color05="dc/8c/c3" # Base 0E - Magenta
+export base16_color06="93/e0/e3" # Base 0C - Cyan
+export base16_color07="dc/dc/cc" # Base 05 - White
+export base16_color08="6f/6f/6f" # Base 03 - Bright Black
+export base16_color09=$base16_color01 # Base 08 - Bright Red
+export base16_color10=$base16_color02 # Base 0B - Bright Green
+export base16_color11=$base16_color03 # Base 0A - Bright Yellow
+export base16_color12=$base16_color04 # Base 0D - Bright Blue
+export base16_color13=$base16_color05 # Base 0E - Bright Magenta
+export base16_color14=$base16_color06 # Base 0C - Bright Cyan
+export base16_color15="ff/ff/ff" # Base 07 - Bright White
+export base16_color16="df/af/8f" # Base 09
+export base16_color17="00/00/00" # Base 0F
+export base16_color18="40/40/40" # Base 01
+export base16_color19="60/60/60" # Base 02
+export base16_color20="80/80/80" # Base 04
+export base16_color21="c0/c0/c0" # Base 06
+export base16_color_foreground="dc/dc/cc" # Base 05
+export base16_color_background="38/38/38" # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -100,27 +100,3 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
-unset base16_color00
-unset base16_color01
-unset base16_color02
-unset base16_color03
-unset base16_color04
-unset base16_color05
-unset base16_color06
-unset base16_color07
-unset base16_color08
-unset base16_color09
-unset base16_color10
-unset base16_color11
-unset base16_color12
-unset base16_color13
-unset base16_color14
-unset base16_color15
-unset base16_color16
-unset base16_color17
-unset base16_color18
-unset base16_color19
-unset base16_color20
-unset base16_color21
-unset base16_color_foreground
-unset base16_color_background


### PR DESCRIPTION
- Change color variable naming (adding base16_ prefix) to prevent namespace conflicts.
- Don't unset these variables after applying the themes, so that users can use them in dotfiles.
- Export these as environment variables so that all dotfiles can access them.
- Resolves #192

I used sed and a couple regexes to apply these changes to every single theme, so some may be a bit garbled.
```
find . -name "base16-*.sh" -exec sed -i "s/color\([0-9][0-9]\)/base16_color\1/g" '{}' \;
find . -name "base16-*.sh" -exec sed -i "s/color_/base16_color_/g" '{}' \;
find . -name "base16-*.sh" -exec sed -i "s/\^base16_color/export base16_color/g" '{}' \;
find . -name "base16-*.sh" -exec sed -i "/^unset base16_color/d" '{}' \;
```
Now if you want to use these colours in dofiles, you can just reference the environment variables. You will probably want to remove the slashes and add a hashtag (1a/2b/3c becomes #1a2b3c). This can be done with tr.
``` $(echo "#$base16_color_foreground" | tr -d '/')```
You may need to add the code for loading base16-shell to your bash_profile as well as bashrc