### PR TITLE
Minor optimizations

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -25,8 +25,8 @@ color18="{{base01-hex-r}}/{{base01-hex-g}}/{{base01-hex-b}}" # Base 01
 color19="{{base02-hex-r}}/{{base02-hex-g}}/{{base02-hex-b}}" # Base 02
 color20="{{base04-hex-r}}/{{base04-hex-g}}/{{base04-hex-b}}" # Base 04
 color21="{{base06-hex-r}}/{{base06-hex-g}}/{{base06-hex-b}}" # Base 06
-color_foreground="{{base05-hex-r}}/{{base05-hex-g}}/{{base05-hex-b}}" # Base 05
-color_background="{{base00-hex-r}}/{{base00-hex-g}}/{{base00-hex-b}}" # Base 00
+color_foreground=$color07 # Base 05
+color_background=$color00 # Base 00
 
 if [ -n "$TMUX" ]; then
   # Tell tmux to pass the escape sequences through
@@ -78,13 +78,13 @@ put_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  put_template_custom Pg {{base05-hex}} # foreground
-  put_template_custom Ph {{base00-hex}} # background
-  put_template_custom Pi {{base05-hex}} # bold color
-  put_template_custom Pj {{base02-hex}} # selection color
-  put_template_custom Pk {{base05-hex}} # selected text color
-  put_template_custom Pl {{base05-hex}} # cursor
-  put_template_custom Pm {{base00-hex}} # cursor text
+  put_template_custom Pg ${color07////} # foreground
+  put_template_custom Ph ${color00////} # background
+  put_template_custom Pi ${color07////} # bold color
+  put_template_custom Pj ${color19////} # selection color
+  put_template_custom Pk ${color07////} # selected text color
+  put_template_custom Pl ${color07////} # cursor
+  put_template_custom Pm ${color00////} # cursor text
 else
   put_template_var 10 $color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -78,13 +78,15 @@ put_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  put_template_custom Pg $(sed -e 's#/##g' <<<$color07) # foreground
-  put_template_custom Ph $(sed -e 's#/##g' <<<$color00) # background
-  put_template_custom Pi $(sed -e 's#/##g' <<<$color07) # bold color
-  put_template_custom Pj $(sed -e 's#/##g' <<<$color19) # selection color
-  put_template_custom Pk $(sed -e 's#/##g' <<<$color07) # selected text color
-  put_template_custom Pl $(sed -e 's#/##g' <<<$color07) # cursor
-  put_template_custom Pm $(sed -e 's#/##g' <<<$color00) # cursor text
+  _IFS=$IFS; ${IFS+':'} unset _IFS
+  IFS=-; set -- $color07; set -- ${1}; IFS=$_IFS; put_template_custom Pg ${1}-hex}} # foreground
+  IFS=-; set -- $color00; set -- ${1}; IFS=$_IFS; put_template_custom Ph ${1}-hex}} # background
+  IFS=-; set -- $color07; set -- ${1}; IFS=$_IFS; put_template_custom Pi ${1}-hex}} # bold color
+  IFS=-; set -- $color19; set -- ${1}; IFS=$_IFS; put_template_custom Pj ${1}-hex}} # selection color
+  IFS=-; set -- $color07; set -- ${1}; IFS=$_IFS; put_template_custom Pk ${1}-hex}} # selected text color
+  IFS=-; set -- $color07; set -- ${1}; IFS=$_IFS; put_template_custom Pl ${1}-hex}} # cursor
+  IFS=-; set -- $color00; set -- ${1}; IFS=$_IFS; put_template_custom Pm ${1}-hex}} # cursor text
+  ${_IFS+':'} unset IFS
 else
   put_template_var 10 $color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then
@@ -100,6 +102,7 @@ fi
 unset -f put_template
 unset -f put_template_var
 unset -f put_template_custom
+unset _IFS
 unset color00
 unset color01
 unset color02

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -78,13 +78,13 @@ put_template 21 $color21
 # foreground / background / cursor color
 if [ -n "$ITERM_SESSION_ID" ]; then
   # iTerm2 proprietary escape codes
-  put_template_custom Pg ${color07////} # foreground
-  put_template_custom Ph ${color00////} # background
-  put_template_custom Pi ${color07////} # bold color
-  put_template_custom Pj ${color19////} # selection color
-  put_template_custom Pk ${color07////} # selected text color
-  put_template_custom Pl ${color07////} # cursor
-  put_template_custom Pm ${color00////} # cursor text
+  put_template_custom Pg $(sed -e 's#/##g' <<<$color07) # foreground
+  put_template_custom Ph $(sed -e 's#/##g' <<<$color00) # background
+  put_template_custom Pi $(sed -e 's#/##g' <<<$color07) # bold color
+  put_template_custom Pj $(sed -e 's#/##g' <<<$color19) # selection color
+  put_template_custom Pk $(sed -e 's#/##g' <<<$color07) # selected text color
+  put_template_custom Pl $(sed -e 's#/##g' <<<$color07) # cursor
+  put_template_custom Pm $(sed -e 's#/##g' <<<$color00) # cursor text
 else
   put_template_var 10 $color_foreground
   if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]; then


### PR DESCRIPTION
Minor optimizations to move the whole routine of hex colors declaration to the initial block

The idea is to have one and only declaration per color, stored in variable and reused elsewhere in the script late

This way It would be cleaner and easier to debug the template, the proposed refactoring dropes out the duplicates of color hex values for iTerm2 and thus delivers template optimization and unification in general