### PR TITLE
Mention required tmux allow-passthrough config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ the profile_helper will update a ~/.vimrc_background file that will have your cu
       source ~/.vimrc_background
     endif
 
+### tmux users
+
+Add the following line to `~/.tmux.config` to passthrough color escape sequences.
+(As of version 3.3 the passthrough of escape sequences is turned off by default)
+
+```tmux
+set -g allow-passthrough 1
+```
+
 ## Troubleshooting
 
 Run the included **colortest** script and check that your colour assignments appear correct. If your teminal does not support the setting of colours in within the 256 colorspace (e.g. Apple Terminal), colours 17 to 21 will appear blue.


### PR DESCRIPTION
Having had my awesome Base16 experience degrade recently - I went hunting to figure out why.  

As of [version 3.3 ](https://github.com/tmux/tmux/blob/master/CHANGES#L30) an [`allow-passthrough` option](https://github.com/tmux/tmux/blob/06869ff22fa9891c9633ce3e3efa77cac758b520/options-table.c#L805-L811) prevents the color escape sequences from working.

I tried to write this in the tone of the readme as I see it - but please feel free to close this and communicate it however you wish 🙏 (I suspect more people will encounter it)