### PR TITLE
Fix BASE16_THEME env set by fish shell helper

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -16,7 +16,7 @@ set SCRIPT_DIR (realpath (dirname (status -f)))
 # load currently active theme...
 if test -e ~/.base16_theme
   set -l SCRIPT_NAME (basename (realpath ~/.base16_theme) .sh)
-  set -gx BASE16_THEME (string match 'base16-*' $BASE16_THEME  | string sub -s (string length 'base16-*'))
+  set -gx BASE16_THEME (string match 'base16-*' $SCRIPT_NAME  | string sub -s (string length 'base16-*'))
   eval sh '"'(realpath ~/.base16_theme)'"'
 end
 


### PR DESCRIPTION
The fish shell helper script was using the wrong variable to parse the current theme name from the theme's path, thus setting the `BASE16_THEME` environment variable to an empty string.

This affects scripts or configurations that rely on `BASE16_THEME`, such as the base16-vim users that use the instructions on the README file (`colorschema base16-$BASE16_THEME`).