### PR TITLE
Various README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ git clone https://github.com/chriskempson/base16-shell.git ~/.config/base16-shel
 
 ## Configuration
 
-We're going to use the example theme of `base16_default` for the following instructions.
-Replace with your desired theme.
-
-Once you have got base16 setup you can try applying themes in your shell by typing `base16_`, letting autocomplete show you the options, then executing the theme you want to try.
-
 ### Bash/ZSH
 
 Add following lines to `~/.bashrc` or `~/.zshrc`:
@@ -35,22 +30,16 @@ BASE16_SHELL="$HOME/.config/base16-shell/"
 [ -n "$PS1" ] && \
     [ -s "$BASE16_SHELL/profile_helper.sh" ] && \
         source "$BASE16_SHELL/profile_helper.sh"
-        
-base16_default
 ```
 
 #### If you're using ZSH + plug
 
-You won't need to do the `git clone` above.
-Add the below commands to your `~/.zshrc` instead.
-(This will likely work for other plugin managers too).
+You won't need to do the `git clone` in the Installation section.
+Add the following commands to your `~/.zshrc` instead:
 
 ```
 # before `zplug load`
 zplug chriskempson/base16-shell, from:github
-
-# after `zplug load`
-base16_materia
 ```
 
 ### Fish
@@ -63,8 +52,6 @@ if status --is-interactive
     set BASE16_SHELL "$HOME/.config/base16-shell/"
     source "$BASE16_SHELL/profile_helper.fish"
 end
-
-base16_materia
 ```
 
 ### Base16-Vim Users
@@ -85,6 +72,12 @@ Add the following line to `~/.tmux.config` to passthrough color escape sequences
 ```tmux
 set -g allow-passthrough 1
 ```
+
+## Usage
+
+If you have just installed and configured base16_shell for the first time, open a new shell or reload the configurations for your current shell (e.g. `source ~/.bashrc`).
+
+Apply themes in your shell by typing `base16_`, using your shell's autocomplete function show you the options, then executing the theme you want to try. The current theme will be saved at the symlink `~/.base16_theme`, and the profile_helper script (see Configuration section) will load the theme (e.g. when you next log in or manually `source` your shell config).
 
 ## Troubleshooting
 


### PR DESCRIPTION
- An earlier commit to the README added commands in the configuration to load a specific theme, defeating the purpose of the .base16_theme file that the helper script automatically loads when starting the shell. These lines have been removed and information about setting the theme has been moved to a new "Usage" section.

- Removed tenuous line about configuration working in unspecified plugin managers

- Changed "below" to "following" for accessibility